### PR TITLE
Support DataContract private fields and properties

### DIFF
--- a/src/NJsonSchema.Tests/Generation/PrivateFieldTests.cs
+++ b/src/NJsonSchema.Tests/Generation/PrivateFieldTests.cs
@@ -1,0 +1,37 @@
+using System.Threading.Tasks;
+using System.Runtime.Serialization;
+using NJsonSchema.Generation;
+using Xunit;
+
+namespace NJsonSchema.Tests.Generation
+{
+  public class PrivateFieldTests
+  {
+    [DataContract]
+    public class ClassWithPrivateField
+    {
+      [DataMember]
+      private int FooField;
+
+      [DataMember]
+      private int FooProp { get; set; }
+
+      public int Get() => FooField + FooProp; // to avoid not-used warning
+    }
+
+    [Fact]
+    public async Task When_property_or_field_is_private_then_schema_still_creates_properties()
+    {
+      //// Act
+      var schema = JsonSchema.FromType<ClassWithPrivateField>(new JsonSchemaGeneratorSettings { SchemaType = SchemaType.OpenApi3 });
+      var json = schema.ToJson();
+
+      //// Assert
+      Assert.Equal(2, schema.ActualProperties.Count);
+      var field = schema.ActualProperties["FooField"].ActualTypeSchema;
+      Assert.Equal(JsonObjectType.Integer, field.Type);
+      var prop = schema.ActualProperties["FooProp"].ActualTypeSchema;
+      Assert.Equal(JsonObjectType.Integer, prop.Type);
+    }
+  }
+}


### PR DESCRIPTION
I am attempting to update from NSwag 12 to 13 and a bunch of my objects lost most of there fields during the update. I eventually tracked it down to NSwag 13 ignoring private fields declared as DataMember.

In f7f530c54f7b8970104fcba21156d02518885057 a fix was put in to
fix a crash when a property or field did not have MemberInfo.
Unfortunately, this also filtered out private fields and properties
since the check only searched the public fields.  This commit
re-allows private properties and fields by searching the entire
type when looking for a MemberInfo for a property.