### PR TITLE
Make indexer optional for TS dictionaries generated from enum keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ src/packages/Newtonsoft.Json**
 
 **.sln.ide/**
 **.vs/**
+.vscode/
 
 /src/NJsonSchema.sln.GhostDoc.xml
 

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptDictionaryTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptDictionaryTests.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using NJsonSchema.CodeGeneration.TypeScript;
 using Xunit;
 
 namespace NJsonSchema.CodeGeneration.TypeScript.Tests
@@ -54,8 +53,8 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
             var code = generator.GenerateFile("MyClass");
 
             //// Assert
-            Assert.Contains("Mapping: { [key in keyof typeof PropertyName]: string; } | undefined;", code);
-            Assert.Contains("Mapping2: { [key in keyof typeof PropertyName]: string; } | undefined;", code);
+            Assert.Contains("Mapping: { [key in keyof typeof PropertyName]?: string; } | undefined;", code);
+            Assert.Contains("Mapping2: { [key in keyof typeof PropertyName]?: string; } | undefined;", code);
         }
 
         [JsonConverter(typeof(StringEnumConverter))]

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
@@ -151,7 +151,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                     var keyType = Settings.TypeScriptVersion >= 2.1m ? prefix + resolvedType : defaultType;
                     if (keyType != defaultType)
                     {
-                        return $"{{ [key in keyof typeof {keyType}]: {valueType}; }}";
+                        return $"{{ [key in keyof typeof {keyType}]?: {valueType}; }}";
                     }
 
                     return $"{{ [key: {keyType}]: {valueType}; }}";


### PR DESCRIPTION
Previously, an empty dictionary would give a TS error because it expected a value for every enum instance.