### PR TITLE
Fix to CSharpTypeResolver to restore binary capability

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
@@ -107,14 +107,14 @@ namespace NJsonSchema.CodeGeneration.CSharp
                 return ResolveBoolean(isNullable);
             }
 
-            if (type.HasFlag(JsonObjectType.String) && !schema.ActualTypeSchema.IsEnumeration)
-            {
-                return ResolveString(schema.ActualTypeSchema, isNullable, typeNameHint);
-            }
-
             if (schema.IsBinary)
             {
                 return "byte[]";
+            }
+
+            if (type.HasFlag(JsonObjectType.String) && !schema.ActualTypeSchema.IsEnumeration)
+            {
+                return ResolveString(schema.ActualTypeSchema, isNullable, typeNameHint);
             }
 
             // Type generating schemas


### PR DESCRIPTION
Changed evaluation order slightly to allow `type: "string", format: "binary"` to resolve to a `byte[]` type, which is otherwise not possible.