### PR TITLE
Typescript: Add setting property EnumStyle with options (Enum, StringLiteral).

### DIFF
--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptDictionaryTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptDictionaryTests.cs
@@ -53,8 +53,32 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
             var code = generator.GenerateFile("MyClass");
 
             //// Assert
+            Assert.Contains("export enum PropertyName {\n    Name = 0,\n    Gender = 1,\n}", code);
             Assert.Contains("Mapping: { [key in keyof typeof PropertyName]?: string; } | undefined;", code);
             Assert.Contains("Mapping2: { [key in keyof typeof PropertyName]?: string; } | undefined;", code);
+        }
+        
+        [Fact]
+        public async Task When_dictionary_key_is_string_literal_then_typescript_has_string_literal_key_ts_2_1()
+        {
+            //// Arrange
+            var schema = JsonSchema.FromType<EnumKeyDictionaryTest>();
+            var data = schema.ToJson();
+
+            //// Act
+            var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings
+            {
+                TypeStyle = TypeScriptTypeStyle.Interface,
+                EnumNameGenerator = new DefaultEnumNameGenerator(),
+                EnumStyle = TypeScriptEnumStyle.StringLiteral, 
+                TypeScriptVersion = 2.1m,
+            });
+            var code = generator.GenerateFile("MyClass");
+
+            //// Assert
+            Assert.Contains("export type PropertyName = 0 | 1;", code);
+            Assert.Contains("Mapping: { [key in PropertyName]?: string; } | undefined;", code);
+            Assert.Contains("Mapping2: { [key in PropertyName]?: string; } | undefined;", code);
         }
 
         [JsonConverter(typeof(StringEnumConverter))]

--- a/src/NJsonSchema.CodeGeneration.TypeScript/NJsonSchema.CodeGeneration.TypeScript.csproj
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/NJsonSchema.CodeGeneration.TypeScript.csproj
@@ -25,6 +25,7 @@
     <EmbeddedResource Include="Templates\ConvertToClass.liquid" />
     <EmbeddedResource Include="Templates\ConvertToJavaScript.liquid" />
     <EmbeddedResource Include="Templates\Enum.liquid" />
+    <EmbeddedResource Include="Templates\Enum.StringLiteral.liquid" />
     <EmbeddedResource Include="Templates\File.FormatDate.liquid" />
     <EmbeddedResource Include="Templates\File.liquid" />
     <EmbeddedResource Include="Templates\Interface.liquid" />

--- a/src/NJsonSchema.CodeGeneration.TypeScript/Templates/Enum.StringLiteral.liquid
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Templates/Enum.StringLiteral.liquid
@@ -1,0 +1,4 @@
+﻿{% if HasDescription -%}
+/** {{ Description }} */
+{% endif -%}
+{% if ExportTypes %}export {% endif %}type {{ Name }} = {% for enumeration in Enums -%}{% if Enums.first.Value != enumeration.Value %} | {% endif %}{{ enumeration.Value }}{% endfor -%};

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptEnumStyle.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptEnumStyle.cs
@@ -1,0 +1,19 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="CSharpGeneratorSettings.cs" company="NJsonSchema">
+//     Copyright (c) Rico Suter. All rights reserved.
+// </copyright>
+// <license>https://github.com/RicoSuter/NJsonSchema/blob/master/LICENSE.md</license>
+//-----------------------------------------------------------------------
+
+namespace NJsonSchema.CodeGeneration.TypeScript
+{
+    /// <summary>The TypeScript enum styles.</summary>
+    public enum TypeScriptEnumStyle
+    {
+        /// <summary>Generates enum.</summary>
+        Enum,
+
+        /// <summary>Generates enum as a string literal.</summary>
+        StringLiteral,
+    }
+}

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptGenerator.cs
@@ -129,7 +129,22 @@ namespace NJsonSchema.CodeGeneration.TypeScript
             if (schema.IsEnumeration)
             {
                 var model = new EnumTemplateModel(typeName, schema, Settings);
-                var template = Settings.TemplateFactory.CreateTemplate("TypeScript", "Enum", model);
+
+                string templateName;
+                if (Settings.EnumStyle == TypeScriptEnumStyle.Enum)
+                {
+                    templateName = nameof(TypeScriptEnumStyle.Enum);
+                }
+                else if (Settings.EnumStyle == TypeScriptEnumStyle.StringLiteral)
+                {
+                    templateName = $"{nameof(TypeScriptEnumStyle.Enum)}.{nameof(TypeScriptEnumStyle.StringLiteral)}";
+                }
+                else
+                {
+                    throw new ArgumentOutOfRangeException(nameof(Settings.EnumStyle), Settings.EnumStyle, "Unknown enum style");
+                }
+
+                var template = Settings.TemplateFactory.CreateTemplate("TypeScript", templateName, model);
                 return new CodeArtifact(typeName, CodeArtifactType.Enum, CodeArtifactLanguage.TypeScript, CodeArtifactCategory.Contract, template);
             }
             else

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptGeneratorSettings.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptGeneratorSettings.cs
@@ -23,6 +23,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
             NullValue = TypeScriptNullValue.Undefined;
             TypeStyle = TypeScriptTypeStyle.Class;
             DateTimeType = TypeScriptDateTimeType.Date;
+            EnumStyle = TypeScriptEnumStyle.Enum;
             ExtensionCode = string.Empty;
             TypeScriptVersion = 2.7m;
             GenerateConstructorInterface = true;
@@ -56,6 +57,9 @@ namespace NJsonSchema.CodeGeneration.TypeScript
 
         /// <summary>Gets or sets the date time type (default: 'Date').</summary>
         public TypeScriptDateTimeType DateTimeType { get; set; }
+        
+        /// <summary>Gets or sets the enum style (default: Enum).</summary>
+        public TypeScriptEnumStyle EnumStyle { get; set; }
 
         /// <summary>Gets or sets the TypeScript module name (default: '', no module).</summary>
         public string ModuleName { get; set; }

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
@@ -149,9 +149,19 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                 if (resolvedType != defaultType)
                 {
                     var keyType = Settings.TypeScriptVersion >= 2.1m ? prefix + resolvedType : defaultType;
-                    if (keyType != defaultType)
+                    if (keyType != defaultType && schema.DictionaryKey.ActualTypeSchema.IsEnumeration)
                     {
-                        return $"{{ [key in keyof typeof {keyType}]?: {valueType}; }}";
+                        if (Settings.EnumStyle == TypeScriptEnumStyle.Enum)
+                        {
+                            return $"{{ [key in keyof typeof {keyType}]?: {valueType}; }}";
+                        }
+
+                        if (Settings.EnumStyle == TypeScriptEnumStyle.StringLiteral)
+                        {
+                            return $"{{ [key in {keyType}]?: {valueType}; }}";
+                        }
+                        
+                        throw new ArgumentOutOfRangeException(nameof(Settings.EnumStyle), Settings.EnumStyle, "Unknown enum style");
                     }
 
                     return $"{{ [key: {keyType}]: {valueType}; }}";

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
@@ -155,8 +155,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                         {
                             return $"{{ [key in keyof typeof {keyType}]?: {valueType}; }}";
                         }
-
-                        if (Settings.EnumStyle == TypeScriptEnumStyle.StringLiteral)
+                        else if (Settings.EnumStyle == TypeScriptEnumStyle.StringLiteral)
                         {
                             return $"{{ [key in {keyType}]?: {valueType}; }}";
                         }


### PR DESCRIPTION
This PR adds support for union string literal types instead of enums. It resolves issue https://github.com/RicoSuter/NSwag/issues/1188