### PR TITLE
Inlined primitive types aren't decorate with validation attributes

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/ValidationAttributesTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/ValidationAttributesTests.cs
@@ -1,0 +1,45 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace NJsonSchema.CodeGeneration.CSharp.Tests
+{
+    public class ValidationAttributesTests
+    {
+        [Fact]
+        public async Task When_string_property_has_maxlength_then_stringlength_attribute_is_rendered_in_Swagger_mode()
+        {
+            //// Arrange
+            const string json = @"{
+                        'type': 'object',
+                        'required': [ 'value' ],
+                        'properties': {
+                            'value': {
+                                '$ref': '#/definitions/string50'
+                            }
+                        },
+                'definitions': {
+                    'string50': {
+                        'type': 'string',
+                        'maxLength': 50
+                    }
+                }
+            }";
+            var schema = await JsonSchema.FromJsonAsync(json);
+
+            //// Act
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings
+            {
+                ClassStyle = CSharpClassStyle.Poco,
+                SchemaType = SchemaType.Swagger2
+            });
+            var code = generator.GenerateFile("Message");
+
+            //// Assert
+            Assert.Null(schema.Properties["value"].MaxLength);
+            Assert.Equal(50, schema.Properties["value"].ActualSchema.MaxLength);
+
+            Assert.Contains("[System.ComponentModel.DataAnnotations.StringLength(50)]\n" +
+                            "        public string Value { get; set; }\n", code);
+        }
+    }
+}

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/ValidationAttributesTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/ValidationAttributesTests.cs
@@ -10,13 +10,13 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
         {
             //// Arrange
             const string json = @"{
-                        'type': 'object',
-                        'required': [ 'value' ],
-                        'properties': {
-                            'value': {
-                                '$ref': '#/definitions/string50'
-                            }
-                        },
+                'type': 'object',
+                'required': [ 'value' ],
+                'properties': {
+                    'value': {
+                        '$ref': '#/definitions/string50'
+                    }
+                },
                 'definitions': {
                     'string50': {
                         'type': 'string',
@@ -40,6 +40,238 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
 
             Assert.Contains("[System.ComponentModel.DataAnnotations.StringLength(50)]\n" +
                             "        public string Value { get; set; }\n", code);
+        }
+
+        [Fact]
+        public async Task When_string_property_has_minlength_then_stringlength_attribute_is_rendered_in_Swagger_mode()
+        {
+            //// Arrange
+            const string json = @"{
+                'type': 'object',
+                'required': [ 'value' ],
+                'properties': {
+                    'value': {
+                        '$ref': '#/definitions/string40'
+                    }
+                },
+                'definitions': {
+                    'string40': {
+                        'type': 'string',
+                        'minLength': 40
+                    }
+                }
+            }";
+            var schema = await JsonSchema.FromJsonAsync(json);
+
+            //// Act
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings
+            {
+                ClassStyle = CSharpClassStyle.Poco,
+                SchemaType = SchemaType.Swagger2
+            });
+            var code = generator.GenerateFile("Message");
+
+            //// Assert
+            Assert.Null(schema.Properties["value"].MinLength);
+            Assert.Equal(40, schema.Properties["value"].ActualSchema.MinLength);
+
+            Assert.Contains("[System.ComponentModel.DataAnnotations.StringLength(int.MaxValue, MinimumLength = 40)]\n" +
+                            "        public string Value { get; set; }\n", code);
+        }
+
+        [Fact]
+        public async Task When_int_property_has_maximum_then_range_attribute_is_rendered_in_Swagger_mode()
+        {
+            //// Arrange
+            const string json = @"{
+                'type': 'object',
+                'required': [ 'value' ],
+                'properties': {
+                    'value': {
+                        '$ref': '#/definitions/int20'
+                    }
+                },
+                'definitions': {
+                    'int20': {
+                        'type': 'integer',
+                        'format': 'int32',
+                        'maximum': 20
+                    }
+                }
+            }";
+            var schema = await JsonSchema.FromJsonAsync(json);
+
+            //// Act
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings
+            {
+                ClassStyle = CSharpClassStyle.Poco,
+                SchemaType = SchemaType.Swagger2
+            });
+            var code = generator.GenerateFile("Message");
+
+            //// Assert
+            Assert.Null(schema.Properties["value"].Maximum);
+            Assert.Equal(20, schema.Properties["value"].ActualSchema.Maximum);
+
+            Assert.Contains("[System.ComponentModel.DataAnnotations.Range(int.MinValue, 20)]\n" +
+                            "        public int Value { get; set; }\n", code);
+        }
+
+        [Fact]
+        public async Task When_int_property_has_minimum_then_range_attribute_is_rendered_in_Swagger_mode()
+        {
+            //// Arrange
+            const string json = @"{
+                'type': 'object',
+                'required': [ 'value' ],
+                'properties': {
+                    'value': {
+                        '$ref': '#/definitions/int10'
+                    }
+                },
+                'definitions': {
+                    'int10': {
+                        'type': 'integer',
+                        'format': 'int32',
+                        'minimum': 10
+                    }
+                }
+            }";
+            var schema = await JsonSchema.FromJsonAsync(json);
+
+            //// Act
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings
+            {
+                ClassStyle = CSharpClassStyle.Poco,
+                SchemaType = SchemaType.Swagger2
+            });
+            var code = generator.GenerateFile("Message");
+
+            //// Assert
+            Assert.Null(schema.Properties["value"].Minimum);
+            Assert.Equal(10, schema.Properties["value"].ActualSchema.Minimum);
+
+            Assert.Contains("[System.ComponentModel.DataAnnotations.Range(10, int.MaxValue)]\n" +
+                            "        public int Value { get; set; }\n", code);
+        }
+
+        [Fact]
+        public async Task When_string_property_has_pattern_then_regularexpression_attribute_is_rendered_in_Swagger_mode()
+        {
+            //// Arrange
+            const string regularExpression = "[a-zA-Z0-9]{5,56}";
+            const string json = @"{
+                        'type': 'object',
+                        'required': [ 'value' ],
+                        'properties': {
+                            'value': {
+                                '$ref': '#/definitions/stringPatterned'
+                            }
+                        },
+                'definitions': {
+                    'stringPatterned': {
+                        'type': 'string',
+                        'pattern': '" + regularExpression + @"'
+                    }
+                }
+            }";
+            var schema = await JsonSchema.FromJsonAsync(json);
+
+            //// Act
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings
+            {
+                ClassStyle = CSharpClassStyle.Poco,
+                SchemaType = SchemaType.Swagger2
+            });
+            var code = generator.GenerateFile("Message");
+
+            //// Assert
+            Assert.Null(schema.Properties["value"].Pattern);
+            Assert.Equal(regularExpression, schema.Properties["value"].ActualSchema.Pattern);
+
+            Assert.Contains("[System.ComponentModel.DataAnnotations.RegularExpression(@\"" + regularExpression + "\")]\n" +
+                            "        public string Value { get; set; }\n", code);
+        }
+
+        [Fact]
+        public async Task When_array_property_has_maxitems_then_maxlength_attribute_is_rendered_in_Swagger_mode()
+        {
+            //// Arrange
+            const string json = @"{
+                'type': 'object',
+                'required': [ 'value' ],
+                'properties': {
+                    'value': {
+                        '$ref': '#/definitions/array10'
+                    }
+                },
+                'definitions': {
+                    'array10': {
+                        'type': 'array',
+                        'items': {
+                           'type': 'string'
+                        },
+                        'maxItems': 10
+                    }
+                }
+            }";
+            var schema = await JsonSchema.FromJsonAsync(json);
+
+            //// Act
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings
+            {
+                ClassStyle = CSharpClassStyle.Poco,
+                SchemaType = SchemaType.Swagger2
+            });
+            var code = generator.GenerateFile("Message");
+
+            //// Assert
+            Assert.Equal(0, schema.Properties["value"].MaxItems);
+            Assert.Equal(10, schema.Properties["value"].ActualSchema.MaxItems);
+
+            Assert.Contains("[System.ComponentModel.DataAnnotations.MaxLength(10)]\n" +
+                            "        public Array10 Value { get; set; } = new Array10();\n", code);
+        }
+
+        [Fact]
+        public async Task When_array_property_has_minitems_then_minlength_attribute_is_rendered_in_Swagger_mode()
+        {
+            //// Arrange
+            const string json = @"{
+                'type': 'object',
+                'required': [ 'value' ],
+                'properties': {
+                    'value': {
+                        '$ref': '#/definitions/array10'
+                    }
+                },
+                'definitions': {
+                    'array10': {
+                        'type': 'array',
+                        'items': {
+                           'type': 'string'
+                        },
+                        'minItems': 10
+                    }
+                }
+            }";
+            var schema = await JsonSchema.FromJsonAsync(json);
+
+            //// Act
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings
+            {
+                ClassStyle = CSharpClassStyle.Poco,
+                SchemaType = SchemaType.Swagger2,
+                InlineNamedArrays = true
+            });
+            var code = generator.GenerateFile("Message");
+
+            //// Assert
+            Assert.Equal(0, schema.Properties["value"].MinItems);
+            Assert.Equal(10, schema.Properties["value"].ActualSchema.MinItems);
+
+            Assert.Contains("[System.ComponentModel.DataAnnotations.MinLength(10)]\n" +
+                            "        public System.Collections.Generic.ICollection<string> Value { get; set; } = new System.Collections.ObjectModel.Collection<string>();\n", code);
         }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
@@ -188,15 +188,27 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                 }
 
                 return _property.ActualTypeSchema.Type.HasFlag(JsonObjectType.String) &&
-                       (_property.MinLength.HasValue || _property.MaxLength.HasValue);
+                       (_property.MinLength.HasValue || _property.MaxLength.HasValue ||
+                       _property.ActualTypeSchema.MinLength.HasValue || _property.ActualTypeSchema.MaxLength.HasValue);
             }
         }
 
         /// <summary>Gets the minimum value of the string length attribute.</summary>
-        public int StringLengthMinimumValue => _property.MinLength ?? 0;
+        public int StringLengthMinimumValue => _property.MinLength ?? _property.ActualTypeSchema.MinLength ?? 0;
 
         /// <summary>Gets the maximum value of the string length attribute.</summary>
-        public string StringLengthMaximumValue => _property.MaxLength.HasValue ? _property.MaxLength.Value.ToString(CultureInfo.InvariantCulture) : $"int.{nameof(int.MaxValue)}";
+        public string StringLengthMaximumValue
+        {
+            get
+            {
+                if (_property.MaxLength.HasValue)
+                    return _property.MaxLength.Value.ToString(CultureInfo.InvariantCulture);
+                if (_property.ActualTypeSchema.MaxLength.HasValue)
+                    return _property.ActualTypeSchema.MaxLength.Value.ToString(CultureInfo.InvariantCulture);
+
+                return $"int.{nameof(int.MaxValue)}";
+            }
+        }
 
         /// <summary>Gets a value indicating whether to render the min length attribute.</summary>
         public bool RenderMinLengthAttribute

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
@@ -124,7 +124,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                     return false;
                 }
 
-                return _property.Maximum.HasValue || _property.Minimum.HasValue;
+                return _property.ActualSchema.Maximum.HasValue || _property.ActualSchema.Minimum.HasValue;
             }
         }
 
@@ -144,8 +144,8 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                     _property.Format == JsonFormatStrings.Decimal ?
                         "double" : "int";
 
-                return _property.Minimum.HasValue
-                    ? ValueGenerator.GetNumericValue(_property.Type, _property.Minimum.Value, format)
+                return _property.ActualSchema.Minimum.HasValue
+                    ? ValueGenerator.GetNumericValue(_property.Type, _property.ActualSchema.Minimum.Value, format)
                     : type + "." + nameof(double.MinValue);
             }
         }
@@ -166,8 +166,8 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                     _property.Format == JsonFormatStrings.Decimal ?
                         "double" : "int";
 
-                return _property.Maximum.HasValue
-                    ? ValueGenerator.GetNumericValue(_property.Type, _property.Maximum.Value, format)
+                return _property.ActualSchema.Maximum.HasValue
+                    ? ValueGenerator.GetNumericValue(_property.Type, _property.ActualSchema.Maximum.Value, format)
                     : type + "." + nameof(double.MaxValue);
             }
         }
@@ -188,27 +188,15 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                 }
 
                 return _property.ActualTypeSchema.Type.HasFlag(JsonObjectType.String) &&
-                       (_property.MinLength.HasValue || _property.MaxLength.HasValue ||
-                       _property.ActualTypeSchema.MinLength.HasValue || _property.ActualTypeSchema.MaxLength.HasValue);
+                       (_property.ActualSchema.MinLength.HasValue || _property.ActualSchema.MaxLength.HasValue);
             }
         }
 
         /// <summary>Gets the minimum value of the string length attribute.</summary>
-        public int StringLengthMinimumValue => _property.MinLength ?? _property.ActualTypeSchema.MinLength ?? 0;
+        public int StringLengthMinimumValue => _property.ActualSchema.MinLength ?? 0;
 
         /// <summary>Gets the maximum value of the string length attribute.</summary>
-        public string StringLengthMaximumValue
-        {
-            get
-            {
-                if (_property.MaxLength.HasValue)
-                    return _property.MaxLength.Value.ToString(CultureInfo.InvariantCulture);
-                if (_property.ActualTypeSchema.MaxLength.HasValue)
-                    return _property.ActualTypeSchema.MaxLength.Value.ToString(CultureInfo.InvariantCulture);
-
-                return $"int.{nameof(int.MaxValue)}";
-            }
-        }
+        public string StringLengthMaximumValue => _property.ActualSchema.MaxLength.HasValue ? _property.ActualSchema.MaxLength.Value.ToString(CultureInfo.InvariantCulture) : $"int.{nameof(int.MaxValue)}";
 
         /// <summary>Gets a value indicating whether to render the min length attribute.</summary>
         public bool RenderMinLengthAttribute
@@ -220,12 +208,12 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                     return false;
                 }
 
-                return _property.ActualTypeSchema.Type.HasFlag(JsonObjectType.Array) && _property.MinItems > 0;
+                return _property.ActualTypeSchema.Type.HasFlag(JsonObjectType.Array) && _property.ActualSchema.MinItems > 0;
             }
         }
 
         /// <summary>Gets the value of the min length attribute.</summary>
-        public int MinLengthAttribute => _property.MinItems;
+        public int MinLengthAttribute => _property.ActualSchema.MinItems;
 
         /// <summary>Gets a value indicating whether to render the max length attribute.</summary>
         public bool RenderMaxLengthAttribute
@@ -237,12 +225,12 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                     return false;
                 }
 
-                return _property.ActualTypeSchema.Type.HasFlag(JsonObjectType.Array) && _property.MaxItems > 0;
+                return _property.ActualTypeSchema.Type.HasFlag(JsonObjectType.Array) && _property.ActualSchema.MaxItems > 0;
             }
         }
 
         /// <summary>Gets the value of the max length attribute.</summary>
-        public int MaxLengthAttribute => _property.MaxItems;
+        public int MaxLengthAttribute => _property.ActualSchema.MaxItems;
 
         /// <summary>Gets a value indicating whether to render a regular expression attribute.</summary>
         public bool RenderRegularExpressionAttribute
@@ -255,12 +243,12 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                 }
 
                 return _property.ActualTypeSchema.Type.HasFlag(JsonObjectType.String) &&
-                       !string.IsNullOrEmpty(_property.Pattern);
+                       !string.IsNullOrEmpty(_property.ActualSchema.Pattern);
             }
         }
 
         /// <summary>Gets the regular expression value for the regular expression attribute.</summary>
-        public string RegularExpressionValue => _property.Pattern?.Replace("\"", "\"\"");
+        public string RegularExpressionValue => _property.ActualSchema.Pattern?.Replace("\"", "\"\"");
 
         /// <summary>Gets a value indicating whether the property type is string enum.</summary>
         public bool IsStringEnum => _property.ActualTypeSchema.IsEnumeration && _property.ActualTypeSchema.Type == JsonObjectType.String;


### PR DESCRIPTION
I create this PR as a starting point. It's only a POC.

I detected that primitives types (see simple repro below) are inlined to not create wrapper around them (which is correct behavior). The issue here is that if the open api definition contains validation rules. NSwag do not generate the validation attributes.

The follow OpenApi 3.0 definition show the simplest reproduction of the issue (same issue with OpenApi 2.0).

I started this PR with a fix for this specific case (string maximum length). Is the current behavior the desired one or should we fix it? I would be happy to augment this PR to cover all validations.

```yaml
openapi: "3.0.0"
info:
  version: 1.0.0
  title: Simple repro of missing validation in case of inlined type

paths:
  /echo:
    post:
      summary: Echo a simple message
      operationId: echo
      requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/message'
      responses:
        '200':
          description: the message to echo
          content:
            application/json:    
              schema:
                $ref: "#/components/schemas/message"

components:
  schemas:
    message:
      type: object
      required:
        - value
      properties:
        value:
          $ref: "#/components/schemas/string50"
    string50:
      type: string
      maxLength: 50
```