### PR TITLE
Convert apostrophe and ampersand to underscore in enum names

### DIFF
--- a/src/NJsonSchema.CodeGeneration/DefaultEnumNameGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration/DefaultEnumNameGenerator.cs
@@ -30,11 +30,13 @@ namespace NJsonSchema.CodeGeneration
             }
 
             return ConversionUtilities.ConvertToUpperCamelCase(name
-                .Replace(":", "-").Replace(@"""", @""), true)
+                .Replace(":", "_").Replace(@"""", @""), true)
                 .Replace(".", "_")
                 .Replace(",", "_")
                 .Replace("#", "_")
+                .Replace("&", "_")
                 .Replace("-", "_")
+                .Replace("'", "_")
                 .Replace("\\", "_");
         }
     }

--- a/src/NJsonSchema.CodeGeneration/DefaultEnumNameGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration/DefaultEnumNameGenerator.cs
@@ -37,6 +37,8 @@ namespace NJsonSchema.CodeGeneration
                 .Replace("&", "_")
                 .Replace("-", "_")
                 .Replace("'", "_")
+                .Replace("(", "_")
+                .Replace(")", "_")
                 .Replace("\\", "_");
         }
     }

--- a/src/NJsonSchema.CodeGeneration/DefaultEnumNameGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration/DefaultEnumNameGenerator.cs
@@ -30,7 +30,7 @@ namespace NJsonSchema.CodeGeneration
             }
 
             return ConversionUtilities.ConvertToUpperCamelCase(name
-                .Replace(":", "_").Replace(@"""", @""), true)
+                .Replace(":", "-").Replace(@"""", @""), true)
                 .Replace(".", "_")
                 .Replace(",", "_")
                 .Replace("#", "_")


### PR DESCRIPTION
Also changed colon to convert to an underscore instead of a hyphen, as hyphen is not valid either.

This solves an immediate issue I'm having. However, I think a better long term solution would be to white-list instead of black-list characters.

Fixes https://github.com/RicoSuter/NSwag/issues/1265