### PR TITLE
Generate x-nullable for array items, dictionary values and properties for Swagger 2

### DIFF
--- a/src/NJsonSchema.Tests/Generation/DictionaryTests.cs
+++ b/src/NJsonSchema.Tests/Generation/DictionaryTests.cs
@@ -58,7 +58,8 @@ namespace NJsonSchema.Tests.Generation
             //// Act
             var schema = await JsonSchema4.FromTypeAsync<EnumKeyDictionaryTest>(new JsonSchemaGeneratorSettings
             {
-                SchemaType = SchemaType.Swagger2
+                SchemaType = SchemaType.Swagger2,
+                GenerateCustomNullableProperties = true
             });
             var data = schema.ToJson();
 

--- a/src/NJsonSchema.Tests/Generation/DictionaryTests.cs
+++ b/src/NJsonSchema.Tests/Generation/DictionaryTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using NJsonSchema.Generation;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -49,6 +50,21 @@ namespace NJsonSchema.Tests.Generation
             //// Assert
             Assert.True(schema.Properties["Mapping3"].IsDictionary);
             Assert.True(schema.Properties["Mapping3"].AdditionalPropertiesSchema.IsNullable(SchemaType.JsonSchema));
+        }
+
+        [Fact]
+        public async Task When_value_type_is_nullable_then_json_schema_is_nullable_Swagger2()
+        {
+            //// Act
+            var schema = await JsonSchema4.FromTypeAsync<EnumKeyDictionaryTest>(new JsonSchemaGeneratorSettings
+            {
+                SchemaType = SchemaType.Swagger2
+            });
+            var data = schema.ToJson();
+
+            //// Assert
+            Assert.True(schema.Properties["Mapping3"].IsDictionary);
+            Assert.True(schema.Properties["Mapping3"].AdditionalPropertiesSchema.IsNullable(SchemaType.Swagger2));
         }
     }
 }

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -238,9 +238,11 @@ namespace NJsonSchema.Generation
                                 schema.OneOf.Add(new JsonSchema4 { Type = JsonObjectType.Null });
                             }
                             else
+                            {
                                 schema.Type = schema.Type | JsonObjectType.Null;
+                            }
                         }
-                        else if (Settings.SchemaType == SchemaType.OpenApi3)
+                        else
                         {
                             schema.IsNullableRaw = isNullable;
                         }
@@ -265,9 +267,13 @@ namespace NJsonSchema.Generation
             if (isNullable)
             {
                 if (Settings.SchemaType == SchemaType.JsonSchema)
+                {
                     referencingSchema.OneOf.Add(new JsonSchema4 { Type = JsonObjectType.Null });
-                else if (Settings.SchemaType == SchemaType.OpenApi3)
+                }
+                else
+                {
                     referencingSchema.IsNullableRaw = true;
+                }
             }
 
             // See https://github.com/RSuter/NJsonSchema/issues/531

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -242,7 +242,7 @@ namespace NJsonSchema.Generation
                                 schema.Type = schema.Type | JsonObjectType.Null;
                             }
                         }
-                        else
+                        else if (Settings.SchemaType == SchemaType.OpenApi3 || Settings.GenerateCustomNullableProperties)
                         {
                             schema.IsNullableRaw = isNullable;
                         }
@@ -270,7 +270,7 @@ namespace NJsonSchema.Generation
                 {
                     referencingSchema.OneOf.Add(new JsonSchema4 { Type = JsonObjectType.Null });
                 }
-                else
+                else if (Settings.SchemaType == SchemaType.OpenApi3 || Settings.GenerateCustomNullableProperties)
                 {
                     referencingSchema.IsNullableRaw = true;
                 }

--- a/src/NJsonSchema/Generation/JsonSchemaGeneratorSettings.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGeneratorSettings.cs
@@ -103,6 +103,9 @@ namespace NJsonSchema.Generation
         [JsonIgnore]
         public ICollection<ISchemaProcessor> SchemaProcessors { get; } = new Collection<ISchemaProcessor>();
 
+        /// <summary>Gets or sets a value indicating whether to generate x-nullable properties (Swagger 2 only).</summary>
+        public bool GenerateCustomNullableProperties { get; set; }
+
         /// <summary>Gets or sets the contract resolver.</summary>
         /// <remarks><see cref="DefaultPropertyNameHandling"/> will be ignored.</remarks>
         [JsonIgnore]

--- a/src/NJsonSchema/JsonSchema4.cs
+++ b/src/NJsonSchema/JsonSchema4.cs
@@ -426,7 +426,7 @@ namespace NJsonSchema
         [JsonProperty("x-abstract", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         public bool IsAbstract { get; set; }
 
-        /// <summary>Gets or sets a value indicating whether the schema is nullable (Open API only).</summary>
+        /// <summary>Gets or sets a value indicating whether the schema is nullable (native in Open API 'nullable', custom in Swagger 'x-nullable').</summary>
         [JsonProperty("x-nullable", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         public bool? IsNullableRaw { get; set; }
 
@@ -729,7 +729,7 @@ namespace NJsonSchema
         /// <returns>true if the type can be null.</returns>
         public virtual bool IsNullable(SchemaType schemaType)
         {
-            if (schemaType == SchemaType.OpenApi3 && IsNullableRaw == true)
+            if (IsNullableRaw == true)
                 return true;
 
             if (IsEnumeration && Enumeration.Contains(null))


### PR DESCRIPTION
Closes https://github.com/RicoSuter/NSwag/issues/2116

Might be a breaking change, check with projects. To avoid this, maybe we need to put x-nullable generation behind a setting/flag (Swagger 2 only - always enabled for OpenAPI 3).