### PR TITLE
Support for '#'

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpPropertyNameGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpPropertyNameGenerator.cs
@@ -27,7 +27,8 @@ namespace NJsonSchema.CodeGeneration.CSharp
                     .Replace("+", "plus"), true)
                 .Replace("*", "Star")
                 .Replace(":", "_")
-                .Replace("-", "_");
+                .Replace("-", "_")
+                .Replace("#", "_");
         }
     }
 }


### PR DESCRIPTION
The Microsoft.IdentityModel.Tokens.JsonWebKey property X5tS256 has the JSON property name 'x5t#S256'. Please add support for changing '#' to a supported C# property character like '_'.