### PR TITLE
Include Id, from the chema to be used in the Property Model and Class model,

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/ClassTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/ClassTemplateModel.cs
@@ -39,6 +39,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                 .Select(property => new PropertyModel(this, property, _resolver, _settings))
                 .ToArray();
 
+            Id = _schema.Id;
             if (schema.InheritedSchema != null)
             {
                 BaseClass = new ClassTemplateModel(BaseClassName, settings, resolver, schema.InheritedSchema, rootObject);
@@ -49,6 +50,11 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                 AllProperties = Properties;
             }
         }
+
+        /// <summary>
+        /// Id for the class instance
+        /// </summary>
+        public string Id { get; set; }
 
         /// <summary>Gets or sets the class name.</summary>
         public override string ClassName { get; }

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
@@ -33,7 +33,16 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
             _property = property;
             _settings = settings;
             _resolver = typeResolver;
+            
+            Id = property.Id;
+            if (property.Reference != null && string.IsNullOrEmpty(Id))
+                Id = property.Reference.Id;
         }
+
+        /// <summary>
+        /// Id for the property
+        /// </summary>
+        public string Id { get;  }
 
         /// <summary>Gets the name of the property.</summary>
         public string Name => _property.Name;


### PR DESCRIPTION
When we generate the models we need to have the ID of the property and the class.-
I Extended the PropertyModel and ClassTemplateModel to include the Id.
Property respects the inheritance.