### PR TITLE
Fix for missing type mapping in SchemaResolver when type is an array

### DIFF
--- a/src/NJsonSchema.Tests/Generation/JsonSchemaGeneratorTests.cs
+++ b/src/NJsonSchema.Tests/Generation/JsonSchemaGeneratorTests.cs
@@ -1,0 +1,32 @@
+﻿using NJsonSchema.Annotations;
+using NJsonSchema.Generation;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NJsonSchema.Tests.Generation
+{
+    public class JsonSchemaGeneratorTests
+    {
+        [JsonSchema(JsonObjectType.Array, ArrayItem = typeof(string))]
+        public class ArrayModel : List<string>
+        {
+        }
+
+        [Fact]
+        public async Task When_type_is_an_array_then_generator_adds_mapping_to_schema_resolver()
+        {
+            //// Arrange
+            var root = new JsonSchema4();
+            var settings = new JsonSchemaGeneratorSettings();
+            var generator = new JsonSchemaGenerator(settings);
+            var schemaResolver = new JsonSchemaResolver(root, settings);
+
+            //// Act
+            await generator.GenerateAsync(typeof(ArrayModel), schemaResolver);
+
+            //// Assert
+            Assert.True(schemaResolver.HasSchema(typeof(ArrayModel), false));
+        }
+    }
+}

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -456,6 +456,11 @@ namespace NJsonSchema.Generation
             }
             else
                 schema.Item = JsonSchema4.CreateAnySchema();
+
+            if(schema.GetType() == typeof(JsonSchema4))
+            {
+                schemaResolver.AddSchema(type, false, schema);
+            }
         }
 
         private async Task GenerateEnum<TSchemaType>(


### PR DESCRIPTION
Currently in `GenerateArray` [method](https://github.com/RSuter/NJsonSchema/blob/b85cad2f4b4532ae24fc07427066d90f291cc18d/src/NJsonSchema/Generation/JsonSchemaGenerator.cs#L436) in `JsonSchemaGenerator` there is no call to`schemaResolver.AddSchema` so type mapping is missing (for ex. [here generated json is missing array-like types](https://github.com/RSuter/NSwag/blob/c2c3ad24fd1ef4e434a4a2fdc7c224c0c6f61771/src/NSwag.Commands/Commands/SwaggerGeneration/TypesToSwaggerCommand.cs#L95)). This PR fixes this problem.