### PR TITLE
Generate enum "StringLiterals" as name implies

### DIFF
--- a/src/NJsonSchema.CodeGeneration.TypeScript/Templates/Enum.StringLiteral.liquid
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Templates/Enum.StringLiteral.liquid
@@ -1,4 +1,6 @@
-﻿{% if HasDescription -%}
+{% if HasDescription -%}
 /** {{ Description }} */
 {% endif -%}
-{% if ExportTypes %}export {% endif %}type {{ Name }} = {% for enumeration in Enums -%}{% if Enums.first.Value != enumeration.Value %} | {% endif %}{{ enumeration.Value }}{% endfor -%};
+{% if ExportTypes %}export {% endif %}type {{ Name }} =
+      {% for enumeration in Enums -%}{% if Enums.first.Value != enumeration.Value %} 
+    | {% endif %}"{{ enumeration.Name }}"{% endfor -%};


### PR DESCRIPTION
For the given enum

```C#
    public enum AccountType
    {
        User,
        Moderator,
        Administrator
    }
```

Rather than generating

```ts
export type AccountType = 0 | 1 | 2;
```

Which is not very useful, generate 

```ts
export type AccountType =
      "User" 
    | "Moderator" 
    | "Administrator";
```

Note this would be a breaking change to anyone who regenerates their model, but I can't actually see the use for this feature as it exists today.