### PR TITLE
Improved generated code with GenerateNullableReferenceTypes

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpGenerator.cs
@@ -86,7 +86,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
             var model = new FileTemplateModel
             {
                 Namespace = Settings.Namespace ?? string.Empty,
-                GenerateNullReferenceTypes = Settings.GenerateNullableReferenceTypes,
+                GenerateNullableReferenceTypes = Settings.GenerateNullableReferenceTypes,
                 TypesCode = artifactCollection.Concatenate()
             };
 

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpGenerator.cs
@@ -86,6 +86,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
             var model = new FileTemplateModel
             {
                 Namespace = Settings.Namespace ?? string.Empty,
+                GenerateNullReferenceTypes = Settings.GenerateNullableReferenceTypes,
                 TypesCode = artifactCollection.Concatenate()
             };
 

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/ClassTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/ClassTemplateModel.cs
@@ -56,6 +56,9 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
         /// <summary>Gets the namespace.</summary>
         public string Namespace => _settings.Namespace;
 
+        /// <summary>Gets a value indicating whether the C#8 nullable reference types are enabled for this file.</summary>
+        public bool GenerateNullableReferenceTypes => _settings.GenerateNullableReferenceTypes;
+
         /// <summary>Gets a value indicating whether an additional properties type is available.</summary>
         public bool HasAdditionalPropertiesType =>
             !_schema.IsDictionary &&

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/FileTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/FileTemplateModel.cs
@@ -14,6 +14,9 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
         /// <summary>Gets or sets the namespace.</summary>
         public string Namespace { get; set; }
 
+        /// <summary>Gets or sets a value indicating whether the C#8 nullable reference types are enabled for this file.</summary>
+        public bool GenerateNullReferenceTypes { get; set; }
+
         /// <summary>Gets or sets the types code.</summary>
         public string TypesCode { get; set; }
     }

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/FileTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/FileTemplateModel.cs
@@ -15,7 +15,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
         public string Namespace { get; set; }
 
         /// <summary>Gets or sets a value indicating whether the C#8 nullable reference types are enabled for this file.</summary>
-        public bool GenerateNullReferenceTypes { get; set; }
+        public bool GenerateNullableReferenceTypes { get; set; }
 
         /// <summary>Gets or sets the types code.</summary>
         public string TypesCode { get; set; }

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
@@ -24,7 +24,7 @@
 {% endif -%}
 {% if RenderInpc or RenderPrism -%}
 {% for property in Properties -%}
-    private {{ property.Type }} {{ property.FieldName }}{% if property.HasDefaultValue %} = {{ property.DefaultValue }}{% endif -%};
+    private {{ property.Type }} {{ property.FieldName }}{% if property.HasDefaultValue %} = {{ property.DefaultValue }}{% elsif GenerateNullableReferenceTypes -%} = default!{% endif -%};
 {% endfor -%}
 
 {% endif -%}
@@ -63,7 +63,7 @@
     [Newtonsoft.Json.JsonConverter(typeof(DateFormatConverter))]
 {%   endif -%}
     {% template Class.Property.Annotations %}
-    public {{ property.Type }} {{ property.PropertyName }}{% if RenderInpc == false and RenderPrism == false %} { get; {% if property.HasSetter and RenderRecord == false %}set; {% endif %}}{% if property.HasDefaultValue and RenderRecord == false %} = {{ property.DefaultValue }};{% endif %}
+    public {{ property.Type }} {{ property.PropertyName }}{% if RenderInpc == false and RenderPrism == false %} { get; {% if property.HasSetter and RenderRecord == false %}set; {% endif %}}{% if property.HasDefaultValue and RenderRecord == false %} = {{ property.DefaultValue }};{% elsif GenerateNullableReferenceTypes and RenderRecord == false -%} = default!;{% endif %}
 {% else %}
     {
         get { return {{ property.FieldName }}; }

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/File.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/File.liquid
@@ -4,7 +4,7 @@
 // </auto-generated>
 //----------------------
 
-{% if GenerateNullReferenceTypes -%}
+{% if GenerateNullableReferenceTypes -%}
 #nullable enable
 
 {% endif -%}

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/File.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/File.liquid
@@ -4,6 +4,10 @@
 // </auto-generated>
 //----------------------
 
+{% if GenerateNullReferenceTypes -%}
+#nullable enable
+
+{% endif -%}
 namespace {{ Namespace }}
 {
     #pragma warning disable // Disable all warnings


### PR DESCRIPTION
Added a `#nullable enable` directive in generated C# source only if `GenerateNullableReferenceTypes` is set to `true`.

Forced properties without a default value to `default(T)!`. This does not change the existing behavior, but there is no warning if the user forgets to set the property.

Fixes #1195
