### PR TITLE
Sanitize the "+" for enum value generation

### DIFF
--- a/src/NJsonSchema.CodeGeneration/DefaultEnumNameGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration/DefaultEnumNameGenerator.cs
@@ -39,6 +39,7 @@ namespace NJsonSchema.CodeGeneration
                 .Replace("'", "_")
                 .Replace("(", "_")
                 .Replace(")", "_")
+                .Replace("+", "_")
                 .Replace("\\", "_");
         }
     }


### PR DESCRIPTION
I noticed this when generation an OA3 spec with NSwag. I am generating a client from a spec that has a string value like "application/json+something". 