### PR TITLE
When a property has a value tag, that tag is used instead of the summary tag

### DIFF
--- a/src/NJsonSchema.Benchmark/SerializationPerformanceTests.cs
+++ b/src/NJsonSchema.Benchmark/SerializationPerformanceTests.cs
@@ -20,9 +20,9 @@ namespace NJsonSchema.Benchmark
         }
 
         [PerfSetup]
-        #pragma warning disable xUnit1013 // Public method should be marked as test
+#pragma warning disable xUnit1013 // Public method should be marked as test
         public void Setup(BenchmarkContext context)
-        #pragma warning restore xUnit1013 // Public method should be marked as test
+#pragma warning restore xUnit1013 // Public method should be marked as test
         {
             _counter = context.GetCounter("Iterations");
         }
@@ -31,6 +31,7 @@ namespace NJsonSchema.Benchmark
         /// Ensure that we can serialise at least 200 times per second (5ms).
         /// </summary>
         [NBenchFact]
+        [Trait("Category", "SkipWhenLiveUnitTesting")]
         [PerfBenchmark(
             Description = "Ensure serialization doesn't take too long",
             NumberOfIterations = 3,
@@ -48,6 +49,7 @@ namespace NJsonSchema.Benchmark
         /// Ensure that we can deserialise at least 200 times per second (5ms).
         /// </summary>
         [NBenchFact]
+        [Trait("Category", "SkipWhenLiveUnitTesting")]
         [PerfBenchmark(
             Description = "Ensure deserialization doesn't take too long",
             NumberOfIterations = 3,

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/CSharpGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/CSharpGeneratorTests.cs
@@ -268,7 +268,8 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             var output = generator.GenerateFile("MyClass");
 
             //// Assert
-            Assert.Contains(@"/// <summary>EnumDesc.</summary>", output);
+            Assert.Contains(@"/// <summary>Gets or sets enumDesc.</summary>", output);
+            Assert.Contains(@"/// <value>EnumDesc.</value>", output);
 
             AssertCompile(output);
         }
@@ -302,8 +303,9 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             var output = generator.GenerateFile("MyClass");
 
             //// Assert
-            Assert.Contains(@"/// <summary>PropertyDesc.</summary>", output);
-
+            Assert.Contains(@"/// <summary>Gets or sets propertyDesc.</summary>", output);
+            Assert.Contains(@"/// <value>PropertyDesc.</value>", output);
+             
             AssertCompile(output);
         }
 

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
@@ -29,6 +29,9 @@
 {%   if property.HasDescription -%}
     /// <summary>{{ property.Description | csharpdocs }}</summary>
 {%   endif -%}
+{%   if property.HasValueDescription -%}
+    /// <value>{{ property.ValueDescription | csharpdocs }}</value>
+{%   endif -%}
     [Newtonsoft.Json.JsonProperty("{{ property.Name }}", Required = {{ property.JsonPropertyRequiredCode }}{% if property.IsStringEnumArray %}, ItemConverterType = typeof(Newtonsoft.Json.Converters.StringEnumConverter){% endif %})]
 {%   if property.RenderRequiredAttribute -%}
     [System.ComponentModel.DataAnnotations.Required{% if property.AllowEmptyStrings %}(AllowEmptyStrings = true){% endif %}]
@@ -55,16 +58,16 @@
         get { return {{ property.FieldName }}; }
 {%     if property.HasSetter -%}
 {%         if RenderInpc -%}
-        {{PropertySetterAccessModifier}}set 
+{{PropertySetterAccessModifier}}set
         {
             if ({{ property.FieldName }} != value)
             {
-                {{ property.FieldName }} = value; 
+{{ property.FieldName }} = value;
                 RaisePropertyChanged();
             }
         }
 {%         else -%}
-        {{PropertySetterAccessModifier}}set { SetProperty(ref {{ property.FieldName }}, value); }
+{{PropertySetterAccessModifier}}set { SetProperty(ref {{ property.FieldName }}, value); }
 {%         endif -%}
 {%     endif -%}
     }
@@ -72,25 +75,28 @@
 
 {% endfor -%}
 {% if HasAdditionalPropertiesType -%}
-    private System.Collections.Generic.IDictionary<string, {{ AdditionalPropertiesType }}> _additionalProperties = new System.Collections.Generic.Dictionary<string, {{ AdditionalPropertiesType }}>();
+    private System.Collections.Generic.IDictionary<string, {{ AdditionalPropertiesType }}>
+    _additionalProperties = new System.Collections.Generic.Dictionary<string, {{ AdditionalPropertiesType }}>
+        ();
 
-    [Newtonsoft.Json.JsonExtensionData]
-    public System.Collections.Generic.IDictionary<string, {{ AdditionalPropertiesType }}> AdditionalProperties
-    {
-        get { return _additionalProperties; }
-        {{PropertySetterAccessModifier}}set { _additionalProperties = value; }
-    }
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, {{ AdditionalPropertiesType }}>
+            AdditionalProperties
+            {
+            get { return _additionalProperties; }
+            {{PropertySetterAccessModifier}}set { _additionalProperties = value; }
+            }
 
-{% endif -%}
-{% if GenerateJsonMethods -%}
-    {% template Class.ToJson %}
-    
-    {% template Class.FromJson %}
-{% endif -%}
-{% if RenderInpc -%}
+            {% endif -%}
+            {% if GenerateJsonMethods -%}
+            {% template Class.ToJson %}
 
-    {% template Class.Inpc %}
-{% endif -%}
+            {% template Class.FromJson %}
+            {% endif -%}
+            {% if RenderInpc -%}
 
-    {% template Class.Body %}
-}
+            {% template Class.Inpc %}
+            {% endif -%}
+
+            {% template Class.Body %}
+            }

--- a/src/NJsonSchema.Tests/Generation/XmlDocTests.cs
+++ b/src/NJsonSchema.Tests/Generation/XmlDocTests.cs
@@ -118,5 +118,25 @@ namespace NJsonSchema.Tests.Generation
             //// Assert
             Assert.Empty(summary);
         }
+
+        public class WithValueTagInXmlDoc
+        {
+            /// <summary>Gets or sets the foo.</summary>
+            /// <value>The foo.</value>
+            public string Foo { get; set; }
+        }
+
+        [Fact]
+        public async Task When_property_has_value_tag_then_it_is_used()
+        {
+            //// Arrange
+
+
+            //// Act
+            var summary = await typeof(WithValueTagInXmlDoc).GetProperty("Foo").GetXmlSummaryAsync();
+
+            //// Assert
+            Assert.Equal("The foo.", summary);
+        }
     }
 }

--- a/src/NJsonSchema/Infrastructure/XmlDocumentationExtensions.cs
+++ b/src/NJsonSchema/Infrastructure/XmlDocumentationExtensions.cs
@@ -71,6 +71,13 @@ namespace NJsonSchema.Infrastructure
         /// <returns>The contents of the "summary" tag for the member.</returns>
         public static async Task<string> GetXmlSummaryAsync(this MemberInfo member)
         {
+            var value = await GetXmlDocumentationTagAsync(member, "value").ConfigureAwait(false);
+
+            if (!string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+
             return await GetXmlDocumentationTagAsync(member, "summary").ConfigureAwait(false);
         }
 


### PR DESCRIPTION
According to StyleCop rules [the `summary` of a property must match its accessors](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1623.md "SA1623PropertySummaryDocumentationMustMatchAccessors").

That means that the `summary` for properties must be something like `Gets or sets …`, which is a description of the .NET property and not its value.

On the other hand, [properties must have a `value` tag](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1609.md "SA1609PropertyDocumentationMustHaveValue") [with text](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1610.md "SA1610PropertyDocumentationMustHaveValueText").

Since the `description` in the swagger is the description of the value, it makes more sense to use this tag.

This PR Solves this.