### PR TITLE
Fixed support for oneOf and anyOf to produce the right result for C# classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ src/packages/Newtonsoft.Json**
 *.vspx
 /src/TestResults
 /src/.cr/*
+
+# Ignore files from JetBrainds Rider
+/src/.idea/

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/AnyOfTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/AnyOfTests.cs
@@ -1,0 +1,387 @@
+﻿using System.Threading.Tasks;
+using NJsonSchema.CodeGeneration.CSharp;
+using Xunit;
+
+namespace NJsonSchema.CodeGeneration.Tests.CSharp
+{
+    public class AnyOfTests
+    {
+        [Fact]
+        public async Task When_anyOf_has_two_schemas_then_the_properties_should_expand_to_single_class()
+        {
+            //// Arrange
+            var json =
+@"{
+    ""anyOf"": [
+        {
+            ""$ref"": ""#/definitions/B""
+        },
+        {
+            ""type"": ""object"", 
+            ""required"": [
+                ""prop""
+            ],
+            ""properties"": {
+                ""prop"": {
+                    ""type"": ""string"",
+                    ""minLength"": 1,
+                    ""maxLength"": 30
+                },
+                ""prop2"": {
+                    ""type"": ""string""
+                }
+            }
+        }
+    ],
+    ""definitions"": {
+        ""B"": {
+            ""properties"": {
+                ""foo"": {
+                    ""type"": ""string""
+                }
+            }
+        }
+    }
+}";
+            var schema = await JsonSchema.FromJsonAsync(json);
+
+            //// Act
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings());
+            var code = generator.GenerateFile("A");
+
+            //// Assert
+            Assert.Contains(@"public partial class A 
+    {
+        [Newtonsoft.Json.JsonProperty(""foo"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Foo { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty(""prop"", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
+        [System.ComponentModel.DataAnnotations.StringLength(30, MinimumLength = 1)]
+        public string Prop { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty(""prop2"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Prop2 { get; set; }
+    
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+    
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }".Replace("\r", string.Empty), code);
+            Assert.DoesNotContain("Anonymous", code);
+        }
+
+        // TODO: This one fails, and I suspect this indicates there is a bug somewhere?
+//         [Fact]
+//         public async Task When_anyOf_has_one_schema_then_the_properties_should_expand_into_class()
+//         {
+//             //// Arrange
+//             var json =
+// @"{
+//     ""type"": ""object"",
+//     ""discriminator"": ""type"",
+//     ""required"": [
+//         ""prop"",
+//         ""type""
+//     ],
+//     ""properties"": {
+//         ""prop"": {
+//             ""type"": ""string"",
+//             ""minLength"": 1,
+//             ""maxLength"": 30
+//         },
+//         ""prop2"": {
+//             ""type"": ""string""
+//         },
+//         ""type"": {
+//             ""type"": ""string""
+//         }
+//     },
+//     ""anyOf"": [
+//         {
+//             ""$ref"": ""#/definitions/B""
+//         }
+//     ],
+//     ""definitions"": {
+//         ""B"": {
+//             ""type"": ""object"",
+//             ""properties"": {
+//                 ""foo"": {
+//                     ""type"": ""string""
+//                 }
+//             }
+//         }
+//     }
+// }";
+//             var schema = await JsonSchema.FromJsonAsync(json);
+//
+//             //// Act
+//             var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings());
+//             var code = generator.GenerateFile("A");
+//
+//             //// Assert
+//             Assert.Contains(@"public partial class A
+//     {
+//         [Newtonsoft.Json.JsonProperty(""prop"", Required = Newtonsoft.Json.Required.Always)]
+//         [System.ComponentModel.DataAnnotations.Required]
+//         [System.ComponentModel.DataAnnotations.StringLength(30, MinimumLength = 1)]
+//         public string Prop { get; set; }
+//
+//         [Newtonsoft.Json.JsonProperty(""prop2"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+//         public string Prop2 { get; set; }
+//
+//         [Newtonsoft.Json.JsonProperty(""type"", Required = Newtonsoft.Json.Required.Always)]
+//         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+//         public string Type { get; set; }
+//
+//         [Newtonsoft.Json.JsonProperty(""foo"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+//         public string Foo { get; set; }
+//
+//         private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+//
+//         [Newtonsoft.Json.JsonExtensionData]
+//         public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+//         {
+//             get { return _additionalProperties; }
+//             set { _additionalProperties = value; }
+//         }".Replace("\r", string.Empty), code);
+//             Assert.DoesNotContain("Anonymous", code);
+//         }
+
+        [Fact]
+        public async Task When_anyOf_has_multiple_refs_then_the_properties_should_expand_to_single_class()
+        {
+            //// Arrange
+            var json = @"{
+                '$schema': 'http://json-schema.org/draft-04/schema#',
+                'id': 'http://some.domain.com/foo.json',
+                'type': 'object',
+                'additionalProperties': false,
+                'definitions': {
+                    'tRef1': {
+                        'properties': {
+                            'val1': {
+                                'type': 'string',
+                            }
+                        }
+                    },
+                    'tRef2': {
+                        'properties': {
+                            'val2': {
+                                'type': 'string',
+                            }
+                        }
+                    },
+                    'tRef3': {
+                        'properties': {
+                            'val3': {
+                                'type': 'string',
+                            }
+                        }
+                    }
+                },
+                'properties' : {
+                    'tAgg': {
+                        'anyOf': [
+                            {'$ref': '#/definitions/tRef1'},
+                            {'$ref': '#/definitions/tRef2'},
+                            {'$ref': '#/definitions/tRef3'}
+                        ]
+                    }
+                }
+            }";
+
+            //// Act
+            var schema = await JsonSchema.FromJsonAsync(json);
+            var settings = new CSharpGeneratorSettings { ClassStyle = CSharpClassStyle.Poco, Namespace = "ns" };
+            var generator = new CSharpGenerator(schema, settings);
+            var code = generator.GenerateFile("Foo");
+
+            //// Assert
+            Assert.Contains(@"public partial class TRef1 
+    {
+        [Newtonsoft.Json.JsonProperty(""val1"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Val1 { get; set; }
+    
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+    
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }".Replace("\r", string.Empty), code);
+            Assert.Contains(@"public partial class TRef1 
+    {
+        [Newtonsoft.Json.JsonProperty(""val1"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Val1 { get; set; }
+    
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+    
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }".Replace("\r", string.Empty), code);
+
+            Assert.Contains(@"public partial class TRef2 
+    {
+        [Newtonsoft.Json.JsonProperty(""val2"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Val2 { get; set; }
+    
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+    
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }".Replace("\r", string.Empty), code);
+
+            Assert.Contains(@"public partial class TRef3 
+    {
+        [Newtonsoft.Json.JsonProperty(""val3"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Val3 { get; set; }
+    
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+    
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }".Replace("\r", string.Empty), code);
+
+            Assert.Contains(@"public partial class Foo 
+    {
+        [Newtonsoft.Json.JsonProperty(""tAgg"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public TAgg TAgg { get; set; }".Replace("\r", string.Empty), code);
+
+            Assert.Contains(@"public partial class TAgg 
+    {
+        [Newtonsoft.Json.JsonProperty(""val1"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Val1 { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty(""val2"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Val2 { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty(""val3"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Val3 { get; set; }
+    
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+    
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }".Replace("\r", string.Empty), code);
+        }
+
+        [Fact]
+        public async Task When_more_properties_are_defined_in_anyOf_and_type_none_then_the_properties_should_expand_to_single_class()
+        {
+            //// Arrange
+            var json = @"{
+                '$schema': 'http://json-schema.org/draft-04/schema#',
+                'type': 'object',
+                'properties': { 
+                    'prop1' : { 'type' : 'string' } 
+                },
+                'anyOf': [
+                    {
+                        'type': 'object', 
+                        'properties': { 
+                            'baseProperty' : { 'type' : 'string' } 
+                        }
+                    },
+                    {
+                        'properties': { 
+                            'prop2' : { 'type' : 'string' } 
+                        }
+                    }
+                ]
+            }";
+
+            //// Act
+            var schema = await JsonSchema.FromJsonAsync(json);
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings { ClassStyle = CSharpClassStyle.Poco });
+            var code = generator.GenerateFile("Foo").Replace("\r\n", "\n");
+
+            //// Assert
+            Assert.Contains(@"public partial class Foo 
+    {
+        [Newtonsoft.Json.JsonProperty(""prop1"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Prop1 { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty(""baseProperty"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string BaseProperty { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty(""prop2"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Prop2 { get; set; }
+    
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+    
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }".Replace("\r", string.Empty), code);
+            Assert.DoesNotContain("class Anonymous", code);
+        }
+
+        [Fact]
+        public async Task When_anyOf_schema_is_object_type_then_the_properties_should_expand_to_single_class()
+        {
+            //// Arrange
+            var json = @"{
+                '$schema': 'http://json-schema.org/draft-04/schema#',
+                'type': 'object',
+                'properties': { 
+                    'prop1' : { 'type' : 'string' } 
+                },
+                'anyOf': [
+                    {
+                        '$ref': '#/definitions/Bar'
+                    }
+                ], 
+                'definitions': {
+                    'Bar':  {
+                        'type': 'object', 
+                        'properties': { 
+                            'prop2' : { 'type' : 'string' } 
+                        }
+                    }
+                }
+            }";
+
+            //// Act
+            var schema = await JsonSchema.FromJsonAsync(json);
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings { ClassStyle = CSharpClassStyle.Poco });
+            var code = generator.GenerateFile("Foo");
+
+            //// Assert
+            Assert.Contains(@"public partial class Foo 
+    {
+        [Newtonsoft.Json.JsonProperty(""prop1"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Prop1 { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty(""prop2"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Prop2 { get; set; }
+    
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+    
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }".Replace("\r", string.Empty), code);
+        }
+    }
+}

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/OneOfTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/OneOfTests.cs
@@ -1,0 +1,386 @@
+﻿using System.Threading.Tasks;
+using NJsonSchema.CodeGeneration.CSharp;
+using Xunit;
+
+namespace NJsonSchema.CodeGeneration.Tests.CSharp
+{
+    public class OneOfTests
+    {
+        [Fact]
+        public async Task When_oneOf_has_two_schemas_then_the_properties_should_expand_to_single_class()
+        {
+            //// Arrange
+            var json =
+@"{
+    ""oneOf"": [
+        {
+            ""$ref"": ""#/definitions/B""
+        },
+        {
+            ""type"": ""object"", 
+            ""required"": [
+                ""prop""
+            ],
+            ""properties"": {
+                ""prop"": {
+                    ""type"": ""string"",
+                    ""minLength"": 1,
+                    ""maxLength"": 30
+                },
+                ""prop2"": {
+                    ""type"": ""string""
+                }
+            }
+        }
+    ],
+    ""definitions"": {
+        ""B"": {
+            ""properties"": {
+                ""foo"": {
+                    ""type"": ""string""
+                }
+            }
+        }
+    }
+}";
+            var schema = await JsonSchema.FromJsonAsync(json);
+
+            //// Act
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings());
+            var code = generator.GenerateFile("A");
+
+            //// Assert
+            Assert.Contains(@"public partial class A 
+    {
+        [Newtonsoft.Json.JsonProperty(""foo"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Foo { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty(""prop"", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
+        [System.ComponentModel.DataAnnotations.StringLength(30, MinimumLength = 1)]
+        public string Prop { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty(""prop2"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Prop2 { get; set; }
+    
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+    
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }".Replace("\r", string.Empty), code);
+            Assert.DoesNotContain("Anonymous", code);
+        }
+
+        [Fact]
+        public async Task When_oneOf_has_one_schema_then_the_properties_should_expand_into_class()
+        {
+            //// Arrange
+            var json =
+@"{
+    ""type"": ""object"",
+    ""discriminator"": ""type"",
+    ""required"": [
+        ""prop"", 
+        ""type""
+    ],
+    ""properties"": {
+        ""prop"": {
+            ""type"": ""string"",
+            ""minLength"": 1,
+            ""maxLength"": 30
+        },
+        ""prop2"": {
+            ""type"": ""string""
+        },
+        ""type"": {
+            ""type"": ""string""
+        }
+    },
+    ""oneOf"": [
+        {
+            ""$ref"": ""#/definitions/B""
+        }
+    ],
+    ""definitions"": {
+        ""B"": {
+            ""type"": ""object"",
+            ""properties"": {
+                ""foo"": {
+                    ""type"": ""string""
+                }
+            }
+        }
+    }
+}";
+            var schema = await JsonSchema.FromJsonAsync(json);
+
+            //// Act
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings());
+            var code = generator.GenerateFile("A");
+
+            //// Assert
+            Assert.Contains(@"public partial class A 
+    {
+        [Newtonsoft.Json.JsonProperty(""prop"", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
+        [System.ComponentModel.DataAnnotations.StringLength(30, MinimumLength = 1)]
+        public string Prop { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty(""prop2"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Prop2 { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty(""type"", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string Type { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty(""foo"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Foo { get; set; }
+    
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+    
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }".Replace("\r", string.Empty), code);
+            Assert.DoesNotContain("Anonymous", code);
+        }
+
+        [Fact]
+        public async Task When_oneOf_has_multiple_refs_then_the_properties_should_expand_to_single_class()
+        {
+            //// Arrange
+            var json = @"{
+                '$schema': 'http://json-schema.org/draft-04/schema#',
+                'id': 'http://some.domain.com/foo.json',
+                'type': 'object',
+                'additionalProperties': false,
+                'definitions': {
+                    'tRef1': {
+                        'properties': {
+                            'val1': {
+                                'type': 'string',
+                            }
+                        }
+                    },
+                    'tRef2': {
+                        'properties': {
+                            'val2': {
+                                'type': 'string',
+                            }
+                        }
+                    },
+                    'tRef3': {
+                        'properties': {
+                            'val3': {
+                                'type': 'string',
+                            }
+                        }
+                    }
+                },
+                'properties' : {
+                    'tAgg': {
+                        'oneOf': [
+                            {'$ref': '#/definitions/tRef1'},
+                            {'$ref': '#/definitions/tRef2'},
+                            {'$ref': '#/definitions/tRef3'}
+                        ]
+                    }
+                }
+            }";
+
+            //// Act
+            var schema = await JsonSchema.FromJsonAsync(json);
+            var settings = new CSharpGeneratorSettings { ClassStyle = CSharpClassStyle.Poco, Namespace = "ns" };
+            var generator = new CSharpGenerator(schema, settings);
+            var code = generator.GenerateFile("Foo");
+
+            //// Assert
+            Assert.Contains(@"public partial class TRef1 
+    {
+        [Newtonsoft.Json.JsonProperty(""val1"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Val1 { get; set; }
+    
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+    
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }".Replace("\r", string.Empty), code);
+            Assert.Contains(@"public partial class TRef1 
+    {
+        [Newtonsoft.Json.JsonProperty(""val1"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Val1 { get; set; }
+    
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+    
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }".Replace("\r", string.Empty), code);
+
+            Assert.Contains(@"public partial class TRef2 
+    {
+        [Newtonsoft.Json.JsonProperty(""val2"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Val2 { get; set; }
+    
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+    
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }".Replace("\r", string.Empty), code);
+
+            Assert.Contains(@"public partial class TRef3 
+    {
+        [Newtonsoft.Json.JsonProperty(""val3"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Val3 { get; set; }
+    
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+    
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }".Replace("\r", string.Empty), code);
+
+            Assert.Contains(@"public partial class Foo 
+    {
+        [Newtonsoft.Json.JsonProperty(""tAgg"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public TAgg TAgg { get; set; }".Replace("\r", string.Empty), code);
+
+            Assert.Contains(@"public partial class TAgg 
+    {
+        [Newtonsoft.Json.JsonProperty(""val1"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Val1 { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty(""val2"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Val2 { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty(""val3"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Val3 { get; set; }
+    
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+    
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }".Replace("\r", string.Empty), code);
+        }
+
+        [Fact]
+        public async Task When_more_properties_are_defined_in_oneOf_and_type_none_then_the_properties_should_expand_to_single_class()
+        {
+            //// Arrange
+            var json = @"{
+                '$schema': 'http://json-schema.org/draft-04/schema#',
+                'type': 'object',
+                'properties': { 
+                    'prop1' : { 'type' : 'string' } 
+                },
+                'oneOf': [
+                    {
+                        'type': 'object', 
+                        'properties': { 
+                            'baseProperty' : { 'type' : 'string' } 
+                        }
+                    },
+                    {
+                        'properties': { 
+                            'prop2' : { 'type' : 'string' } 
+                        }
+                    }
+                ]
+            }";
+
+            //// Act
+            var schema = await JsonSchema.FromJsonAsync(json);
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings { ClassStyle = CSharpClassStyle.Poco });
+            var code = generator.GenerateFile("Foo").Replace("\r\n", "\n");
+
+            //// Assert
+            Assert.Contains(@"public partial class Foo 
+    {
+        [Newtonsoft.Json.JsonProperty(""prop1"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Prop1 { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty(""baseProperty"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string BaseProperty { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty(""prop2"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Prop2 { get; set; }
+    
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+    
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }".Replace("\r", string.Empty), code);
+            Assert.DoesNotContain("class Anonymous", code);
+        }
+
+        [Fact]
+        public async Task When_oneOf_schema_is_object_type_then_the_properties_should_expand_to_single_class()
+        {
+            //// Arrange
+            var json = @"{
+                '$schema': 'http://json-schema.org/draft-04/schema#',
+                'type': 'object',
+                'properties': { 
+                    'prop1' : { 'type' : 'string' } 
+                },
+                'oneOf': [
+                    {
+                        '$ref': '#/definitions/Bar'
+                    }
+                ], 
+                'definitions': {
+                    'Bar':  {
+                        'type': 'object', 
+                        'properties': { 
+                            'prop2' : { 'type' : 'string' } 
+                        }
+                    }
+                }
+            }";
+
+            //// Act
+            var schema = await JsonSchema.FromJsonAsync(json);
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings { ClassStyle = CSharpClassStyle.Poco });
+            var code = generator.GenerateFile("Foo");
+
+            //// Assert
+            Assert.Contains(@"public partial class Foo 
+    {
+        [Newtonsoft.Json.JsonProperty(""prop1"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Prop1 { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty(""prop2"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Prop2 { get; set; }
+    
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+    
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }".Replace("\r", string.Empty), code);
+        }
+    }
+}

--- a/src/NJsonSchema.CodeGeneration/TypeResolverBase.cs
+++ b/src/NJsonSchema.CodeGeneration/TypeResolverBase.cs
@@ -49,8 +49,7 @@ namespace NJsonSchema.CodeGeneration
         /// <returns>The type name.</returns>
         public virtual string GetOrGenerateTypeName(JsonSchema schema, string typeNameHint)
         {
-            schema = RemoveNullability(schema).ActualSchema;
-
+            schema = schema.ActualSchema;
             RegisterSchemaDefinitions(schema.Definitions);
 
             if (!_generatedTypeNames.ContainsKey(schema))
@@ -80,26 +79,16 @@ namespace NJsonSchema.CodeGeneration
             }
         }
 
-        /// <summary>Removes a nullable oneOf reference if available.</summary>
-        /// <param name="schema">The schema.</param>
-        /// <returns>The actually resolvable schema</returns>
-        public JsonSchema RemoveNullability(JsonSchema schema)
-        {
-            // TODO: Method on JsonSchema4?
-            return schema.OneOf.FirstOrDefault(o => !o.IsNullable(SchemaType.JsonSchema)) ?? schema;
-        }
-
-        /// <summary>Gets the actual schema (i.e. when not referencing a type schema or it is inlined) 
+        /// <summary>Gets the actual schema (i.e. when not referencing a type schema or it is inlined)
         /// and removes a nullable oneOf reference if available.</summary>
         /// <param name="schema">The schema.</param>
         /// <returns>The actually resolvable schema</returns>
         public JsonSchema GetResolvableSchema(JsonSchema schema)
         {
-            schema = RemoveNullability(schema);
             return IsDefinitionTypeSchema(schema.ActualSchema) ? schema : schema.ActualSchema;
         }
 
-        /// <summary>Checks whether the given schema generates a new type (e.g. class, enum, class with dictionary inheritance, etc.) 
+        /// <summary>Checks whether the given schema generates a new type (e.g. class, enum, class with dictionary inheritance, etc.)
         /// or is an inline type (e.g. string, number, etc.). Warning: Enum will also return true.</summary>
         /// <param name="schema"></param>
         /// <returns></returns>

--- a/src/NJsonSchema/JsonSchema.cs
+++ b/src/NJsonSchema/JsonSchema.cs
@@ -249,7 +249,7 @@ namespace NJsonSchema
             }
         }
 
-        /// <summary>Gets the inherited/parent schema which may also be inlined 
+        /// <summary>Gets the inherited/parent schema which may also be inlined
         /// (the schema itself if it is a dictionary or array, otherwise <see cref="InheritedSchema"/>).</summary>
         /// <remarks>Used for code generation.</remarks>
         [JsonIgnore]
@@ -312,8 +312,9 @@ namespace NJsonSchema
             get
             {
                 var properties = Properties
-                    .Union(AllOf.Where(s => s.ActualSchema != InheritedSchema)
-                    .SelectMany(s => s.ActualSchema.ActualProperties))
+                    .Union(AllOf.Where(s => s.ActualSchema != InheritedSchema).SelectMany(s => s.ActualSchema.ActualProperties))
+                    .Union(AnyOf.Where(s => s.ActualSchema != InheritedSchema).SelectMany(s => s.ActualSchema.ActualProperties))
+                    .Union(OneOf.Where(s => s.ActualSchema != InheritedSchema).SelectMany(s => s.ActualSchema.ActualProperties))
                     .ToList();
 
                 var duplicatedProperties = properties


### PR DESCRIPTION
Referenced in this issue:

https://github.com/RicoSuter/NSwag/issues/2991

The only valid solution to generation of classes in C# to support anyOf and oneOf, is to merge all the properties together into the request and response classes, including flattening the inherited properties as inheritance cannot be used here. It's kind of ugly to use oneOf and anyOf IMHO anyway, but that's how some API's are designed (like ShipEngine), and without these changes this will generate bogus request and response classes.

I have added some unit tests for the new code I wrote, but it breaks some of the other tests so it's not clear if those tests need to be fixed to suit the new code, or if we need to find a different way to enable this support for C# code generation if it will break other languages?