### PR TITLE
Fix TypeScript generator generating invalid keys

### DIFF
--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/DictionaryTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/DictionaryTests.cs
@@ -259,5 +259,50 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
                 }
             }
         }
+
+        [Fact]
+        public async Task When_dictionary_has_arbitrary_nonenum_key_then_generated_typescript_uses_plain_string_key()
+        {
+            //// Arrange
+            var json = @"{
+    ""properties"": {
+        ""myDict"": {
+            ""type"": ""object"",
+            ""additionalProperties"": {
+                ""$ref"": ""#/definitions/myItem""
+            }
+        }
+    },
+    ""definitions"": {
+        ""myItem"": {
+            ""type"": ""object"",
+            ""additionalProperties"": false,
+            ""properties"": {
+                ""name"": {
+                    ""type"": ""string""
+                },
+                ""age"": {
+                    ""type"": ""integer""
+                }
+            }
+        }
+    }
+}";
+
+            var schema = await JsonSchema.FromJsonAsync(json);
+
+            //// Act
+            var codeGenerator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings
+            {
+                ConvertConstructorInterfaceData = true,
+                TypeStyle = TypeScriptTypeStyle.Class,
+                TypeScriptVersion = 2.7m
+            });
+
+            var code = codeGenerator.GenerateFile("Test");
+
+            //// Assert
+            Assert.DoesNotContain("[key in keyof typeof Istring]", code);
+        }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
@@ -143,10 +143,9 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                     schema.AdditionalPropertiesSchema?.ActualSchema.Type.HasFlag(JsonObjectType.Object) == true ? "I" : "";
 
                 var valueType = prefix + ResolveDictionaryValueType(schema, "any");
-
                 var defaultType = "string";
-                var resolvedType = ResolveDictionaryKeyType(schema, defaultType);
 
+                var resolvedType = ResolveDictionaryKeyType(schema, defaultType);
                 if (resolvedType != defaultType)
                 {
                     var keyType = Settings.TypeScriptVersion >= 2.1m ? prefix + resolvedType : defaultType;

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
@@ -145,13 +145,20 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                 var valueType = prefix + ResolveDictionaryValueType(schema, "any");
 
                 var defaultType = "string";
-                var keyType = Settings.TypeScriptVersion >= 2.1m ? prefix + ResolveDictionaryKeyType(schema, defaultType) : defaultType;
-                if (keyType != defaultType)
+                var resolvedType = ResolveDictionaryKeyType(schema, defaultType);
+
+                if (resolvedType != defaultType)
                 {
-                    return $"{{ [key in keyof typeof {keyType}]: {valueType}; }}";
+                    var keyType = Settings.TypeScriptVersion >= 2.1m ? prefix + resolvedType : defaultType;
+                    if (keyType != defaultType)
+                    {
+                        return $"{{ [key in keyof typeof {keyType}]: {valueType}; }}";
+                    }
+
+                    return $"{{ [key: {keyType}]: {valueType}; }}";
                 }
 
-                return $"{{ [key: {keyType}]: {valueType}; }}";
+                return $"{{ [key: {resolvedType}]: {valueType}; }}";
             }
 
             return (addInterfacePrefix && !schema.ActualTypeSchema.IsEnumeration && SupportsConstructorConversion(schema) ? "I" : "") +


### PR DESCRIPTION
# Description

When one has a dictionary that has keys of non-string type that are
also not enums, they should be generated as string keys on the
TypeScript side.

The correct type is resolved (`string`) but an interface prefix is added
for some reason, which breaks the generated TypeScript since there is
no type called `Istring`.

This bug seems to have been introduced with commit
543724234ea7fc97e1d81ce7cc9fd2ca76c32fa8
from pull request #755.

This commit should fix issue #898.

# Notes

When running the tests I get two failures, but they seem to be unrelated to the code I have touched. I am also not sure if this is the cleanest solution, so I'm open to suggestions for how to improve it, but it fixes the generation issue.