### PR TITLE
Fix Iany

### DIFF
--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
@@ -142,9 +142,13 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                     SupportsConstructorConversion(schema.AdditionalPropertiesSchema) &&
                     schema.AdditionalPropertiesSchema?.ActualSchema.Type.HasFlag(JsonObjectType.Object) == true ? "I" : "";
 
-                var valueType = prefix + ResolveDictionaryValueType(schema, "any");
-                var defaultType = "string";
+                var valueType = ResolveDictionaryValueType(schema, "any");
+                if (valueType != "any")
+                {
+                    valueType = prefix + valueType;
+                }
 
+                var defaultType = "string";
                 var resolvedType = ResolveDictionaryKeyType(schema, defaultType);
                 if (resolvedType != defaultType)
                 {


### PR DESCRIPTION
This fixes an Iany being generated which is not valid typescript code. It simply checks if the value is not "any" and only then does it add the prefix.

#898

Before:
extensions?: { [key: string]: Iany; } | null;

After:
extensions?: { [key: string]: any; } | null;