### PR TITLE
Fix index out of range error on convert to camel case methods

### DIFF
--- a/src/NJsonSchema/ConversionUtilities.cs
+++ b/src/NJsonSchema/ConversionUtilities.cs
@@ -26,7 +26,7 @@ namespace NJsonSchema
                 return string.Empty;
             }
 
-            input = ConvertDashesToCamelCase((input[0].ToString().ToLowerInvariant() + input.Substring(1))
+            input = ConvertDashesToCamelCase((input[0].ToString().ToLowerInvariant() + (input.Length > 1 ? input.Substring(1) : ""))
                 .Replace(" ", "_")
                 .Replace("/", "_"));
 
@@ -54,7 +54,7 @@ namespace NJsonSchema
                 return string.Empty;
             }
 
-            input = ConvertDashesToCamelCase((input[0].ToString().ToUpperInvariant() + input.Substring(1))
+            input = ConvertDashesToCamelCase((input[0].ToString().ToUpperInvariant() + (input.Length > 1 ? input.Substring(1) : ""))
                 .Replace(" ", "_")
                 .Replace("/", "_"));
 


### PR DESCRIPTION
When passing a string of length 1 to the camel case methods, it was throwing an index out of range exception. This PR is to fix that issue: #1181 