### PR TITLE
Patches/upgrade obsolete yamldotnet

### DIFF
--- a/src/NJsonSchema.CodeGeneration.Tests/NJsonSchema.CodeGeneration.Tests.csproj
+++ b/src/NJsonSchema.CodeGeneration.Tests/NJsonSchema.CodeGeneration.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.0;net451</TargetFrameworks>
+        <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
         <SignAssembly>True</SignAssembly>
         <AssemblyOriginatorKeyFile>../NJsonSchema.snk</AssemblyOriginatorKeyFile>
         <IsPackable>false</IsPackable>
@@ -11,11 +11,12 @@
         <PackageReference Include="xunit" Version="2.3.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.6.1" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="1.3.2" Condition="'$(TargetFramework)' == 'net452'" />
 
         <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
 
         <PackageReference Condition="'$(TargetFramework)' == 'netcoreapp2.0'" Include="System.ComponentModel.Annotations" Version="4.4.0" />
-        <Reference Condition="'$(TargetFramework)' == 'net451'" Include="System.ComponentModel.DataAnnotations"></Reference>
+        <Reference Condition="'$(TargetFramework)' == 'net452'" Include="System.ComponentModel.DataAnnotations"></Reference>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\NJsonSchema.CodeGeneration.CSharp\NJsonSchema.CodeGeneration.CSharp.csproj" />

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/NJsonSchema.CodeGeneration.TypeScript.Tests.csproj
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/NJsonSchema.CodeGeneration.TypeScript.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1998,1591</NoWarn>
@@ -11,7 +11,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     <PackageReference Condition="'$(TargetFramework)' == 'netcoreapp2.0'" Include="System.ComponentModel.Annotations" Version="4.4.0" />
-    <Reference Condition="'$(TargetFramework)' == 'net451'" Include="System.ComponentModel.DataAnnotations">
+    <Reference Condition="'$(TargetFramework)' == 'net452'" Include="System.ComponentModel.DataAnnotations">
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NJsonSchema.Tests/Generation/ContractResolverTests.cs
+++ b/src/NJsonSchema.Tests/Generation/ContractResolverTests.cs
@@ -13,7 +13,7 @@ namespace NJsonSchema.Tests.Generation
 {
     public class ContractResolverTests
     {
-#if !NET45
+#if !NET452
         [Fact]
 #endif
         public async Task Properties_should_match_custom_resolver()

--- a/src/NJsonSchema.Tests/Generation/SystemTextJson/SystemTextJsonOptionsConverterTests.cs
+++ b/src/NJsonSchema.Tests/Generation/SystemTextJson/SystemTextJsonOptionsConverterTests.cs
@@ -1,4 +1,4 @@
-﻿#if !NET46 && !NET45
+﻿#if !NET46 && !NET452
 
 using Newtonsoft.Json.Converters;
 using NJsonSchema.Generation;

--- a/src/NJsonSchema.Tests/NJsonSchema.Tests.csproj
+++ b/src/NJsonSchema.Tests/NJsonSchema.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net46;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net46;net452</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -46,7 +46,7 @@
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
 
     <PackageReference Condition="'$(TargetFramework)' == 'netcoreapp2.0'" Include="System.ComponentModel.Annotations" Version="4.4.0" />
-    <Reference Condition="'$(TargetFramework)' == 'net45'" Include="System.ComponentModel.DataAnnotations"></Reference>
+    <Reference Condition="'$(TargetFramework)' == 'net452'" Include="System.ComponentModel.DataAnnotations"></Reference>
     <Reference Condition="'$(TargetFramework)' == 'net46'" Include="System.ComponentModel.DataAnnotations"></Reference>
 
     <PackageReference Include="NodaTime" Version="2.2.0" />

--- a/src/NJsonSchema.Yaml.Tests/NJsonSchema.Yaml.Tests.csproj
+++ b/src/NJsonSchema.Yaml.Tests/NJsonSchema.Yaml.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net46;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net46;net452</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup>
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     <PackageReference Condition="'$(TargetFramework)' == 'netcoreapp2.0'" Include="System.ComponentModel.Annotations" Version="4.4.0" />
-    <Reference Condition="'$(TargetFramework)' == 'net45'" Include="System.ComponentModel.DataAnnotations">
+    <Reference Condition="'$(TargetFramework)' == 'net452'" Include="System.ComponentModel.DataAnnotations">
     </Reference>
     <Reference Condition="'$(TargetFramework)' == 'net46'" Include="System.ComponentModel.DataAnnotations">
     </Reference>

--- a/src/NJsonSchema.Yaml/NJsonSchema.Yaml.csproj
+++ b/src/NJsonSchema.Yaml/NJsonSchema.Yaml.csproj
@@ -19,6 +19,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.4.1" />
-    <PackageReference Include="YamlDotNet.Signed" Version="5.1.0" />
+    <PackageReference Include="YamlDotNet" Version="8.1.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Hello,

I wanted to change the obsolete package of YamlDotNet.Signed 5.1.0 to the latest YamlDotNet 8.1.2 to avoid conflicts in my dependencies.
https://github.com/RicoSuter/NJsonSchema/issues/1203

While doing so, I saw the net45 tests were not running because the xunit runner is no longer compatible with net45 and requires net452. So I fixed that and saw that an old net45 test was using the CodeDomProvider which is not compatible with C# 6+ and cannot understand the read-only properties generated by NJsonSchema. So I used the latest version of Roslyn (1.3.2) compatible with net452 for this test instead, copying the netcoreapp2.0 test.
Now every tests seems to run smoothly again.
