### PR TITLE
Fix ToSampleJson issues for Array

### DIFF
--- a/src/NJsonSchema/Generation/SampleJsonDataGenerator.cs
+++ b/src/NJsonSchema/Generation/SampleJsonDataGenerator.cs
@@ -50,7 +50,6 @@ namespace NJsonSchema.Generation
                 {
                     var array = new JArray();
                     array.Add(Generate(schema.Item, usedSchemas));
-                    array.Add(Generate(schema.Item, usedSchemas));
                     return array;
                 }
                 else if (schema.Items.Count > 0)
@@ -73,7 +72,7 @@ namespace NJsonSchema.Generation
                 {
                     return JToken.FromObject(schema.Enumeration.First());
                 }
-                else if (schema.Type.HasFlag(JsonObjectType.Integer))
+                else if (schema.Type.HasFlag(JsonObjectType.Integer) || schema.Type.HasFlag(JsonObjectType.Number))
                 {
                     return JToken.FromObject(0);
                 }
@@ -87,9 +86,13 @@ namespace NJsonSchema.Generation
                     {
                         return JToken.FromObject(DateTimeOffset.UtcNow.ToString("o"));
                     }
-                    else
+                    else if (property != null)
                     {
                         return JToken.FromObject(property.Name);
+                    }
+                    else
+                    {
+                        return JToken.FromObject("");
                     }
                 }
                 else if (schema.Type.HasFlag(JsonObjectType.Boolean))


### PR DESCRIPTION
Current ToSampleJson will throw an null reference exception when invoke the ToSampleJson on an  array schema like below:
`{
  "type": "array",
  "items": [
    {
      "type": "number"
    },
    {
      "type": "string"
    },
    {
      "type": "string",
      "enum": ["Street", "Avenue", "Boulevard"]
    },
    {
      "type": "string",
      "enum": ["NW", "NE", "SW", "SE"]
    }
  ]
}`

Besides, ToSampleJson will also insert a null item for array.

This PR just fix above issues.