### PR TITLE
Ensure nullable marker isn't on enum default value

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/NullableEnumTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/NullableEnumTests.cs
@@ -40,5 +40,44 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             //// Assert
             Assert.Contains(@"public Sex? Sex", code);
         }
+
+        [Fact]
+        public async Task When_Swagger2_enum_property_is_not_required_and_has_default_then_it_is_nullable_with_default_value()
+        {
+            //// Arrange
+            var json =
+            @"{
+    ""type"": ""object"",
+    ""required"": [
+        ""name"",
+        ""photoUrls""
+    ],
+    ""properties"": {
+        ""status"": {
+            ""type"": ""string"",
+            ""description"": ""pet status in the store"",
+            ""default"": ""available"",
+            ""enum"": [
+                ""available"",
+                ""pending"",
+                ""sold""
+            ]
+        }
+    }
+}";
+            var schema = await JsonSchema.FromJsonAsync(json);
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings
+            {
+                SchemaType = SchemaType.Swagger2,
+                GenerateDefaultValues = true,
+                GenerateOptionalPropertiesAsNullable = true
+            });
+
+            //// Act
+            var code = generator.GenerateFile("MyClass");
+
+            //// Assert
+            Assert.Contains("public MyClassStatus? Status { get; set; } = MyNamespace.MyClassStatus.Available;", code);
+        }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
@@ -70,7 +70,8 @@ namespace NJsonSchema.CodeGeneration.CSharp
             // Primitive schemas (no new type)
             if (Settings.GenerateOptionalPropertiesAsNullable &&
                 schema is JsonSchemaProperty property &&
-                !property.IsRequired)
+                !property.IsRequired &&
+                !schema.IsEnumeration)
             {
                 isNullable = true;
             }

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
@@ -70,8 +70,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
             // Primitive schemas (no new type)
             if (Settings.GenerateOptionalPropertiesAsNullable &&
                 schema is JsonSchemaProperty property &&
-                !property.IsRequired &&
-                !schema.IsEnumeration)
+                !property.IsRequired)
             {
                 isNullable = true;
             }

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpValueGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpValueGenerator.cs
@@ -117,7 +117,13 @@ namespace NJsonSchema.CodeGeneration.CSharp
         /// <returns>The enum default value.</returns>
         protected override string GetEnumDefaultValue(JsonSchema schema, JsonSchema actualSchema, string typeNameHint, TypeResolverBase typeResolver)
         {
-            return _settings.Namespace + "." + base.GetEnumDefaultValue(schema, actualSchema, typeNameHint, typeResolver);
+            var defaultValue = base.GetEnumDefaultValue(schema, actualSchema, typeNameHint, typeResolver);
+            return _settings.Namespace + "." + RemoveNullabilityFromDefaultEnumTypeIfPresent(defaultValue);
+        }
+
+        private string RemoveNullabilityFromDefaultEnumTypeIfPresent(string defaultValue)
+        {
+          return defaultValue.Replace("?", string.Empty);
         }
     }
 }


### PR DESCRIPTION
Hey, thanks for maintaining such a great repo + toolset here! 

I'm hoping to address #1141. I'm not entirely certain this is the best way to approach fixing what's happening here, effectively this condition was previously overriding the intentionally set `isNullable = false` in `ValueGeneratorBase.GetEnumDefaultValue`. There doesn't seem to be a ton of testing around `GenerateOptionalPropertiesAsNullable` so I'm not particularly confident in this change, but I can try to add more to establish expected behavior here. 

Optimally, it'd be nice if the type resolution knew if it was being used to resolve a type for a property type or for the value of a property - is there anything on the `JsonSchema` classes that'd indicate that? If not, another possible way to make this happen might be to make `CSharpValueGenerator.GetEnumDefaultValue` more explicit in removing possible nullability (though I don't want to encroach too much on what seems to be the responsibility of the TypeResolver classes).

Please let me know how y'all would like to proceed, I was mainly hoping to call attention to this issue since it came up recently for us.