### PR TITLE
Allow float to be converted to float instead of double

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
@@ -238,6 +238,11 @@ namespace NJsonSchema.CodeGeneration.CSharp
                 return isNullable ? "decimal?" : "decimal";
             }
 
+            if (schema.Format == JsonFormatStrings.Float)
+            {
+                return isNullable ? "float?" : "float";
+            }
+
             return isNullable ? "double?" : "double";
         }
 

--- a/src/NJsonSchema/Generation/DefaultReflectionService.cs
+++ b/src/NJsonSchema/Generation/DefaultReflectionService.cs
@@ -89,10 +89,14 @@ namespace NJsonSchema.Generation
                 return JsonTypeDescription.Create(contextualType, JsonObjectType.Integer, false, JsonFormatStrings.Long);
             }
 
-            if (type == typeof(double) ||
-                type == typeof(float))
+            if (type == typeof(double))
             {
                 return JsonTypeDescription.Create(contextualType, JsonObjectType.Number, false, JsonFormatStrings.Double);
+            }
+
+            if (type == typeof(float))
+            {
+                return JsonTypeDescription.Create(contextualType, JsonObjectType.Number, false, JsonFormatStrings.Float);
             }
 
             if (type == typeof(decimal))


### PR DESCRIPTION
This PR fixes [#1122](https://github.com/RicoSuter/NSwag/issues/1122).

If `format` is specified as `float`, the corresponding type in generated C# code will be `float` instead of `double`. I basically just did what @RicoSuter suggested in [this comment](https://github.com/RicoSuter/NSwag/issues/1122#issuecomment-418359039).

Tests in NJsonSchema as well as NSwag executed locally are all passing.