### PR TITLE
DefaultTypeNameGenerator remove illegal characters

### DIFF
--- a/src/NJsonSchema.Tests/Generation/DefaultTypeNameGeneratorTests.cs
+++ b/src/NJsonSchema.Tests/Generation/DefaultTypeNameGeneratorTests.cs
@@ -32,5 +32,34 @@ namespace NJsonSchema.Tests.Generation
                 Assert.Equal(p.Value, name);
             }
         }
+
+        [Fact]
+        public void When_type_name_is_genererated_then_it_removes_Illegal_characters()
+        {
+            var tests = new Dictionary<string, string>
+            {
+                { "foo.bar+", "Bar" },
+                { "foo+Bar", "Foo_Bar" },
+                { "foo++Bar", "Foo_Bar" },
+                { "abc.1fooBar", "_1fooBar" },
+                { "foo9[bar]", "Foo9OfBar" },
+                { "bar[a+,b]", "BarOfA_AndB" },
+                { "foo.bar[a.b+]", "BarOfB" },
+                { "foo.bar[a.b+, c.+d+]", "BarOfB_And_d" },
+                { " Foo.ActionRes+ponse [System.Net.HttpSta+tusCode, Us+er]", "ActionRes_ponseOfHttpSta_tusCodeAndUs_er" }
+            };
+
+            //// Arrange
+            var generator = new DefaultTypeNameGenerator();
+
+            foreach (var p in tests)
+            {
+                //// Act
+                var name = generator.Generate(new JsonSchema(), p.Key, new List<string>());
+
+                //// Assert
+                Assert.Equal(p.Value, name);
+            }
+        }
     }
 }

--- a/src/NJsonSchema/DefaultTypeNameGenerator.cs
+++ b/src/NJsonSchema/DefaultTypeNameGenerator.cs
@@ -8,6 +8,8 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
 
 namespace NJsonSchema
 {
@@ -51,7 +53,7 @@ namespace NJsonSchema
                 typeName = GenerateAnonymousTypeName(typeNameHint, reservedTypeNames);
             }
 
-            return typeName;
+            return RemoveIllegalCharacters(typeName);
         }
 
         /// <summary>Generates the type name for the given schema.</summary>
@@ -95,6 +97,42 @@ namespace NJsonSchema
             }
 
             return GenerateAnonymousTypeName("Anonymous", reservedTypeNames);
+        }
+
+        /// <summary>
+        /// replaces all characters that are not normals letters, numbers or underscore, with an underscore.
+        /// Will prepend an underscore if the first characters is a number
+        /// In case there are this would result in multiple underscores in a row, strips down to one underscore.
+        /// Will trim any underscores at the end of the typename
+        /// </summary>
+        /// <param name="typeName"></param>
+        /// <returns></returns>
+        private string RemoveIllegalCharacters(string typeName)
+        {
+            // TODO: Find a way to support unicode characters up to 3.0
+            var legalTypeName = new StringBuilder(typeName);
+
+            var firstCharacter = legalTypeName[0].ToString();
+            var regexValidStartChar = new Regex("[a-zA-Z_]");
+            var regexInvalidCharacters = new Regex("\\W");
+
+            if (!regexValidStartChar.IsMatch(firstCharacter))
+            {
+                if (!regexInvalidCharacters.IsMatch(firstCharacter))
+                    legalTypeName.Insert(0, "_");
+                else
+                    legalTypeName[0] = '_';
+            }
+
+            var illegalMatches = regexInvalidCharacters.Matches(legalTypeName.ToString());
+            for (int i = illegalMatches.Count - 1; i >= 0; i--)
+            {
+                var illegalMatchIndex = illegalMatches[i].Index;
+                legalTypeName[illegalMatchIndex] = '_';
+            }
+            var regexMoreThanOneUnderscore = new Regex("[_]{2,}");
+            var legalTypeNameString = regexMoreThanOneUnderscore.Replace(legalTypeName.ToString(), "_");
+            return legalTypeNameString.TrimEnd('_');
         }
     }
 }


### PR DESCRIPTION
Replace illegal characters with an underscore, such that there are no names generated that cannot compile.
