### PR TITLE
ValueSource introdeced in the JsonSchemaExtensionDataAttribute

### DIFF
--- a/src/NJsonSchema.Tests/NJsonSchema.Tests.Net4.csproj
+++ b/src/NJsonSchema.Tests/NJsonSchema.Tests.Net4.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Generation\XmlDocTests.cs" />
     <Compile Include="Generation\XmlObjectTests.cs" />
     <Compile Include="Serialization\ExtensionDataTests.cs" />
+    <Compile Include="Serialization\PostProcessTests.cs" />
     <Compile Include="Validation\EnumValidationTests.cs" />
     <Compile Include="Validation\LineInformationTest.cs" />
     <Compile Include="Validation\NullPropertyTests.cs" />

--- a/src/NJsonSchema.Tests/NJsonSchema.Tests.csproj
+++ b/src/NJsonSchema.Tests/NJsonSchema.Tests.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Generation\XmlDocTests.cs" />
     <Compile Include="Generation\XmlObjectTests.cs" />
     <Compile Include="Serialization\ExtensionDataTests.cs" />
+    <Compile Include="Serialization\PostProcessTests.cs" />
     <Compile Include="Validation\EnumValidationTests.cs" />
     <Compile Include="Validation\LineInformationTest.cs" />
     <Compile Include="Validation\NullPropertyTests.cs" />

--- a/src/NJsonSchema.Tests/Serialization/ExtensionDataTests.cs
+++ b/src/NJsonSchema.Tests/Serialization/ExtensionDataTests.cs
@@ -67,7 +67,16 @@ namespace NJsonSchema.Tests.Serialization
         {
             [JsonSchemaExtensionData("Foo", 2)]
             [JsonSchemaExtensionData("Bar", 3)]
+            [JsonSchemaExtensionData("example", typeof(MyTest), "PropertyExample")]
             public string Property { get; set; }
+
+            public static object PropertyExample
+            {
+                get
+                {
+                    return new List<string> { "FirstStr", "SecondStr" };
+                }
+            }
         }
 
         [TestMethod]
@@ -95,6 +104,7 @@ namespace NJsonSchema.Tests.Serialization
             //// Assert
             Assert.AreEqual(2, schema.Properties["Property"].ExtensionData["Foo"]);
             Assert.AreEqual(3, schema.Properties["Property"].ExtensionData["Bar"]);
+            Assert.IsInstanceOfType(schema.Properties["Property"].ExtensionData["example"], typeof(List<string>));
         }
     }
 }

--- a/src/NJsonSchema.Tests/Serialization/PostProcessTests.cs
+++ b/src/NJsonSchema.Tests/Serialization/PostProcessTests.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NJsonSchema.Tests.Serialization
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    using NJsonSchema.Annotations;
+
+    [TestClass]
+    public class PostProcessTests
+    {
+        [JsonSchemaPostProcess(typeof(MyTest), nameof(PostProcess))]
+        public class MyTest
+        {
+            public string Property { get; set; }
+
+            public static void PostProcess(JsonSchema4 schema)
+            {
+                schema.Description = "FromPostProcess";
+            }
+        }
+
+        [TestMethod]
+        public async Task schema_should_be_postprocessed()
+        {
+            //// Arrange
+
+
+            //// Act
+            var schema = await JsonSchema4.FromTypeAsync<MyTest>();
+
+            //// Assert
+            Assert.AreEqual("FromPostProcess", schema.Description);
+
+        }
+    }
+}

--- a/src/NJsonSchema/Annotations/JsonSchemaExtensionDataAttribute.cs
+++ b/src/NJsonSchema/Annotations/JsonSchemaExtensionDataAttribute.cs
@@ -24,10 +24,31 @@ namespace NJsonSchema.Annotations
             Value = value;
         }
 
+        /// <summary>Initializes a new instance of the <see cref="JsonSchemaExtensionDataAttribute"/> class.</summary>
+        /// <param name="property">The property.</param>
+        /// <param name="valueSourceType">The type to get value from.</param>
+        /// <param name="valueSourceProperty">The property of the type to get value from.</param>
+        public JsonSchemaExtensionDataAttribute(string property, Type valueSourceType, string valueSourceProperty)
+        {
+            Property = property;
+            ValueSourceType = valueSourceType;
+            ValueSourceProperty = valueSourceProperty;
+            IsValueSourceSpecified = true;
+        }
+
         /// <summary>Gets the property name.</summary>
         public string Property { get; private set; }
 
         /// <summary>Gets the value.</summary>
         public object Value { get; private set; }
+
+        /// <summary>The property of the type to get value from.</summary>
+        public string ValueSourceProperty { get; private set; }
+
+        /// <summary>The type to get value from.</summary>
+        public Type ValueSourceType { get; private set; }
+        
+        /// <summary>Shows that attribute constructed with value source pair.</summary>
+        public bool IsValueSourceSpecified { get; private set; }
     }
 }

--- a/src/NJsonSchema/Annotations/JsonSchemaExtensionDataAttribute.cs
+++ b/src/NJsonSchema/Annotations/JsonSchemaExtensionDataAttribute.cs
@@ -26,14 +26,13 @@ namespace NJsonSchema.Annotations
 
         /// <summary>Initializes a new instance of the <see cref="JsonSchemaExtensionDataAttribute"/> class.</summary>
         /// <param name="property">The property.</param>
-        /// <param name="valueSourceType">The type to get value from.</param>
-        /// <param name="valueSourceProperty">The property of the type to get value from.</param>
+        /// <param name="valueSourceType">The type to get the value from.</param>
+        /// <param name="valueSourceProperty">The property of the type to get the value from.</param>
         public JsonSchemaExtensionDataAttribute(string property, Type valueSourceType, string valueSourceProperty)
         {
             Property = property;
             ValueSourceType = valueSourceType;
             ValueSourceProperty = valueSourceProperty;
-            IsValueSourceSpecified = true;
         }
 
         /// <summary>Gets the property name.</summary>
@@ -48,7 +47,7 @@ namespace NJsonSchema.Annotations
         /// <summary>The type to get value from.</summary>
         public Type ValueSourceType { get; private set; }
         
-        /// <summary>Shows that attribute constructed with value source pair.</summary>
-        public bool IsValueSourceSpecified { get; private set; }
+        /// <summary>Gets a value indicating whether the value is read by reflection.</summary>
+        public bool IsValueSourceSpecified => !string.IsNullOrEmpty(ValueSourceProperty);
     }
 }

--- a/src/NJsonSchema/Annotations/JsonSchemaPostProcessAttribute.cs
+++ b/src/NJsonSchema/Annotations/JsonSchemaPostProcessAttribute.cs
@@ -1,5 +1,5 @@
-﻿//-----------------------------------------------------------------------
-// <copyright file="JsonSchemaAttribute.cs" company="NJsonSchema">
+//-----------------------------------------------------------------------
+// <copyright file="JsonSchemaPostProcessAttribute.cs" company="NJsonSchema">
 //     Copyright (c) Rico Suter. All rights reserved.
 // </copyright>0
 // <license>https://github.com/rsuter/NJsonSchema/blob/master/LICENSE.md</license>
@@ -9,15 +9,11 @@ namespace NJsonSchema.Annotations
 {
     using System;
 
-    /// <summary>
-    /// Allows to post process schema.
-    /// </summary>
+    /// <summary>Allows to post process schema.</summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, AllowMultiple = true)]
     public class JsonSchemaPostProcessAttribute : Attribute
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="JsonSchemaPostProcessAttribute"/> class. 
-        /// </summary>
+        /// <summary>Initializes a new instance of the <see cref="JsonSchemaPostProcessAttribute"/> class.</summary>
         /// <param name="type">Type to get post-process method from.</param>
         /// <param name="methodName">Name of post-process method.</param>
         public JsonSchemaPostProcessAttribute(Type type, string methodName)

--- a/src/NJsonSchema/Annotations/JsonSchemaPostProcessAttribute.cs
+++ b/src/NJsonSchema/Annotations/JsonSchemaPostProcessAttribute.cs
@@ -1,31 +1,32 @@
-//-----------------------------------------------------------------------
+/-----------------------------------------------------------------------
 // <copyright file="JsonSchemaPostProcessAttribute.cs" company="NJsonSchema">
 //     Copyright (c) Rico Suter. All rights reserved.
 // </copyright>0
 // <license>https://github.com/rsuter/NJsonSchema/blob/master/LICENSE.md</license>
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
+
+using System;
+
 namespace NJsonSchema.Annotations
 {
-    using System;
-
     /// <summary>Allows to post process schema.</summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, AllowMultiple = true)]
     public class JsonSchemaPostProcessAttribute : Attribute
     {
         /// <summary>Initializes a new instance of the <see cref="JsonSchemaPostProcessAttribute"/> class.</summary>
         /// <param name="type">Type to get post-process method from.</param>
-        /// <param name="methodName">Name of post-process method.</param>
+        /// <param name="methodName">Name of the post-process method.</param>
         public JsonSchemaPostProcessAttribute(Type type, string methodName)
         {
             Type = type;
             MethodName = methodName;
         }
 
-        /// <summary>Name of post-process method.</summary>
-        public string MethodName { get; }
-
         /// <summary>Type to get post-process method from.</summary>
         public Type Type { get; }
+
+        /// <summary>Name of post-process method.</summary>
+        public string MethodName { get; }
     }
 }

--- a/src/NJsonSchema/Annotations/JsonSchemaPostProcessAttribute.cs
+++ b/src/NJsonSchema/Annotations/JsonSchemaPostProcessAttribute.cs
@@ -1,0 +1,35 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="JsonSchemaAttribute.cs" company="NJsonSchema">
+//     Copyright (c) Rico Suter. All rights reserved.
+// </copyright>0
+// <license>https://github.com/rsuter/NJsonSchema/blob/master/LICENSE.md</license>
+// <author>Rico Suter, mail@rsuter.com</author>
+//-----------------------------------------------------------------------
+namespace NJsonSchema.Annotations
+{
+    using System;
+
+    /// <summary>
+    /// Allows to post process schema.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, AllowMultiple = true)]
+    public class JsonSchemaPostProcessAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonSchemaPostProcessAttribute"/> class. 
+        /// </summary>
+        /// <param name="type">Type to get post-process method from.</param>
+        /// <param name="methodName">Name of post-process method.</param>
+        public JsonSchemaPostProcessAttribute(Type type, string methodName)
+        {
+            Type = type;
+            MethodName = methodName;
+        }
+
+        /// <summary>Name of post-process method.</summary>
+        public string MethodName { get; }
+
+        /// <summary>Type to get post-process method from.</summary>
+        public Type Type { get; }
+    }
+}

--- a/src/NJsonSchema/NJsonSchema.Net4.csproj
+++ b/src/NJsonSchema/NJsonSchema.Net4.csproj
@@ -41,6 +41,7 @@
   <ItemGroup>
     <Compile Include="Annotations\JsonSchemaAttribute.cs" />
     <Compile Include="Annotations\JsonSchemaExtensionDataAttribute.cs" />
+    <Compile Include="Annotations\JsonSchemaPostProcessAttribute.cs" />
     <Compile Include="Annotations\MultipleOfAttribute.cs" />
     <Compile Include="Collections\ObservableDictionary.cs" />
     <Compile Include="ConversionUtilities.cs" />

--- a/src/NJsonSchema/NJsonSchema.csproj
+++ b/src/NJsonSchema/NJsonSchema.csproj
@@ -72,6 +72,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Annotations\JsonSchemaPostProcessAttribute.cs" />
     <Compile Include="ConversionUtilities.cs" />
     <Compile Include="DefaultSchemaNameGenerator.cs" />
     <Compile Include="DefaultTypeNameGenerator.cs" />


### PR DESCRIPTION
This improvement allows to put into the schema arbitrary extension data, not only build-in clr types.
Very useful to put rich "example" objects.