### PR TITLE
Add GenerateOptionalPropertiesAsNullable setting

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/NullableTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/NullableTests.cs
@@ -55,7 +55,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             {
                 ClassStyle = CSharpClassStyle.Poco,
                 SchemaType = SchemaType.OpenApi3,
-                GenerateNullableOptionalProperties = true
+                GenerateOptionalPropertiesAsNullable = true
             });
             var code = generator.GenerateFile("MyClass");
 

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/NullableTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/NullableTests.cs
@@ -1,0 +1,67 @@
+﻿using NJsonSchema.CodeGeneration.CSharp;
+using NJsonSchema.Generation;
+using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NJsonSchema.CodeGeneration.Tests.CSharp
+{
+    public class NullableTests
+    {
+        private class ClassWithRequiredObject
+        {
+            public int Property { get; set; }
+
+            [Required]
+            public int Property2 { get; set; }
+        }
+
+        [Fact]
+        public async Task When_property_is_optional_and_GenerateNullableOptionalProperties_is_not_set_then_CSharp_property_is_not_nullable()
+        {
+            //// Arrange
+            var schema = JsonSchema.FromType<ClassWithRequiredObject>(new JsonSchemaGeneratorSettings
+            {
+                SchemaType = SchemaType.OpenApi3
+            });
+            var schemaData = schema.ToJson();
+
+            //// Act
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings
+            {
+                ClassStyle = CSharpClassStyle.Poco,
+                SchemaType = SchemaType.OpenApi3,
+                //GenerateNullableOptionalProperties = false
+            });
+            var code = generator.GenerateFile("MyClass");
+
+            //// Assert
+            Assert.Contains("public int Property { get; set; }", code);
+            Assert.Contains("public int Property2 { get; set; }", code);
+        }
+
+        [Fact]
+        public async Task When_property_is_optional_and_GenerateNullableOptionalProperties_is_set_then_CSharp_property_is_nullable()
+        {
+            //// Arrange
+            var schema = JsonSchema.FromType<ClassWithRequiredObject>(new JsonSchemaGeneratorSettings
+            {
+                SchemaType = SchemaType.OpenApi3
+            });
+            var schemaData = schema.ToJson();
+
+            //// Act
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings
+            {
+                ClassStyle = CSharpClassStyle.Poco,
+                SchemaType = SchemaType.OpenApi3,
+                GenerateNullableOptionalProperties = true
+            });
+            var code = generator.GenerateFile("MyClass");
+
+            //// Assert
+            Assert.Contains("public int? Property { get; set; }", code);
+            Assert.Contains("public int Property2 { get; set; }", code);
+        }
+    }
+}

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpGeneratorSettings.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpGeneratorSettings.cs
@@ -134,5 +134,8 @@ namespace NJsonSchema.CodeGeneration.CSharp
 
         /// <summary>Gets or sets a value indicating whether named/referenced arrays should be inlined or generated as class with array inheritance.</summary>
         public bool InlineNamedArrays { get; set; }
+
+        /// <summary>Gets or sets a value indicating whether optional schema properties (not required) are generated as nullable properties (default: false).</summary>
+        public bool GenerateNullableOptionalProperties { get; set; }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpGeneratorSettings.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpGeneratorSettings.cs
@@ -136,6 +136,6 @@ namespace NJsonSchema.CodeGeneration.CSharp
         public bool InlineNamedArrays { get; set; }
 
         /// <summary>Gets or sets a value indicating whether optional schema properties (not required) are generated as nullable properties (default: false).</summary>
-        public bool GenerateNullableOptionalProperties { get; set; }
+        public bool GenerateOptionalPropertiesAsNullable { get; set; }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
@@ -68,6 +68,12 @@ namespace NJsonSchema.CodeGeneration.CSharp
             }
 
             // Primitive schemas (no new type)
+            if (Settings.GenerateNullableOptionalProperties &&
+                schema is JsonSchemaProperty property &&
+                !property.IsRequired)
+            {
+                isNullable = true;
+            }
 
             if (schema.ActualTypeSchema.IsAnyType &&
                 schema.InheritedSchema == null && // not in inheritance hierarchy

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
@@ -68,7 +68,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
             }
 
             // Primitive schemas (no new type)
-            if (Settings.GenerateNullableOptionalProperties &&
+            if (Settings.GenerateOptionalPropertiesAsNullable &&
                 schema is JsonSchemaProperty property &&
                 !property.IsRequired)
             {

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
@@ -50,6 +50,9 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
         /// <summary>Gets the name of the field.</summary>
         public string FieldName => "_" + ConversionUtilities.ConvertToLowerCamelCase(PropertyName, true);
 
+        /// <summary>Gets a value indicating whether the property is nullable.</summary>
+        public override bool IsNullable => _settings.GenerateNullableOptionalProperties && !_property.IsRequired ? true : base.IsNullable;
+
         /// <summary>Gets or sets a value indicating whether empty strings are allowed.</summary>
         public bool AllowEmptyStrings =>
             _property.ActualTypeSchema.Type.HasFlag(JsonObjectType.String) &&

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
@@ -51,7 +51,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
         public string FieldName => "_" + ConversionUtilities.ConvertToLowerCamelCase(PropertyName, true);
 
         /// <summary>Gets a value indicating whether the property is nullable.</summary>
-        public override bool IsNullable => _settings.GenerateOptionalPropertiesAsNullable && !_property.IsRequired ? true : base.IsNullable;
+        public override bool IsNullable => (_settings.GenerateOptionalPropertiesAsNullable && !_property.IsRequired) || base.IsNullable;
 
         /// <summary>Gets or sets a value indicating whether empty strings are allowed.</summary>
         public bool AllowEmptyStrings =>

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
@@ -51,7 +51,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
         public string FieldName => "_" + ConversionUtilities.ConvertToLowerCamelCase(PropertyName, true);
 
         /// <summary>Gets a value indicating whether the property is nullable.</summary>
-        public override bool IsNullable => _settings.GenerateNullableOptionalProperties && !_property.IsRequired ? true : base.IsNullable;
+        public override bool IsNullable => _settings.GenerateOptionalPropertiesAsNullable && !_property.IsRequired ? true : base.IsNullable;
 
         /// <summary>Gets or sets a value indicating whether empty strings are allowed.</summary>
         public bool AllowEmptyStrings =>

--- a/src/NJsonSchema.CodeGeneration/Models/PropertyModelBase.cs
+++ b/src/NJsonSchema.CodeGeneration/Models/PropertyModelBase.cs
@@ -55,7 +55,7 @@ namespace NJsonSchema.CodeGeneration.Models
         public string PropertyName { get; set; }
 
         /// <summary>Gets a value indicating whether the property is nullable.</summary>
-        public bool IsNullable => _property.IsNullable(_settings.SchemaType);
+        public virtual bool IsNullable => _property.IsNullable(_settings.SchemaType);
 
         /// <summary>Gets a value indicating whether the property is required.</summary>
         public bool IsRequired => _property.IsRequired;


### PR DESCRIPTION
We should not fix JsonSchemaProperty class (because the schema is not really nullable) but just enhance the C# generator with an additional setting (to avoid breaking changes).

