### PR TITLE
Remove the exclamation mark to find embedded templates

### DIFF
--- a/src/NJsonSchema.CodeGeneration/DefaultTemplateFactory.cs
+++ b/src/NJsonSchema.CodeGeneration/DefaultTemplateFactory.cs
@@ -74,6 +74,7 @@ namespace NJsonSchema.CodeGeneration
         /// <exception cref="InvalidOperationException">Could not load template.</exception>
         protected virtual string GetEmbeddedLiquidTemplate(string language, string template)
         {
+            template = template.TrimEnd('!');
             var assembly = GetLiquidAssembly("NJsonSchema.CodeGeneration." + language);
             var resourceName = "NJsonSchema.CodeGeneration." + language + ".Templates." + template + ".liquid";
 


### PR DESCRIPTION
Hi @RicoSuter 

Last month I created a PR in NSWag to extend controller templates: https://github.com/RicoSuter/NSwag/pull/2691
But you told me I could use '{% template%}' instead to overwrite a template. 
-> However, this didn't work and you said it was probably a bug.

After some debugging, I found out that the exclamation mark used internally to overwrite templates is not removed when looking for the embedded template.

This pull request removes the exclamation mark at the end of the template name. 

I will also create a pull request for NSwag.
+  With this PR the following issue can also be closed:
https://github.com/RicoSuter/NJsonSchema/issues/1133