### PR TITLE
Added support for specifying explicit enumName values using DisplayAtttribute on enum members

### DIFF
--- a/src/NJsonSchema.Tests/Generation/EnumGenerationTests.cs
+++ b/src/NJsonSchema.Tests/Generation/EnumGenerationTests.cs
@@ -3,6 +3,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using NJsonSchema.Generation;
+using System.Runtime.Serialization;
+using System.ComponentModel.DataAnnotations;
 
 namespace NJsonSchema.Tests.Generation
 {
@@ -101,6 +103,47 @@ namespace NJsonSchema.Tests.Generation
             Assert.AreEqual("A", schema.Properties["Bar"].ActualPropertySchema.EnumerationNames.ElementAt(0));
             Assert.AreEqual("B", schema.Properties["Bar"].ActualPropertySchema.EnumerationNames.ElementAt(1));
             Assert.AreEqual("C", schema.Properties["Bar"].ActualPropertySchema.EnumerationNames.ElementAt(2));
+        }
+
+
+        public class ClassWithStringEnum
+        {
+            public StringEnum Bar { get; set; }
+        }
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public enum StringEnum
+        {
+            [Display(Name="Zero Five Six Two")]
+            [EnumMember(Value = "0562")]
+            _0562,
+
+            [EnumMember(Value = "0532")]
+            _0532,
+
+            _0502
+        }
+
+
+        [TestMethod]
+        public void When_enum_is_generated_then_names_are_set_from_display_annotation_if_present()
+        {
+            //// Arrange
+
+            //// Act
+            var schema = JsonSchema4.FromType<ClassWithStringEnum>(new JsonSchemaGeneratorSettings
+            {
+                DefaultEnumHandling = EnumHandling.String
+            });
+
+            //// Assert
+            Assert.AreEqual(3, schema.Properties["Bar"].ActualPropertySchema.EnumerationNames.Count);
+            Assert.AreEqual("Zero Five Six Two", schema.Properties["Bar"].ActualPropertySchema.EnumerationNames.ElementAt(0));
+            Assert.AreEqual("0562", schema.Properties["Bar"].ActualPropertySchema.Enumeration.ElementAt(0));
+            Assert.AreEqual("_0532", schema.Properties["Bar"].ActualPropertySchema.EnumerationNames.ElementAt(1));
+            Assert.AreEqual("0532", schema.Properties["Bar"].ActualPropertySchema.Enumeration.ElementAt(1));
+            Assert.AreEqual("_0502", schema.Properties["Bar"].ActualPropertySchema.EnumerationNames.ElementAt(2));
+            Assert.AreEqual("_0502", schema.Properties["Bar"].ActualPropertySchema.Enumeration.ElementAt(2));
         }
     }
 }

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -335,6 +335,7 @@ namespace NJsonSchema.Generation
 
             foreach (var enumName in Enum.GetNames(type))
             {
+                var attributes = type.GetTypeInfo().GetDeclaredField(enumName).GetCustomAttributes(); // EnumMember only checked if StringEnumConverter is used
                 if (typeDescription.Type == JsonObjectType.Integer)
                 {
                     var value = Convert.ChangeType(Enum.Parse(type, enumName), Enum.GetUnderlyingType(type));
@@ -342,7 +343,6 @@ namespace NJsonSchema.Generation
                 }
                 else
                 {
-                    var attributes = type.GetTypeInfo().GetDeclaredField(enumName).GetCustomAttributes(); // EnumMember only checked if StringEnumConverter is used
                     dynamic enumMemberAttribute = TryGetAttribute(attributes, "System.Runtime.Serialization.EnumMemberAttribute");
                     if (enumMemberAttribute != null && !string.IsNullOrEmpty(enumMemberAttribute.Value))
                         schema.Enumeration.Add((string)enumMemberAttribute.Value);
@@ -350,7 +350,15 @@ namespace NJsonSchema.Generation
                         schema.Enumeration.Add(enumName);
                 }
 
-                schema.EnumerationNames.Add(enumName);
+                dynamic displayAttribute = TryGetAttribute(attributes, "System.ComponentModel.DataAnnotations.DisplayAttribute");
+                if (displayAttribute != null && !string.IsNullOrEmpty(displayAttribute.Name))
+                {
+                    schema.EnumerationNames.Add(displayAttribute.Name);
+
+                }
+                else {
+                    schema.EnumerationNames.Add(enumName);
+                }
             }
         }
 


### PR DESCRIPTION
The current implementation for generating enumNames in a schema uses the enum member name which is constrained to being a valid c# identifier. This change enables the value used for the enumName to be specified by applying a System.ComponentModel.DisplayAttribute to the original enum which provides the flexibility to include spaces (or other extended characters) in an enumName as per the example in the draft proposal at https://github.com/json-schema/json-schema/wiki/enumNames-(v5-proposal)
