### PR TITLE
Remove sorting by name from 'Record' class type

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/GeneralGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/GeneralGeneratorTests.cs
@@ -385,9 +385,9 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             {
                 Type = JsonObjectType.String
             };
-            
+
             var generator = new CSharpGenerator(schema);
-            
+
             // Act
             var output = generator.GenerateFile("MyClass");
 
@@ -1596,7 +1596,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             Assert.Contains(@"public string Street { get; }", output);
             Assert.DoesNotContain(@"public string Street { get; set; }", output);
 
-            Assert.Contains("public Address(string @city, string @street)", output);
+            Assert.Contains("public Address(string @street, string @city)", output);
 
             AssertCompile(output);
         }
@@ -1665,11 +1665,11 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
 
             Assert.Contains("protected AbstractAddress(string @city, string @streetName)", output);
 
-            Assert.Contains("public PostAddress(string @city, int @houseNumber, string @streetName, string @zip)", output);
+            Assert.Contains("public PostAddress(string @zip, int @houseNumber, string @city, string @streetName)", output);
             Assert.Contains(": base(city, streetName)", output);
 
-            Assert.Contains("public PersonAddress(string @addressee, string @city, int @houseNumber, string @streetName, string @zip)", output);
-            Assert.Contains(": base(city, houseNumber, streetName, zip)", output);
+            Assert.Contains("public PersonAddress(string @addressee, string @zip, int @houseNumber, string @city, string @streetName)", output);
+            Assert.Contains(": base(zip, houseNumber, city, streetName)", output);
 
             AssertCompile(output);
         }

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.Constructor.Record.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.Constructor.Record.liquid
@@ -1,18 +1,15 @@
-﻿{% assign skipComma = true -%}
+{% assign skipComma = true -%}
 {% if HasInheritance %}
 {% assign parentProperties = BaseClass.AllProperties -%}
 {% else %}
 {% assign parentProperties = "" | empty -%}
 {% endif %}
 
-{% assign sortedProperties = AllProperties | sort: "Name" -%}
-{% assign sortedParentProperties = parentProperties | sort: "Name" -%}
-
 [Newtonsoft.Json.JsonConstructor]
-{% if IsAbstract %}protected{% else %}public{% endif %} {{ClassName}}({% for property in sortedProperties -%}{% if skipComma -%}{% assign skipComma = false %}{% else %}, {% endif -%} {{ property.Type }} @{{ property.Name | lowercamelcase }}{% endfor -%})
+{% if IsAbstract %}protected{% else %}public{% endif %} {{ClassName}}({% for property in AllProperties -%}{% if skipComma -%}{% assign skipComma = false %}{% else %}, {% endif -%} {{ property.Type }} @{{ property.Name | lowercamelcase }}{% endfor -%})
 {% assign skipComma = true -%}
 {% if HasInheritance -%}
-    : base({% for property in sortedParentProperties -%}{% if skipComma -%}{% assign skipComma = false %}{% else %}, {% endif -%}{{ property.Name | lowercamelcase }}{% endfor -%})
+    : base({% for property in parentProperties -%}{% if skipComma -%}{% assign skipComma = false %}{% else %}, {% endif -%}{{ property.Name | lowercamelcase }}{% endfor -%})
 {% endif -%}
 {
 {% for property in Properties -%}


### PR DESCRIPTION
I don't see a good reason for sorting constructor parameters by name. Following the natural flow of properties as they are defined in the specs seems like a better approach since related properties are usually defined close to each other (or at least they _should_ be).