### PR TITLE
Fix/1047

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/NJsonSchema.CodeGeneration.CSharp.Tests.csproj
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/NJsonSchema.CodeGeneration.CSharp.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1998,1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="References\A.json" />

--- a/src/NJsonSchema.CodeGeneration.Tests/NJsonSchema.CodeGeneration.Tests.csproj
+++ b/src/NJsonSchema.CodeGeneration.Tests/NJsonSchema.CodeGeneration.Tests.csproj
@@ -1,8 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">    <PropertyGroup>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
         <TargetFrameworks>netcoreapp2.0;net451</TargetFrameworks>
         <SignAssembly>True</SignAssembly>
         <AssemblyOriginatorKeyFile>../NJsonSchema.snk</AssemblyOriginatorKeyFile>
         <IsPackable>false</IsPackable>
+        <NoWarn>1998,1591</NoWarn>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/NJsonSchema.CodeGeneration.TypeScript.Tests.csproj
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/NJsonSchema.CodeGeneration.TypeScript.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>netcoreapp2.0;net451</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1998,1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />

--- a/src/NJsonSchema.CodeGeneration.TypeScript/NJsonSchema.CodeGeneration.TypeScript.csproj
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/NJsonSchema.CodeGeneration.TypeScript.csproj
@@ -5,7 +5,9 @@
     <Version>10.0.22</Version>
     <PackageTags>json schema validation generator .net</PackageTags>
     <Copyright>Copyright © Rico Suter, 2018</Copyright>
+    <!--
     <PackageLicenseUrl>https://github.com/RicoSuter/NJsonSchema/blob/master/LICENSE.md</PackageLicenseUrl>
+    -->
     <PackageProjectUrl>http://NJsonSchema.org</PackageProjectUrl>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>../NJsonSchema.snk</AssemblyOriginatorKeyFile>

--- a/src/NJsonSchema.CodeGeneration.TypeScript/NJsonSchema.CodeGeneration.TypeScript.nuspec
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/NJsonSchema.CodeGeneration.TypeScript.nuspec
@@ -7,7 +7,7 @@
         <description>$description$</description>
         <tags>json schema validation generator codegen .net</tags>
         <projectUrl>http://NJsonSchema.org</projectUrl>
-        <licenseUrl>https://github.com/RicoSuter/NJsonSchema/blob/master/LICENSE.md</licenseUrl>
+        <license type="MIT"/>
     </metadata>
     <files>
         <file src="bin\Release\NJsonSchema.CodeGeneration.TypeScript.dll" target="lib\portable-net45+win+wpa81+wp80+MonoAndroid10+MonoTouch10" />

--- a/src/NJsonSchema.Tests/Generation/InheritanceTests.cs
+++ b/src/NJsonSchema.Tests/Generation/InheritanceTests.cs
@@ -300,9 +300,10 @@ namespace NJsonSchema.Tests.Generation
 
             //// Act
             JsonSchema GetSchema() => JsonSchema.FromType<BaseClass_WithIntDiscriminant>();
+            Action getSchemaAction = () => GetSchema();
 
             //// Assert
-            Assert.Throws<InvalidOperationException>(GetSchema);
+            Assert.Throws<InvalidOperationException>(getSchemaAction);
         }
 
         public class Foo

--- a/src/NJsonSchema.Tests/NJsonSchema.Tests.csproj
+++ b/src/NJsonSchema.Tests/NJsonSchema.Tests.csproj
@@ -8,6 +8,7 @@
 
   <PropertyGroup>
     <DocumentationFile>bin\Debug\$(TargetFramework)\NJsonSchema.Tests.xml</DocumentationFile>
+    <NoWarn>1998,1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adds mitigations for issue #1047

* Suppresses XML and `async`/`await` compiler warnings in test projects due to the (literally) thousands of spurious warnings.

* Fixes build errors (not warnings) that are raised when I run the command-line `build\01_Build.bat` on my computer.

I'm not able to fix the errors from `02_CreatePackages.bat`, however.