### PR TITLE
Do not use GetResolvedPropertyName

### DIFF
--- a/src/NJsonSchema.Tests/Generation/JsonPropertyAttributeTests.cs
+++ b/src/NJsonSchema.Tests/Generation/JsonPropertyAttributeTests.cs
@@ -20,6 +20,28 @@ namespace NJsonSchema.Tests.Generation
         }
 
         [Fact]
+        public async Task When_name_of_JsonPropertyAttribute_is_set_then_it_is_used_as_json_property_name_even_with_contactresolver_that_has_nameing_strategy()
+        {
+            var settings = new NJsonSchema.Generation.JsonSchemaGeneratorSettings();
+            settings.SerializerSettings = new JsonSerializerSettings
+            {
+                ContractResolver = new Newtonsoft.Json.Serialization.DefaultContractResolver
+                {
+                    NamingStrategy = new Newtonsoft.Json.Serialization.CamelCaseNamingStrategy()
+                }
+            };
+
+            //// Arrange
+            var schema = JsonSchema.FromType<JsonPropertyAttributeTests.MyJsonPropertyTestClass>(settings);
+
+            //// Act
+            var property = schema.Properties["NewName"];
+
+            //// Assert
+            Assert.Equal("NewName", property.Name);
+        }
+
+        [Fact]
         public async Task When_required_is_always_in_JsonPropertyAttribute_then_the_property_is_required()
         {
             //// Arrange

--- a/src/NJsonSchema.Tests/Generation/JsonPropertyAttributeTests.cs
+++ b/src/NJsonSchema.Tests/Generation/JsonPropertyAttributeTests.cs
@@ -42,6 +42,22 @@ namespace NJsonSchema.Tests.Generation
         }
 
         [Fact]
+        public async Task Use_JsonSchemaGeneratorSettings_ContractResolver_For_JsonPropertyName()
+        {
+            var settings = new NJsonSchema.Generation.JsonSchemaGeneratorSettings();
+            settings.ContractResolver = new Newtonsoft.Json.Serialization.CamelCasePropertyNamesContractResolver();
+
+            //// Arrange
+            var schema = JsonSchema.FromType<JsonPropertyAttributeTests.MyJsonPropertyTestClass>(settings);
+
+            //// Act
+            var property = schema.Properties["newName"];
+
+            //// Assert
+            Assert.Equal("newName", property.Name);
+        }
+
+        [Fact]
         public async Task When_required_is_always_in_JsonPropertyAttribute_then_the_property_is_required()
         {
             //// Arrange

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -322,14 +322,7 @@ namespace NJsonSchema.Generation
         {
             try
             {
-                var propertyName = contextualMember?.MemberInfo != null ?
-                    contextualMember.MemberInfo.DeclaringType.GetContextualPropertiesAndFields().First(p => p.Name == contextualMember.Name).GetName() :
-                    jsonProperty.PropertyName;
-
-                var contractResolver = Settings.ActualContractResolver as DefaultContractResolver;
-                return contractResolver != null
-                    ? contractResolver.GetResolvedPropertyName(propertyName)
-                    : propertyName;
+                return jsonProperty.PropertyName;
             }
             catch (Exception e)
             {

--- a/src/NJsonSchema/Generation/JsonSchemaGeneratorSettings.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGeneratorSettings.cs
@@ -257,11 +257,11 @@ namespace NJsonSchema.Generation
             }
             else if (DefaultPropertyNameHandling == PropertyNameHandling.CamelCase)
             {
-                ActualContractResolver = new CamelCasePropertyNamesContractResolver();
+                ActualContractResolver = new DefaultContractResolver { NamingStrategy = new CamelCaseNamingStrategy(false, true) };
             }
             else if (DefaultPropertyNameHandling == PropertyNameHandling.SnakeCase)
             {
-                ActualContractResolver = new DefaultContractResolver { NamingStrategy = new SnakeCaseNamingStrategy() };
+                ActualContractResolver = new DefaultContractResolver { NamingStrategy = new SnakeCaseNamingStrategy(false, true) };
             }
             else
             {


### PR DESCRIPTION
The default behavior for a JsonProperty in Json.NET is to ignore NameingStrategy unless overrideSpecifiedNames is true.

However due to how NJsonSchema used contractResolver.GetResolvedPropertyName the behavior would not match the expected.

Calling ```contractResolver.GetResolvedPropertyName``` would process ```JsonProperty.Name``` that where already correct making them incorrect if overrideSpecifiedNames was false on the NamingStrategy.

If we re-configure ```DefaultPropertyNameHandling == PropertyNameHandling.SnakeCase``` and ```DefaultPropertyNameHandling == PropertyNameHandling.CamelCase``` to overrideSpecifiedNames they act as they use to.

This allows us to use JsonProperty.Name without breaking compatibility.
