### PR TITLE
Fixes bad System.XML reference

### DIFF
--- a/src/NJsonSchema/NJsonSchema.csproj
+++ b/src/NJsonSchema/NJsonSchema.csproj
@@ -45,7 +45,7 @@
     <Reference Include="System" />
     <Reference Include="System.Net" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.XML" />
+    <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This was causing a compile failure on Linux because Linux has a case sensitive file system, and it also made compiler warnings in my project using yours.