### PR TITLE
Add support for minlength/maxlength/regularexpression attributes on array and dictionary properties

### DIFF
--- a/src/NJsonSchema.Benchmark/JsonInheritanceConverterBenchmarks.cs
+++ b/src/NJsonSchema.Benchmark/JsonInheritanceConverterBenchmarks.cs
@@ -31,7 +31,7 @@ namespace NJsonSchema.Benchmark
             RunMode = RunMode.Throughput,
             TestMode = TestMode.Test)]
         [CounterThroughputAssertion("Iterations", MustBe.GreaterThan, 100)]
-        public void Write()
+        public void Serialize()
         {
             _tests.When_serializing_discriminator_property_is_set();
             _tests.When_serializing_discriminator_property_is_overwritten_if_already_present();
@@ -45,7 +45,7 @@ namespace NJsonSchema.Benchmark
             RunMode = RunMode.Throughput,
             TestMode = TestMode.Test)]
         [CounterThroughputAssertion("Iterations", MustBe.GreaterThan, 100)]
-        public void Read()
+        public void Deserialize()
         {
             _tests.When_deserializing_type_is_resolved_using_discriminator_value();
             _tests.When_deserializing_existing_property_is_populated_with_discriminator_value();

--- a/src/NJsonSchema.Tests/Conversion/TypeToSchemaTests.cs
+++ b/src/NJsonSchema.Tests/Conversion/TypeToSchemaTests.cs
@@ -87,24 +87,6 @@ namespace NJsonSchema.Tests.Conversion
             Assert.Equal("regex", schema.Properties["RegexString"].Pattern);
         }
 
-        public class ClassWithRegexDictionaryProperty
-        {
-            [RegularExpression("^\\d+\\.\\d+\\.\\d+\\.\\d+$")]
-            public Dictionary<string, string> Versions { get; set; }
-        }
-
-        [Fact]
-        public async Task When_dictionary_property_has_regex_attribute_then_regex_is_added_to_additionalProperties()
-        {
-            //// Act
-            var schema = JsonSchema.FromType<ClassWithRegexDictionaryProperty>();
-            var json = schema.ToJson();
-
-            //// Assert
-            Assert.Null(schema.Properties["Versions"].Pattern);
-            Assert.NotNull(schema.Properties["Versions"].AdditionalPropertiesSchema.ActualSchema.Pattern);
-        }
-
         [Fact]
         public async Task When_converting_range_property_then_it_should_be_set_as_min_max()
         {

--- a/src/NJsonSchema.Tests/Generation/AllowAdditionalPropertiesTests.cs
+++ b/src/NJsonSchema.Tests/Generation/AllowAdditionalPropertiesTests.cs
@@ -2,10 +2,11 @@
 using NJsonSchema.Generation;
 using System.Collections.Generic;
 using Xunit;
+using System.ComponentModel.DataAnnotations;
 
 namespace NJsonSchema.Tests.Generation
 {
-    public class AlwaysAllowAdditionalObjectPropertiesTests
+    public class AllowAdditionalPropertiesTests
     {
         public class Person
         {

--- a/src/NJsonSchema.Tests/Generation/AllowAdditionalPropertiesTests.cs
+++ b/src/NJsonSchema.Tests/Generation/AllowAdditionalPropertiesTests.cs
@@ -2,7 +2,6 @@
 using NJsonSchema.Generation;
 using System.Collections.Generic;
 using Xunit;
-using System.ComponentModel.DataAnnotations;
 
 namespace NJsonSchema.Tests.Generation
 {

--- a/src/NJsonSchema.Tests/Generation/AttributeGenerationTests.cs
+++ b/src/NJsonSchema.Tests/Generation/AttributeGenerationTests.cs
@@ -1,3 +1,4 @@
+using NJsonSchema.Annotations;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
@@ -213,7 +214,7 @@ namespace NJsonSchema.Tests.Generation
 
         public class ClassWithDictionary
         {
-            [RegularExpression(".*"), MinLength(2), MaxLength(3)]
+            [JsonSchemaPatternProperties(".*"), MinLength(2), MaxLength(3)]
             public Dictionary<string, string> Dict { get; set; }
         }
 

--- a/src/NJsonSchema/Annotations/JsonSchemaPatternPropertiesAttribute.cs
+++ b/src/NJsonSchema/Annotations/JsonSchemaPatternPropertiesAttribute.cs
@@ -1,0 +1,39 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="JsonSchemaPatternPropertiesAttribute.cs" company="NJsonSchema">
+//     Copyright (c) Rico Suter. All rights reserved.
+// </copyright>
+// <license>https://github.com/rsuter/NJsonSchema/blob/master/LICENSE.md</license>
+// <author>Rico Suter, mail@rsuter.com</author>
+//-----------------------------------------------------------------------
+
+using System;
+
+namespace NJsonSchema.Annotations
+{
+    /// <summary>Annotation to specify the JSON Schema pattern properties.</summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = true)]
+    public class JsonSchemaPatternPropertiesAttribute : Attribute
+    {
+        /// <summary>Initializes a new instance of the <see cref="JsonSchemaAttribute" /> class.</summary>
+        /// <param name="regularExpression">The pattern property regular expression.</param>
+        public JsonSchemaPatternPropertiesAttribute(string regularExpression)
+            : this(regularExpression, null)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="JsonSchemaAttribute" /> class.</summary>
+        /// <param name="regularExpression">The pattern property regular expression.</param>
+        /// <param name="type">The pattern properties type.</param>
+        public JsonSchemaPatternPropertiesAttribute(string regularExpression, Type type)
+        {
+            RegularExpression = regularExpression;
+            Type = type;
+        }
+
+        /// <summary>Gets the pattern properties regular expression.</summary>
+        public string RegularExpression { get; }
+
+        /// <summary>Gets the pattern properties type.</summary>
+        public Type Type { get; }
+    }
+}

--- a/src/NJsonSchema/Generation/DefaultReflectionService.cs
+++ b/src/NJsonSchema/Generation/DefaultReflectionService.cs
@@ -237,14 +237,9 @@ namespace NJsonSchema.Generation
                 return true;
             }
 
-            if (defaultReferenceTypeNullHandling == ReferenceTypeNullHandling.Default && 
-                contextualType.Nullability != Nullability.Unknown)
+            if (contextualType.Nullability != Nullability.Unknown)
             {
                 return contextualType.Nullability == Nullability.Nullable;
-            }
-            else if (contextualType.IsNullableType)
-            {
-                return true;
             }
 
             var isValueType = contextualType.Type != typeof(string) &&

--- a/src/NJsonSchema/Generation/JsonSchemaGeneratorSettings.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGeneratorSettings.cs
@@ -36,7 +36,9 @@ namespace NJsonSchema.Generation
         /// <summary>Initializes a new instance of the <see cref="JsonSchemaGeneratorSettings"/> class.</summary>
         public JsonSchemaGeneratorSettings()
         {
-            DefaultReferenceTypeNullHandling = ReferenceTypeNullHandling.Default;
+            DefaultReferenceTypeNullHandling = ReferenceTypeNullHandling.Null;
+            DefaultDictionaryValueReferenceTypeNullHandling = ReferenceTypeNullHandling.NotNull;
+
             SchemaType = SchemaType.JsonSchema;
             GenerateAbstractSchemas = true;
 
@@ -52,8 +54,11 @@ namespace NJsonSchema.Generation
             ExcludedTypeNames = new string[0];
         }
 
-        /// <summary>Gets or sets the default reference type null handling when no nullability information is available (if NotNullAttribute and CanBeNullAttribute are missing, default: Null).</summary>
+        /// <summary>Gets or sets the default reference type null handling when no nullability information is available (default: Null).</summary>
         public ReferenceTypeNullHandling DefaultReferenceTypeNullHandling { get; set; }
+
+        /// <summary>Gets or sets the default reference type null handling of dictionary value types when no nullability information is available (default: NotNull).</summary>
+        public ReferenceTypeNullHandling DefaultDictionaryValueReferenceTypeNullHandling { get; set; }
 
         /// <summary>Gets or sets a value indicating whether to generate abstract properties (i.e. interface and abstract properties. Properties may defined multiple times in a inheritance hierarchy, default: false).</summary>
         public bool GenerateAbstractProperties { get; set; }
@@ -81,7 +86,7 @@ namespace NJsonSchema.Generation
         public bool GenerateEnumMappingDescription { get; set; }
 
         /// <summary>Will set `additionalProperties` on all added <see cref="JsonSchema">schema definitions and references</see>(default: false).</summary>
-        public bool AlwaysAllowAdditionalObjectProperties { get; set;}
+        public bool AlwaysAllowAdditionalObjectProperties { get; set; }
 
         /// <summary>Gets or sets the schema type to generate (default: JsonSchema).</summary>
         public SchemaType SchemaType { get; set; }

--- a/src/NJsonSchema/Generation/ReferenceTypeNullHandling.cs
+++ b/src/NJsonSchema/Generation/ReferenceTypeNullHandling.cs
@@ -11,9 +11,6 @@ namespace NJsonSchema.Generation
     /// <summary>Specifies the default null handling for reference types when no nullability information is available.</summary>
     public enum ReferenceTypeNullHandling
     {
-        /// <summary>Use default behavior of the current runtime (e.g. use Null Reference Type annotations if available or Null references).</summary>
-        Default,
-
         /// <summary>Reference types are nullable by default (C# default).</summary>
         Null,
 


### PR DESCRIPTION
- Support minlength/maxlength/regularexpression attributes on dictionary and array properties
- Add JsonSchemaPatternPropertiesAttribute on dictionary properties
- Improve nullability checks
- Add DefaultDictionaryValueReferenceTypeNullHandling setting (default: NotNull)

Closes #991
Closes #992