### PR TITLE
Fixes extensionData being on wrong target

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/NJsonSchema.CodeGeneration.CSharp.csproj
+++ b/src/NJsonSchema.CodeGeneration.CSharp/NJsonSchema.CodeGeneration.CSharp.csproj
@@ -4,7 +4,7 @@
     <Description>JSON Schema reader, generator and validator for .NET</Description>
     <Version>10.1.2</Version>
     <PackageTags>json schema validation generator .net</PackageTags>
-    <Copyright>Copyright © Rico Suter, 2018</Copyright>
+    <Copyright>Copyright © Rico Suter, 2020</Copyright>
     <PackageLicenseUrl>https://github.com/rsuter/NJsonSchema/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageProjectUrl>http://NJsonSchema.org</PackageProjectUrl>
     <SignAssembly>True</SignAssembly>

--- a/src/NJsonSchema.CodeGeneration.TypeScript/NJsonSchema.CodeGeneration.TypeScript.csproj
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/NJsonSchema.CodeGeneration.TypeScript.csproj
@@ -4,7 +4,7 @@
     <Description>JSON Schema reader, generator and validator for .NET</Description>
     <Version>10.1.2</Version>
     <PackageTags>json schema validation generator .net</PackageTags>
-    <Copyright>Copyright © Rico Suter, 2018</Copyright>
+    <Copyright>Copyright © Rico Suter, 2020</Copyright>
     <PackageLicenseUrl>https://github.com/RicoSuter/NJsonSchema/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageProjectUrl>http://NJsonSchema.org</PackageProjectUrl>
     <SignAssembly>True</SignAssembly>

--- a/src/NJsonSchema.CodeGeneration/NJsonSchema.CodeGeneration.csproj
+++ b/src/NJsonSchema.CodeGeneration/NJsonSchema.CodeGeneration.csproj
@@ -4,7 +4,7 @@
     <Description>JSON Schema reader, generator and validator for .NET</Description>
     <Version>10.1.2</Version>
     <PackageTags>json schema validation generator .net</PackageTags>
-    <Copyright>Copyright © Rico Suter, 2018</Copyright>
+    <Copyright>Copyright © Rico Suter, 2020</Copyright>
     <PackageLicenseUrl>https://github.com/rsuter/NJsonSchema/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageProjectUrl>http://NJsonSchema.org</PackageProjectUrl>
     <SignAssembly>True</SignAssembly>

--- a/src/NJsonSchema.Tests/Generation/ExtensionDataGenerationTests.cs
+++ b/src/NJsonSchema.Tests/Generation/ExtensionDataGenerationTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
-using NJsonSchema.Annotations;
 using NJsonSchema.Generation;
 using Xunit;
 
@@ -28,42 +27,6 @@ namespace NJsonSchema.Tests.Generation
             Assert.Equal(1, schema.ActualProperties.Count);
             Assert.True(schema.AllowAdditionalProperties);
             Assert.True(schema.AdditionalPropertiesSchema.ActualSchema.IsAnyType);
-        }
-
-        public class SubData2
-        {
-            public int id { get; set; }
-        }
-
-        public class ClassWithExtensionData2
-        {
-            [JsonSchemaExtensionDataAttribute("x-other", "barfoo")]
-            public string other { get; set; }
-
-            [JsonSchemaExtensionDataAttribute("x-data", "foobar")]
-            public SubData2 data { get; set; }
-        }
-
-        public class ClassWithoutExtensionData2
-        {
-            public string other { get; set; }
-
-            public SubData2 noAttribute { get; set; }
-        }
-
-        public class Wrapper2
-        {
-            public ClassWithoutExtensionData2 noExtensionData { get; set; }
-
-            public ClassWithExtensionData2 hasExtensionData { get; set; }
-        }
-
-        [Fact]
-        public async Task When_class_has_property_with_JsonExtensionDataAttribute_on_property_then_AdditionalProperties_schema_is_set_with_values()
-        {
-            //// Act
-            var schema = JsonSchema.FromType<Wrapper2>(new JsonSchemaGeneratorSettings { SchemaType = SchemaType.OpenApi3 });
-            var json = schema.ToJson();
         }
     }
 }

--- a/src/NJsonSchema.Tests/Generation/ExtensionDataGenerationTests.cs
+++ b/src/NJsonSchema.Tests/Generation/ExtensionDataGenerationTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using NJsonSchema.Annotations;
 using NJsonSchema.Generation;
 using Xunit;
 
@@ -27,6 +28,42 @@ namespace NJsonSchema.Tests.Generation
             Assert.Equal(1, schema.ActualProperties.Count);
             Assert.True(schema.AllowAdditionalProperties);
             Assert.True(schema.AdditionalPropertiesSchema.ActualSchema.IsAnyType);
+        }
+
+        public class SubData2
+        {
+            public int id { get; set; }
+        }
+
+        public class ClassWithExtensionData2
+        {
+            [JsonSchemaExtensionDataAttribute("x-other", "barfoo")]
+            public string other { get; set; }
+
+            [JsonSchemaExtensionDataAttribute("x-data", "foobar")]
+            public SubData2 data { get; set; }
+        }
+
+        public class ClassWithoutExtensionData2
+        {
+            public string other { get; set; }
+
+            public SubData2 noAttribute { get; set; }
+        }
+
+        public class Wrapper2
+        {
+            public ClassWithoutExtensionData2 noExtensionData { get; set; }
+
+            public ClassWithExtensionData2 hasExtensionData { get; set; }
+        }
+
+        [Fact]
+        public async Task When_class_has_property_with_JsonExtensionDataAttribute_on_property_then_AdditionalProperties_schema_is_set_with_values()
+        {
+            //// Act
+            var schema = JsonSchema.FromType<Wrapper2>(new JsonSchemaGeneratorSettings { SchemaType = SchemaType.OpenApi3 });
+            var json = schema.ToJson();
         }
     }
 }

--- a/src/NJsonSchema.Tests/Generation/JsonSchemaExtensionDataAttributeGeneratorTests.cs
+++ b/src/NJsonSchema.Tests/Generation/JsonSchemaExtensionDataAttributeGeneratorTests.cs
@@ -9,7 +9,6 @@ namespace NJsonSchema.Tests.Generation
 {
     public class JsonSchemaExtensionDataAttributeGeneratorTests
     {
-
         public class MyType
         {
             public int Id { get; set; }
@@ -126,15 +125,15 @@ namespace NJsonSchema.Tests.Generation
             Assert.Equal(0, result);
         }
 
-
         [Fact]
         public async Task When_class_has_property_with_JsonSchemaExtensionDataAttribute_on_property_then_extensiondata_is_set_to_property()
         {
             //// Act
-            var schema = JsonSchema.FromType<ClassWithExtensionData>(
-                new JsonSchemaGeneratorSettings {
-                    SchemaType = SchemaType.OpenApi3 
-                });
+            var schema = JsonSchema.FromType<ClassWithExtensionData>(new JsonSchemaGeneratorSettings
+            {
+                SchemaType = SchemaType.OpenApi3
+            });
+
             var json = schema.ToJson();
 
             var expectedJSON = @"{

--- a/src/NJsonSchema.Tests/Generation/JsonSchemaExtensionDataAttributeGeneratorTests.cs
+++ b/src/NJsonSchema.Tests/Generation/JsonSchemaExtensionDataAttributeGeneratorTests.cs
@@ -1,0 +1,180 @@
+﻿using NJsonSchema.Annotations;
+using NJsonSchema.Generation;
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NJsonSchema.Tests.Generation
+{
+    public class JsonSchemaExtensionDataAttributeGeneratorTests
+    {
+
+        public class MyType
+        {
+            public int Id { get; set; }
+        }
+
+        public class ClassWithExtensionData
+        {
+            [JsonSchemaExtensionData("x-other", "barfoo")]
+            public string TextFieldExtension { get; set; }
+
+            [JsonSchemaExtensionData("x-data", "foobar")]
+            public MyType SubDataExtension { get; set; }
+        }
+
+        public class ClassWithoutExtensionData
+        {
+            public string TextFieldNoExtension { get; set; }
+
+            public MyType SubDataNoExtension { get; set; }
+        }
+
+        public class RootType
+        {
+            public ClassWithoutExtensionData Extension { get; set; }
+
+            public ClassWithExtensionData NoExtension { get; set; }
+        }
+
+        [Fact]
+        public async Task When_class_has_property_with_JsonSchemaExtensionDataAttribute_on_property_then_extensiondata_schema_is_set_on_property_level()
+        {
+            //// Act
+            var schema = JsonSchema.FromType<RootType>(new JsonSchemaGeneratorSettings { SchemaType = SchemaType.OpenApi3 });
+            var json = schema.ToJson();
+
+            var expectedJSON = @"{
+              ""$schema"": ""http://json-schema.org/draft-04/schema#"",
+              ""title"": ""RootType"",
+              ""type"": ""object"",
+              ""additionalProperties"": false,
+              ""properties"": {
+                ""Extension"": {
+                  ""x-nullable"": true,
+                  ""oneOf"": [
+                    {
+                      ""$ref"": ""#/definitions/ClassWithoutExtensionData""
+                    }
+                  ]
+                },
+                ""NoExtension"": {
+                  ""x-nullable"": true,
+                  ""oneOf"": [
+                    {
+                      ""$ref"": ""#/definitions/ClassWithExtensionData""
+                    }
+                  ]
+                }
+              },
+              ""definitions"": {
+                ""ClassWithoutExtensionData"": {
+                  ""type"": ""object"",
+                  ""additionalProperties"": false,
+                  ""properties"": {
+                    ""TextFieldNoExtension"": {
+                      ""type"": ""string"",
+                      ""x-nullable"": true
+                    },
+                    ""SubDataNoExtension"": {
+                      ""x-nullable"": true,
+                      ""oneOf"": [
+                        {
+                          ""$ref"": ""#/definitions/MyType""
+                        }
+                      ]
+                    }
+                  }
+                },
+                ""MyType"": {
+                  ""type"": ""object"",
+                  ""additionalProperties"": false,
+                  ""properties"": {
+                    ""Id"": {
+                      ""type"": ""integer"",
+                      ""format"": ""int32""
+                    }
+                  }
+                },
+                ""ClassWithExtensionData"": {
+                  ""type"": ""object"",
+                  ""additionalProperties"": false,
+                  ""properties"": {
+                    ""TextFieldExtension"": {
+                      ""type"": ""string"",
+                      ""x-nullable"": true,
+                      ""x-other"": ""barfoo""
+                    },
+                    ""SubDataExtension"": {
+                      ""x-nullable"": true,
+                      ""oneOf"": [
+                        {
+                          ""$ref"": ""#/definitions/MyType""
+                        }
+                      ],
+                      ""x-data"": ""foobar""
+                    }
+                  }
+                }
+              }
+            }";
+
+            //// Assert generated JSON matches schema, ignores whitespace and spaces
+            var result = String.Compare(json, expectedJSON, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase | CompareOptions.IgnoreSymbols);
+
+            Assert.Equal(0, result);
+        }
+
+
+        [Fact]
+        public async Task When_class_has_property_with_JsonSchemaExtensionDataAttribute_on_property_then_extensiondata_is_set_to_property()
+        {
+            //// Act
+            var schema = JsonSchema.FromType<ClassWithExtensionData>(
+                new JsonSchemaGeneratorSettings {
+                    SchemaType = SchemaType.OpenApi3 
+                });
+            var json = schema.ToJson();
+
+            var expectedJSON = @"{
+                ""$schema"": ""http://json-schema.org/draft-04/schema#"",
+                ""title"": ""ClassWithExtensionData"",
+                ""type"": ""object"",
+                ""additionalProperties"": false,
+                ""properties"": {
+                    ""TextFieldExtension"": {
+                        ""type"": ""string"",
+                        ""x-nullable"": true,
+                        ""x-other"": ""barfoo""
+                    },
+                    ""SubDataExtension"": {
+                        ""x-nullable"": true,
+                        ""oneOf"": [{
+                                ""$ref"": ""#/definitions/MyType""
+                            }
+                        ],
+                        ""x-data"": ""foobar"",
+                    }
+                },
+                ""definitions"": {
+                    ""MyType"": {
+                        ""type"": ""object"",
+                        ""additionalProperties"": false,
+                        ""properties"": {
+                            ""Id"": {
+                                ""type"": ""integer"",
+                                ""format"": ""int32""
+                            }
+                        }
+                    }
+                }
+            }";
+
+            //// Assert generated JSON matches schema, ignores whitespace and spaces
+            var result = String.Compare(json, expectedJSON, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase | CompareOptions.IgnoreSymbols);
+
+            Assert.Equal(0, result);
+        }
+    }
+}

--- a/src/NJsonSchema.Yaml/NJsonSchema.Yaml.csproj
+++ b/src/NJsonSchema.Yaml/NJsonSchema.Yaml.csproj
@@ -4,7 +4,7 @@
     <Description>JSON Schema reader, generator and validator for .NET</Description>
     <Version>10.1.2</Version>
     <PackageTags>json schema validation generator .net</PackageTags>
-    <Copyright>Copyright © Rico Suter, 2018</Copyright>
+    <Copyright>Copyright © Rico Suter, 2020</Copyright>
     <PackageLicenseUrl>https://github.com/rsuter/NJsonSchema/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageProjectUrl>http://NJsonSchema.org</PackageProjectUrl>
     <SignAssembly>True</SignAssembly>

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -273,7 +273,11 @@ namespace NJsonSchema.Generation
                 referencedSchema = Generate<JsonSchema>(typeDescription.ContextualType, schemaResolver);
             }
 
-            var referencingSchema = new TSchemaType();
+            var referencingSchema = new TSchemaType() {
+                ExtensionData = referencedSchema.ExtensionData
+            };
+            referencedSchema.ExtensionData = null;
+
             transformation?.Invoke(referencingSchema, referencedSchema);
 
             if (isNullable)

--- a/src/NJsonSchema/NJsonSchema.csproj
+++ b/src/NJsonSchema/NJsonSchema.csproj
@@ -4,7 +4,7 @@
     <Description>JSON Schema reader, generator and validator for .NET</Description>
     <Version>10.1.2</Version>
     <PackageTags>json schema validation generator .net</PackageTags>
-    <Copyright>Copyright © Rico Suter, 2018</Copyright>
+    <Copyright>Copyright © Rico Suter, 2020</Copyright>
     <PackageLicenseUrl>https://github.com/RicoSuter/NJsonSchema/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageProjectUrl>http://NJsonSchema.org</PackageProjectUrl>
     <SignAssembly>True</SignAssembly>


### PR DESCRIPTION
Resolves Github https://github.com/RicoSuter/NJsonSchema/issues/1112

There is one test case failing:
 `NJsonSchema.CodeGeneration.Tests.Samples.SampleTests.When_JSON_contains_DateTime_is_available_then_JObject_validator_validates_correctly`

This test did not pass before or after my changes.
