### PR TITLE
Fix formatting of Typescript dictionary types

### DIFF
--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/ClassGenerationTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/ClassGenerationTests.cs
@@ -177,9 +177,9 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
             var code = generator.GenerateFile("MyClass");
 
             //// Assert
-            Assert.Contains("a: { [key: string] : string; };", code);
+            Assert.Contains("a: { [key: string]: string; };", code);
             Assert.Contains("this.a = {};", code);
-            Assert.Contains("b: { [key: string] : string; };", code);
+            Assert.Contains("b: { [key: string]: string; };", code);
         }
 
         [Fact]

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/ConstructorInterfaceTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/ConstructorInterfaceTests.cs
@@ -84,9 +84,9 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
     supervisor: MyClass;
     address: IAddress;
     cars: ICar[];
-    skills: { [key: string] : ISkill; };
+    skills: { [key: string]: ISkill; };
     foo: Car[][];
-    bar: { [key: string] : Skill[]; };
+    bar: { [key: string]: Skill[]; };
 }".Replace("\r", "").Replace("\n", ""), output.Replace("\r", "").Replace("\n", ""));
         }
 
@@ -120,9 +120,9 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
             });
 
             var output = generator.GenerateFile("MyClass");
-            
+
             //// Assert
-            Assert.Contains("custom4: { [key: string] : string; }[];", output);
+            Assert.Contains("custom4: { [key: string]: string; }[];", output);
         }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/DictionaryTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/DictionaryTests.cs
@@ -33,7 +33,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
             var code = codeGenerator.GenerateFile("MetadataDictionary");
 
             //// Assert
-            Assert.DoesNotContain("extends { [key: string] : any; }", code);
+            Assert.DoesNotContain("extends { [key: string]: any; }", code);
             Assert.Contains("[key: string]: any; ", code);
         }
 
@@ -53,7 +53,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
             var code = codeGenerator.GenerateFile("MetadataDictionary");
 
             //// Assert
-            Assert.DoesNotContain("extends { [key: string] : any; }", code);
+            Assert.DoesNotContain("extends { [key: string]: any; }", code);
             Assert.DoesNotContain("super()", code);
             Assert.Contains("[key: string]: any; ", code);
         }
@@ -74,7 +74,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
             var code = codeGenerator.GenerateFile("MetadataDictionary");
 
             //// Assert
-            Assert.DoesNotContain("extends { [key: string] : string; }", code);
+            Assert.DoesNotContain("extends { [key: string]: string; }", code);
             Assert.Contains("[key: string]: string | any; ", code);
         }
 
@@ -94,7 +94,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
             var code = codeGenerator.GenerateFile("MetadataDictionary");
 
             //// Assert
-            Assert.DoesNotContain("extends { [key: string] : string; }", code);
+            Assert.DoesNotContain("extends { [key: string]: string; }", code);
             Assert.DoesNotContain("super()", code);
             Assert.Contains("[key: string]: string | any; ", code);
         }
@@ -232,7 +232,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
             //// Assert
             if (inlineNamedDictionaries)
             {
-                Assert.Contains("foo: { [key: string] : string; };", code);
+                Assert.Contains("foo: { [key: string]: string; };", code);
                 Assert.Contains(@"data[""Foo""] = {};", code);
                 Assert.Contains(@"this.foo = {} as any;", code);
 

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/InheritanceTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/InheritanceTests.cs
@@ -53,7 +53,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
 
             if (inlineNamedDictionaries)
             {
-                Assert.Contains("customDictionary: { [key: string] : any; } | undefined;", code);
+                Assert.Contains("customDictionary: { [key: string]: any; } | undefined;", code);
                 Assert.DoesNotContain("EmptyClassInheritingDictionary", code);
             }
             else

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptDictionaryTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptDictionaryTests.cs
@@ -38,8 +38,8 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
             var code = generator.GenerateFile("MyClass");
 
             //// Assert
-            Assert.Contains("Mapping: { [key: string] : string; };", code);
-            Assert.Contains("Mapping2: { [key: string] : string; };", code);
+            Assert.Contains("Mapping: { [key: string]: string; };", code);
+            Assert.Contains("Mapping2: { [key: string]: string; };", code);
         }
 
         [Fact]
@@ -54,8 +54,8 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
             var code = generator.GenerateFile("MyClass");
 
             //// Assert
-            Assert.Contains("Mapping: { [key in keyof typeof PropertyName] : string; } | undefined;", code);
-            Assert.Contains("Mapping2: { [key in keyof typeof PropertyName] : string; } | undefined;", code);
+            Assert.Contains("Mapping: { [key in keyof typeof PropertyName]: string; } | undefined;", code);
+            Assert.Contains("Mapping2: { [key in keyof typeof PropertyName]: string; } | undefined;", code);
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -88,8 +88,8 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
             var code = generator.GenerateFile("MyClass");
 
             //// Assert
-            Assert.Contains("Mapping: { [key: string] : Gender; };", code);
-            Assert.Contains("Mapping2: { [key: string] : Gender; };", code);
+            Assert.Contains("Mapping: { [key: string]: Gender; };", code);
+            Assert.Contains("Mapping2: { [key: string]: Gender; };", code);
         }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptGeneratorTests.cs
@@ -94,7 +94,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
 
             //// Assert
             Assert.Contains(@"lastName: string;", output);
-            Assert.Contains(@"Dictionary: { [key: string] : number; };", output);
+            Assert.Contains(@"Dictionary: { [key: string]: number; };", output);
         }
 
         [Fact]
@@ -260,7 +260,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
             var code = generator.GenerateFile("MyClass");
 
             //// Assert
-            Assert.Contains("dict: { [key: string] : string; };", code); // property not nullable
+            Assert.Contains("dict: { [key: string]: string; };", code); // property not nullable
             Assert.Contains("this.dict = {};", code); // must be initialized with {}
         }
 

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptObjectTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptObjectTests.cs
@@ -52,7 +52,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
             var code = generator.GenerateFile("MyClass");
 
             //// Assert
-            Assert.Contains("Test: { [key: string] : any; };", code);
+            Assert.Contains("Test: { [key: string]: any; };", code);
         }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
@@ -148,10 +148,10 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                 var keyType = Settings.TypeScriptVersion >= 2.1m ? prefix + ResolveDictionaryKeyType(schema, defaultType) : defaultType;
                 if (keyType != defaultType)
                 {
-                    return $"{{ [key in keyof typeof {keyType}] : {valueType}; }}";
+                    return $"{{ [key in keyof typeof {keyType}]: {valueType}; }}";
                 }
 
-                return $"{{ [key: {keyType}] : {valueType}; }}";
+                return $"{{ [key: {keyType}]: {valueType}; }}";
             }
 
             return (addInterfacePrefix && !schema.ActualTypeSchema.IsEnumeration && SupportsConstructorConversion(schema) ? "I" : "") +


### PR DESCRIPTION
Small change that updates the formatting of dictionary types in Typescript. Removes the space before the colon. So that code generation changes from

`Promise<{ [key: string] : number; }>`

to

`Promise<{ [key: string]: number; }>`

which is more generally accepted and often done by autoformatters.