### PR TITLE
Deprecation improvements

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/ObsoleteTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/ObsoleteTests.cs
@@ -15,7 +15,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
         public class ObsoletePropertyWithMessageTestClass
         {
-            [Obsolete("Reason property is obsolete")]
+            [Obsolete("Reason property is \"obsolete\"")]
             public string Property { get; set; }
         }
 
@@ -25,7 +25,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             public string Property { get; set; }
         }
 
-        [Obsolete("Reason class is obsolete")]
+        [Obsolete(@"Reason class is ""obsolete""")]
         public class ObsoleteWithMessageTestClass
         {
             public string Property { get; set; }
@@ -57,7 +57,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             var code = generator.GenerateFile();
 
             //// Assert
-            Assert.Contains("[System.Obsolete(\"Reason property is obsolete\")]", code);
+            Assert.Contains("[System.Obsolete(\"Reason property is \\\"obsolete\\\"\")]", code);
             Assert.Contains("public string Property { get; set; }", code);
         }
 
@@ -91,7 +91,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             var code = generator.GenerateFile();
 
             //// Assert
-            Assert.Contains("[System.Obsolete(\"Reason class is obsolete\")]", code);
+            Assert.Contains("[System.Obsolete(\"Reason class is \\\"obsolete\\\"\")]", code);
             Assert.Contains("public partial class ObsoleteWithMessageTestClass", code);
         }
     }

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/ObsoleteTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/ObsoleteTests.cs
@@ -91,7 +91,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             var code = generator.GenerateFile();
 
             //// Assert
-            Assert.Contains("[System.Obsolete(\"Reason property is obsolete\")]", code);
+            Assert.Contains("[System.Obsolete(\"Reason class is obsolete\")]", code);
             Assert.Contains("public partial class ObsoleteWithMessageTestClass", code);
         }
     }

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/ObsoleteTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/ObsoleteTests.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Threading.Tasks;
+using NJsonSchema.CodeGeneration.CSharp;
+using Xunit;
+
+namespace NJsonSchema.CodeGeneration.Tests.CSharp
+{
+    public class ObsoleteTests
+    {
+        public class ObsoletePropertyTestClass
+        {
+            [Obsolete]
+            public string Property { get; set; }
+        }
+
+        public class ObsoletePropertyWithMessageTestClass
+        {
+            [Obsolete("Reason property is obsolete")]
+            public string Property { get; set; }
+        }
+
+        [Obsolete]
+        public class ObsoleteTestClass
+        {
+            public string Property { get; set; }
+        }
+
+        [Obsolete("Reason class is obsolete")]
+        public class ObsoleteWithMessageTestClass
+        {
+            public string Property { get; set; }
+        }
+
+        [Fact]
+        public async Task When_property_is_obsolete_then_obsolete_attribute_is_rendered()
+        {
+            //// Arrange
+            var schema = JsonSchema.FromType<ObsoletePropertyTestClass>();
+            var generator = new CSharpGenerator(schema);
+
+            //// Act
+            var code = generator.GenerateFile();
+
+            //// Assert
+            Assert.Contains("[System.Obsolete]", code);
+            Assert.Contains("public string Property { get; set; }", code);
+        }
+
+        [Fact]
+        public async Task When_property_is_obsolete_with_a_message_then_obsolete_attribute_with_a_message_is_rendered()
+        {
+            //// Arrange
+            var schema = JsonSchema.FromType<ObsoletePropertyWithMessageTestClass>();
+            var generator = new CSharpGenerator(schema);
+
+            //// Act
+            var code = generator.GenerateFile();
+
+            //// Assert
+            Assert.Contains("[System.Obsolete(\"Reason property is obsolete\")]", code);
+            Assert.Contains("public string Property { get; set; }", code);
+        }
+
+        [Fact]
+        public async Task When_class_is_obsolete_then_obsolete_attribute_is_rendered()
+        {
+            //// Arrange
+#pragma warning disable 612
+            var schema = JsonSchema.FromType<ObsoleteTestClass>();
+#pragma warning restore 612
+            var generator = new CSharpGenerator(schema);
+
+            //// Act
+            var code = generator.GenerateFile();
+
+            //// Assert
+            Assert.Contains("[System.Obsolete]", code);
+            Assert.Contains("public partial class ObsoleteTestClass", code);
+        }
+
+        [Fact]
+        public async Task When_class_is_obsolete_with_a_message_then_obsolete_attribute_with_a_message_is_rendered()
+        {
+            //// Arrange
+#pragma warning disable 618
+            var schema = JsonSchema.FromType<ObsoleteWithMessageTestClass>();
+#pragma warning restore 618
+            var generator = new CSharpGenerator(schema);
+
+            //// Act
+            var code = generator.GenerateFile();
+
+            //// Assert
+            Assert.Contains("[System.Obsolete(\"Reason property is obsolete\")]", code);
+            Assert.Contains("public partial class ObsoleteWithMessageTestClass", code);
+        }
+    }
+}

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/ClassTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/ClassTemplateModel.cs
@@ -142,5 +142,14 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
 
         /// <summary>Gets the JSON serializer parameter code.</summary>
         public string JsonSerializerParameterCode => CSharpJsonSerializerGenerator.GenerateJsonSerializerParameterCode(_settings, null);
+
+        /// <summary>Gets a value indicating whether the class is deprecated.</summary>
+        public bool IsDeprecated => _schema.IsDeprecated;
+
+        /// <summary>Gets a value indicating whether the class has a deprecated message.</summary>
+        public bool HasDeprecatedMessage => !string.IsNullOrEmpty(_schema.DeprecatedMessage);
+
+        /// <summary>Gets the deprecated message.</summary>
+        public string DeprecatedMessage => _schema.DeprecatedMessage;
     }
 }

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
@@ -280,6 +280,15 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
         /// <summary>Gets a value indicating whether the property should be formatted like a date.</summary>
         public bool IsDate => _property.Format == JsonFormatStrings.Date;
 
+        /// <summary>Gets a value indicating whether the property is deprecated.</summary>
+        public bool IsDeprecated => _property.IsDeprecated;
+
+        /// <summary>Gets a value indicating whether the property has a deprecated message.</summary>
+        public bool HasDeprecatedMessage => !string.IsNullOrEmpty(_property.DeprecatedMessage);
+
+        /// <summary>Gets the deprecated message.</summary>
+        public string DeprecatedMessage => _property.DeprecatedMessage;
+
         private string GetSchemaFormat(JsonSchema schema)
         {
             if (Type == "long" || Type == "long?")

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
@@ -13,6 +13,9 @@
 {% if InheritsExceptionSchema -%}
 [Newtonsoft.Json.JsonObjectAttribute]
 {% endif -%}
+{% if IsDeprecated -%}
+[System.Obsolete{% if HasDeprecatedMessage %}("{{ DeprecatedMessage }}"){% endif %}]
+{% endif -%}
 {% template Class.Annotations %}
 {{ TypeAccessModifier }} {% if IsAbstract %}abstract {% endif %}partial class {{ClassName}} {% template Class.Inheritance %}
 {
@@ -61,6 +64,9 @@
 {%   endif -%}
 {%   if property.IsDate and UseDateFormatConverter -%}
     [Newtonsoft.Json.JsonConverter(typeof(DateFormatConverter))]
+{%   endif -%}
+{%   if property.IsDeprecated -%}
+    [System.Obsolete{% if property.HasDeprecatedMessage %}("{{ property.DeprecatedMessage }}"){% endif %}]
 {%   endif -%}
     {% template Class.Property.Annotations %}
     public {{ property.Type }} {{ property.PropertyName }}{% if RenderInpc == false and RenderPrism == false %} { get; {% if property.HasSetter and RenderRecord == false %}set; {% endif %}}{% if property.HasDefaultValue and RenderRecord == false %} = {{ property.DefaultValue }};{% elsif GenerateNullableReferenceTypes and RenderRecord == false -%} = default!;{% endif %}

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
@@ -14,7 +14,7 @@
 [Newtonsoft.Json.JsonObjectAttribute]
 {% endif -%}
 {% if IsDeprecated -%}
-[System.Obsolete{% if HasDeprecatedMessage %}("{{ DeprecatedMessage }}"){% endif %}]
+[System.Obsolete{% if HasDeprecatedMessage %}({{ DeprecatedMessage | literal }}){% endif %}]
 {% endif -%}
 {% template Class.Annotations %}
 {{ TypeAccessModifier }} {% if IsAbstract %}abstract {% endif %}partial class {{ClassName}} {% template Class.Inheritance %}
@@ -66,7 +66,7 @@
     [Newtonsoft.Json.JsonConverter(typeof(DateFormatConverter))]
 {%   endif -%}
 {%   if property.IsDeprecated -%}
-    [System.Obsolete{% if property.HasDeprecatedMessage %}("{{ property.DeprecatedMessage }}"){% endif %}]
+    [System.Obsolete{% if property.HasDeprecatedMessage %}({{ property.DeprecatedMessage | literal }}){% endif %}]
 {%   endif -%}
     {% template Class.Property.Annotations %}
     public {{ property.Type }} {{ property.PropertyName }}{% if RenderInpc == false and RenderPrism == false %} { get; {% if property.HasSetter and RenderRecord == false %}set; {% endif %}}{% if property.HasDefaultValue and RenderRecord == false %} = {{ property.DefaultValue }};{% elsif GenerateNullableReferenceTypes and RenderRecord == false -%} = default!;{% endif %}

--- a/src/NJsonSchema.CodeGeneration/DefaultTemplateFactory.cs
+++ b/src/NJsonSchema.CodeGeneration/DefaultTemplateFactory.cs
@@ -202,6 +202,11 @@ namespace NJsonSchema.CodeGeneration
                 return ConversionUtilities.ConvertToUpperCamelCase(input, firstCharacterMustBeAlpha);
             }
 
+            public static string Literal(string input)
+            {
+                return "\"" + ConversionUtilities.ConvertToStringLiteral(input) + "\"";
+            }
+
             public static IEnumerable<object> Concat(Context context, IEnumerable<object> input, IEnumerable<object> concat)
             {
                 return input.Concat(concat ?? Enumerable.Empty<object>()).ToList();

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -522,6 +522,13 @@ namespace NJsonSchema.Generation
             schema.Description = type.ToCachedType().GetDescription();
             schema.Example = GenerateExample(type.ToContextualType());
 
+            dynamic obsoleteAttribute = type.GetTypeInfo().GetCustomAttributes(false).FirstAssignableToTypeNameOrDefault("System.ObsoleteAttribute");
+            if (obsoleteAttribute != null)
+            {
+                schema.IsDeprecated = true;
+                schema.DeprecatedMessage = obsoleteAttribute.Message;
+            }
+
             if (Settings.GetActualGenerateAbstractSchema(type))
             {
                 schema.IsAbstract = type.GetTypeInfo().IsAbstract;
@@ -1225,6 +1232,13 @@ namespace NJsonSchema.Generation
                     if (propertySchema.Example == null)
                     {
                         propertySchema.Example = GenerateExample(memberInfo);
+                    }
+
+                    dynamic obsoleteAttribute = memberInfo.ContextAttributes.FirstAssignableToTypeNameOrDefault("System.ObsoleteAttribute");
+                    if (obsoleteAttribute != null)
+                    {
+                        propertySchema.IsDeprecated = true;
+                        propertySchema.DeprecatedMessage = obsoleteAttribute.Message;
                     }
 
                     propertySchema.Default = ConvertDefaultValue(memberInfo, jsonProperty.DefaultValue);

--- a/src/NJsonSchema/JsonSchema.Serialization.cs
+++ b/src/NJsonSchema/JsonSchema.Serialization.cs
@@ -42,6 +42,7 @@ namespace NJsonSchema
 
                 resolver.RenameProperty(typeof(JsonSchema), "x-nullable", "nullable");
                 resolver.RenameProperty(typeof(JsonSchema), "x-example", "example");
+                resolver.RenameProperty(typeof(JsonSchema), "x-deprecated", "deprecated");
             }
             else if (schemaType == SchemaType.Swagger2)
             {

--- a/src/NJsonSchema/JsonSchema.cs
+++ b/src/NJsonSchema/JsonSchema.cs
@@ -441,7 +441,7 @@ namespace NJsonSchema
         [JsonProperty("minProperties", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         public int MinProperties { get; set; }
 
-        /// <summary>Gets or sets a value indicating whether the schema is deprecated (native in Open API 'deprecated', custom in Swagger 'x-deprecated').</summary>
+        /// <summary>Gets or sets a value indicating whether the schema is deprecated (native in Open API 'deprecated', custom in Swagger/JSON Schema 'x-deprecated').</summary>
         [JsonProperty("x-deprecated", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool IsDeprecated { get; set; }
 

--- a/src/NJsonSchema/JsonSchema.cs
+++ b/src/NJsonSchema/JsonSchema.cs
@@ -445,6 +445,10 @@ namespace NJsonSchema
         [JsonProperty("x-deprecated", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool IsDeprecated { get; set; }
 
+        /// <summary>Gets or sets a message indicating why the schema is deprecated (custom extension, sets 'x-deprecatedMessage').</summary>
+        [JsonProperty("x-deprecatedMessage", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string DeprecatedMessage { get; set; }
+
         /// <summary>Gets or sets a value indicating whether the type is abstract, i.e. cannot be instantiated directly (x-abstract).</summary>
         [JsonProperty("x-abstract", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         public bool IsAbstract { get; set; }

--- a/src/NJsonSchema/JsonSchema.cs
+++ b/src/NJsonSchema/JsonSchema.cs
@@ -441,7 +441,7 @@ namespace NJsonSchema
         [JsonProperty("minProperties", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         public int MinProperties { get; set; }
 
-        /// <summary>Gets or sets a value indicating whether the schema is deprecated (Swagger and Open API only).</summary>
+        /// <summary>Gets or sets a value indicating whether the schema is deprecated (native in Open API 'deprecated', custom in Swagger 'x-deprecated').</summary>
         [JsonProperty("x-deprecated", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool IsDeprecated { get; set; }
 


### PR DESCRIPTION
This hopefully addresses the crux of this issue:
https://github.com/RicoSuter/NJsonSchema/issues/1031

and will unblock this enhancement in NSwag:
https://github.com/RicoSuter/NSwag/issues/2595

Along with a change to use the native deprecated attribute in OpenAPI 3.0 instead of the x-deprecated extension (#1208)

Ultimately this allows the retention of `[Obsolete("Reason")]` on classes and properties between code and generated client.