### PR TITLE
Implement TypeScriptGeneratorSettings.UseLeafType

### DIFF
--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptDiscriminatorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptDiscriminatorTests.cs
@@ -1,0 +1,62 @@
+﻿using System.Threading.Tasks;
+using Newtonsoft.Json;
+using NJsonSchema.Converters;
+using System.Runtime.Serialization;
+using Xunit;
+
+namespace NJsonSchema.CodeGeneration.TypeScript.Tests
+{
+    public class TypeScriptDiscriminatorTests
+    {
+        [JsonConverter(typeof(JsonInheritanceConverter), "type")]
+        [KnownType(typeof(OneChild))]
+        [KnownType(typeof(SecondChild))]
+        public abstract class Base
+        {
+            public EBase Type { get; }
+        }
+
+        public enum EBase
+        {
+            OneChild,
+            SecondChild
+        }
+
+        public class OneChild : Base
+        {
+            public string A { get; }
+        }
+
+        public class SecondChild : Base
+        {
+            public string B { get; }
+        }
+
+        public class Nested
+        {
+            public Base Child { get; set; }
+        }
+
+        [Fact]
+        public async Task When_parameter_is_abstract_then_generate_union()
+        {
+            //// Arrange
+            var schema = JsonSchema.FromType<Nested>();
+            var data = schema.ToJson();
+
+            //// Act
+            var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings
+            {
+                UseLeafType = true,
+                TypeStyle = TypeScriptTypeStyle.Interface,
+                TypeScriptVersion = 1.8m
+            });
+            var code = generator.GenerateFile("MyClass");
+
+            //// Assert
+            Assert.Contains("export interface OneChild extends Base", code);
+            Assert.Contains("export interface SecondChild extends Base", code);
+            Assert.Contains("Child: OneChild | SecondChild;", code);
+        }
+    }
+}

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptGeneratorSettings.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptGeneratorSettings.cs
@@ -24,6 +24,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
             TypeStyle = TypeScriptTypeStyle.Class;
             DateTimeType = TypeScriptDateTimeType.Date;
             EnumStyle = TypeScriptEnumStyle.Enum;
+            UseLeafType = false;
             ExtensionCode = string.Empty;
             TypeScriptVersion = 2.7m;
             GenerateConstructorInterface = true;
@@ -60,6 +61,9 @@ namespace NJsonSchema.CodeGeneration.TypeScript
         
         /// <summary>Gets or sets the enum style (default: Enum).</summary>
         public TypeScriptEnumStyle EnumStyle { get; set; }
+
+        /// <summary>Generate leaf types for an object with discriminator.</summary>
+        public bool UseLeafType { get; set; }
 
         /// <summary>Gets or sets the TypeScript module name (default: '', no module).</summary>
         public string ModuleName { get; set; }

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
@@ -169,15 +169,13 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                 return $"{{ [key: {resolvedType}]: {valueType}; }}";
             }
 
-            if (
-                Settings.UseLeafType
-                && schema.DiscriminatorObject == null
-                && schema.ActualTypeSchema.DiscriminatorObject != null
-            )
+            if (Settings.UseLeafType &&
+                schema.DiscriminatorObject == null &&
+                schema.ActualTypeSchema.DiscriminatorObject != null)
             {
                 var types = schema.ActualTypeSchema.ActualDiscriminatorObject.Mapping
-                    .Select(x => Resolve(
-                        x.Value,
+                    .Select(m => Resolve(
+                        m.Value,
                         typeNameHint,
                         addInterfacePrefix
                     ));

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
@@ -169,6 +169,22 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                 return $"{{ [key: {resolvedType}]: {valueType}; }}";
             }
 
+            if (
+                Settings.UseLeafType
+                && schema.DiscriminatorObject == null
+                && schema.ActualTypeSchema.DiscriminatorObject != null
+            )
+            {
+                var types = schema.ActualTypeSchema.ActualDiscriminatorObject.Mapping
+                    .Select(x => Resolve(
+                        x.Value,
+                        typeNameHint,
+                        addInterfacePrefix
+                    ));
+
+                return string.Join(" | ", types);
+            }
+
             return (addInterfacePrefix && !schema.ActualTypeSchema.IsEnumeration && SupportsConstructorConversion(schema) ? "I" : "") +
                 GetOrGenerateTypeName(schema, typeNameHint);
         }


### PR DESCRIPTION
Hi,
we are using `JsonInheritanceConverter` on abstract classes. So NSwag knows about leaf types. Our Front-end developers complain, that Typescript produce warnings (we are using `TypeStyle = TypeScriptTypeStyle.Interface`) that object contains unknown properties for the base type.

This PR solves it. It allows generating leaf types as a union type for properties.

For following DTO:
```cs
public abstract class Base {}
public class OneChild : Base {}
public class SecondChild : Base {}
public class Nested {
  public Base Child { get; set; }
}
```

It generates:
```ts
export interface Base {}
export interface OneChild extends Base {}
export interface SecondChild extends Base {}
export interface Nested {
  Child: OneChild | SecondChild;
}
```

Instead of:
```ts
export interface Nested {
  Child: Base;
}
```