### PR TITLE
Generate empty classes if base class is present. 

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/EmptyClassTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/EmptyClassTests.cs
@@ -1,0 +1,99 @@
+﻿using NJsonSchema.CodeGeneration.CSharp;
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NJsonSchema.CodeGeneration.Tests.CSharp
+{
+    public class EmptyClassTests
+    {
+        [Fact]
+        public async Task Empty_class_is_generated_when_base_class_is_inpc()
+        {
+            //// Arrange
+            var path = GetTestDirectory() + "/EmptyClasses/EmptyClass.json";
+
+            //// Act
+            var schema = await JsonSchema4.FromFileAsync(path);
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings { ClassStyle = CSharpClassStyle.Inpc });
+            var code = generator.GenerateFile("MyClass");
+
+            //// Assert
+            Assert.Contains("public partial class ClassWithoutProperties", code);
+            Assert.Contains("public partial class ClassWithProperties", code);
+            Assert.Contains("public ClassWithoutProperties A", code);
+            Assert.Contains("public ClassWithoutProperties B", code);
+            Assert.Contains("public ClassWithProperties C", code);
+            Assert.Contains("public ClassWithProperties D", code);
+        }
+
+        [Fact]
+        public async Task Empty_class_is_generated_when_base_class_is_prism()
+        {
+            //// Arrange
+            var path = GetTestDirectory() + "/EmptyClasses/EmptyClass.json";
+
+            //// Act
+            var schema = await JsonSchema4.FromFileAsync(path);
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings { ClassStyle = CSharpClassStyle.Prism });
+            var code = generator.GenerateFile("MyClass");
+
+            //// Assert
+            Assert.Contains("public partial class ClassWithoutProperties", code);
+            Assert.Contains("public partial class ClassWithProperties", code);
+            Assert.Contains("public ClassWithoutProperties A", code);
+            Assert.Contains("public ClassWithoutProperties B", code);
+            Assert.Contains("public ClassWithProperties C", code);
+            Assert.Contains("public ClassWithProperties D", code);
+        }
+
+        [Fact]
+        public async Task Empty_class_is_not_generated_when_base_class_is_poco()
+        {
+            //// Arrange
+            var path = GetTestDirectory() + "/EmptyClasses/EmptyClass.json";
+
+            //// Act
+            var schema = await JsonSchema4.FromFileAsync(path);
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings { ClassStyle = CSharpClassStyle.Poco });
+            var code = generator.GenerateFile("MyClass");
+
+            //// Assert
+            Assert.DoesNotContain("public partial class ClassWithoutProperties", code);
+            Assert.Contains("public partial class ClassWithProperties", code);
+            Assert.Contains("public object A { get; set; } = new object();", code);
+            Assert.Contains("public object B { get; set; } = new object();", code);
+            Assert.Contains("public ClassWithProperties C { get; set; } = new ClassWithProperties();", code);
+            Assert.Contains("public ClassWithProperties D { get; set; } = new ClassWithProperties();", code);
+        }
+
+        [Fact]
+        public async Task Empty_class_is_not_generated_when_base_class_is_record()
+        {
+            //// Arrange
+            var path = GetTestDirectory() + "/EmptyClasses/EmptyClass.json";
+
+            //// Act
+            var schema = await JsonSchema4.FromFileAsync(path);
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings { ClassStyle = CSharpClassStyle.Record });
+            var code = generator.GenerateFile("MyClass");
+
+            //// Assert
+            Assert.DoesNotContain("public partial class ClassWithoutProperties", code);
+            Assert.Contains("public partial class ClassWithProperties", code);
+            Assert.Contains("public object A { get; }", code);
+            Assert.Contains("public object B { get; }", code);
+            Assert.Contains("public ClassWithProperties C { get; }", code);
+            Assert.Contains("public ClassWithProperties D { get; }", code);
+        }
+
+        private string GetTestDirectory()
+        {
+            var codeBase = Assembly.GetExecutingAssembly().CodeBase;
+            var uri = new UriBuilder(codeBase);
+            return Path.GetDirectoryName(Uri.UnescapeDataString(uri.Path));
+        }
+    }
+}

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/EmptyClasses/EmptyClass.json
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/EmptyClasses/EmptyClass.json
@@ -1,0 +1,38 @@
+{
+    "definitions": {
+        "ClassWithoutProperties": {
+            "type": "object",
+            "description": "This is an empty class containing no properties"
+        },
+        "ClassWithProperties": {
+            "type": "object",
+            "description": "This is a class containing properties",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "This is the ID of ClassWithProperties"
+                }
+            }
+        }
+    },
+    "type": "object",
+    "description": "This is a class referencing the classes above",
+    "properties": {
+        "a": {
+            "$ref": "#/definitions/ClassWithoutProperties",
+            "description": "This is a property of type ClassWithoutProperties"
+        },
+        "b": {
+            "$ref": "#/definitions/ClassWithoutProperties",
+            "description": "This is a property of type ClassWithoutProperties"
+        },
+        "c": {
+            "$ref": "#/definitions/ClassWithProperties",
+            "description": "This is a property of type ClassWithProperties"
+        },
+        "d": {
+            "$ref": "#/definitions/ClassWithProperties",
+            "description": "This is a property of type ClassWithProperties"
+        }
+    }
+}

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/NJsonSchema.CodeGeneration.CSharp.Tests.csproj
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/NJsonSchema.CodeGeneration.CSharp.Tests.csproj
@@ -19,4 +19,9 @@
     <ProjectReference Include="..\NJsonSchema.CodeGeneration\NJsonSchema.CodeGeneration.csproj" />
     <ProjectReference Include="..\NJsonSchema\NJsonSchema.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <None Update="EmptyClasses\EmptyClass.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
@@ -65,7 +65,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
 
             // Primitive schemas (no new type)
 
-            if (schema.ActualTypeSchema.IsAnyType)
+            if (schema.ActualTypeSchema.IsAnyType && !IsDefinitionTypeSchema(schema.ActualTypeSchema))
                 return "object";
 
             var type = schema.ActualTypeSchema.Type;
@@ -113,6 +113,11 @@ namespace NJsonSchema.CodeGeneration.CSharp
             if ((schema.IsDictionary && !Settings.InlineNamedDictionaries) ||
                 (schema.IsArray && !Settings.InlineNamedArrays) ||
                 (schema.IsTuple && !Settings.InlineNamedTuples))
+            {
+                return true;
+            }
+
+            if (schema.IsAnyType && (Settings.ClassStyle == CSharpClassStyle.Inpc || Settings.ClassStyle == CSharpClassStyle.Prism))
             {
                 return true;
             }


### PR DESCRIPTION
Resolves issue #879. Open point is a failing test for that inheritance / dictionary stuff. Don't know how to handle that really.