### PR TITLE
Support for multilingual DisplayAttribute

### DIFF
--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -351,10 +351,29 @@ namespace NJsonSchema.Generation
             var contextualType = typeDescription.ContextualType;
 
             dynamic displayAttribute = contextualType.ContextAttributes.FirstAssignableToTypeNameOrDefault("System.ComponentModel.DataAnnotations.DisplayAttribute");
+#if NETSTANDARD10
             if (displayAttribute != null && displayAttribute.Name != null)
             {
                 schema.Title = displayAttribute.Name;
             }
+#else
+            if (displayAttribute != null && displayAttribute.Name != null && displayAttribute.ResourceType == null)
+            {
+                schema.Title = displayAttribute.Name;
+            }
+
+            else if (displayAttribute != null && displayAttribute.Name != null && displayAttribute.ResourceType != null)
+            {
+                schema.Title = displayAttribute.ResourceType
+                    .GetProperty(displayAttribute.Name,
+                    BindingFlags.NonPublic |
+                    BindingFlags.Instance |
+                    BindingFlags.Static |
+                    BindingFlags.Public
+                    ).GetValue(null);
+
+            }
+#endif
 
             dynamic defaultValueAttribute = contextualType.ContextAttributes.FirstAssignableToTypeNameOrDefault("System.ComponentModel.DefaultValueAttribute");
             if (defaultValueAttribute != null)

--- a/src/NJsonSchema/NJsonSchema.csproj
+++ b/src/NJsonSchema/NJsonSchema.csproj
@@ -20,6 +20,9 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'net40'">
     <DefineConstants>LEGACY</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.0'">
+      <DefineConstants>NETSTANDARD10</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>


### PR DESCRIPTION
I needed NJsonSchema in a multilingual project, where each language was added in .resx files. NJsonSchema didn't respect ResourceType argument in DisplayAttribute. So I added support for this scenario. Also it doesn't matter if the resource class has internal or public accessory.
Since Net standard 1.0 doesn't have BindingFlags, I kept the past behavior if target framework is Net standard 1.0