### PR TITLE
Add support for ISO8601 (2019-10-01T14:48:19.000Z) datetime parsing in JsonSchema.FromSampleJson

### DIFF
--- a/src/NJsonSchema.Tests/Generation/SampleJsonSchemaGeneratorTests.cs
+++ b/src/NJsonSchema.Tests/Generation/SampleJsonSchemaGeneratorTests.cs
@@ -1,4 +1,5 @@
-﻿using NJsonSchema.Generation;
+﻿using Newtonsoft.Json;
+using NJsonSchema.Generation;
 using Xunit;
 
 namespace NJsonSchema.Tests.Generation
@@ -121,6 +122,29 @@ namespace NJsonSchema.Tests.Generation
             //// Assert
             Assert.Equal(JsonObjectType.Array, property.Type);
             Assert.Equal(JsonObjectType.Integer, property.Item.ActualSchema.Type);
+        }
+
+        [Fact]
+        public void Iso8601Dates()
+        {
+            JsonConvert.DefaultSettings = () => new JsonSerializerSettings
+            {
+                DateParseHandling = DateParseHandling.None
+            };
+
+            //// Arrange
+            var data = @"{
+                ""FutureDate"": ""3500-08-03T23:51:56.000Z""
+            }";
+            var generator = new SampleJsonSchemaGenerator();
+
+            //// Act
+            var schema = generator.Generate(data);
+            var property = schema.Properties["FutureDate"];
+
+            //// Assert
+            Assert.Equal(JsonObjectType.String, property.Type);
+            Assert.Equal(JsonFormatStrings.DateTime, property.Format);
         }
     }
 }

--- a/src/NJsonSchema/Generation/SampleJsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/SampleJsonSchemaGenerator.cs
@@ -129,14 +129,14 @@ namespace NJsonSchema.Generation
                 schema.Format = JsonFormatStrings.Date;
             }
 
-            if (schema.Type == JsonObjectType.String && Regex.IsMatch(token.Value<string>(), "^[0-2][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] [0-9][0-9]:[0-9][0-9](:[0-9][0-9])?$"))
-            {
-                schema.Format = JsonFormatStrings.DateTime;
-            }
-
             if (schema.Type == JsonObjectType.String && Regex.IsMatch(token.Value<string>(), "^[0-9][0-9]:[0-9][0-9](:[0-9][0-9])?$"))
             {
                 schema.Format = JsonFormatStrings.TimeSpan;
+            }
+
+            if (schema.Type == JsonObjectType.String && schema.Format == null && DateTime.TryParse(token.Value<string>(), null, System.Globalization.DateTimeStyles.RoundtripKind, out _))
+            {
+                schema.Format = JsonFormatStrings.DateTime;
             }
         }
 


### PR DESCRIPTION
Given a DateTime formatted as per below, we should be able to infer the `date-time` format correctly if we've overridden `DateParseHandling = DateParseHandling.None` in `JsonConvert.DefaultSettings`.

**Sample DateTime**
`2018-08-03T23:51:56.000Z`
The other option is to explicitly set DateParseHandling when we define our settings.
```cs
// SampleJsonSchemaGenerator.cs
public JsonSchema Generate(string json)
{
    var token = JsonConvert.DeserializeObject<JToken>(json, new JsonSerializerSettings
    {
        DateFormatHandling = DateFormatHandling.IsoDateFormat,
        DateParseHandling = DateParseHandling.DateTime // <<< Option 2 >>>

    });

    var schema = new JsonSchema();
    Generate(token, schema, schema, "Anonymous");
    return schema;
}
```
 