### PR TITLE
Add possibility to control discriminator property (use e.g. enum)

### DIFF
--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptDiscriminatorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptDiscriminatorTests.cs
@@ -9,7 +9,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
 {
     public class TypeScriptDiscriminatorTests
     {
-        [JsonConverter(typeof(JsonInheritanceConverter), "type")]
+        [JsonConverter(typeof(JsonInheritanceConverter), nameof(Type))]
         [KnownType(typeof(OneChild))]
         [KnownType(typeof(SecondChild))]
         public abstract class Base
@@ -38,6 +38,45 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
             public Base Child { get; set; }
 
             public ICollection<Base> Children { get; set; }
+        }
+
+        [Fact]
+        public async Task When_generating_interface_contract_add_discriminator()
+        {
+            //// Arrange
+            var schema = JsonSchema.FromType<Nested>();
+            var data = schema.ToJson();
+
+            //// Act
+            var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings
+            {
+                TypeStyle = TypeScriptTypeStyle.Interface,
+                TypeScriptVersion = 1.8m,
+            });
+            var code = generator.GenerateFile("MyClass");
+
+            //// Assert
+            Assert.Contains("export interface Base {\n    Type: EBase;\n}", code);
+        }
+        
+        [Fact]
+        public async Task When_generating_interface_contract_add_discriminator_string_literal()
+        {
+            //// Arrange
+            var schema = JsonSchema.FromType<Nested>();
+            var data = schema.ToJson();
+
+            //// Act
+            var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings
+            {
+                TypeStyle = TypeScriptTypeStyle.Interface,
+                TypeScriptVersion = 1.8m,
+                EnumStyle = TypeScriptEnumStyle.StringLiteral,
+            });
+            var code = generator.GenerateFile("MyClass");
+
+            //// Assert
+            Assert.Contains("export interface Base {\n    Type: EBase;\n}", code);
         }
 
         [Fact]

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptDiscriminatorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptDiscriminatorTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Newtonsoft.Json;
 using NJsonSchema.Converters;
+using NJsonSchema.Generation;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Xunit;
@@ -48,7 +49,10 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
         public async Task When_generating_interface_contract_add_discriminator()
         {
             //// Arrange
-            var schema = JsonSchema.FromType<Nested>();
+            var schema = JsonSchema.FromType<Nested>(new JsonSchemaGeneratorSettings
+            {
+                GenerateAbstractProperties = true,
+            });
             var data = schema.ToJson();
 
             //// Act
@@ -67,7 +71,10 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
         public async Task When_generating_interface_contract_add_discriminator_string_literal()
         {
             //// Arrange
-            var schema = JsonSchema.FromType<Nested>();
+            var schema = JsonSchema.FromType<Nested>(new JsonSchemaGeneratorSettings
+            {
+                GenerateAbstractProperties = true,
+            });
             var data = schema.ToJson();
 
             //// Act

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptDiscriminatorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptDiscriminatorTests.cs
@@ -14,7 +14,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
         [KnownType(typeof(SecondChild))]
         public abstract class Base
         {
-            public EBase Type { get; }
+            public abstract EBase Type { get; }
         }
 
         public enum EBase
@@ -26,11 +26,15 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
         public class OneChild : Base
         {
             public string A { get; }
+
+            public override EBase Type => EBase.OneChild;
         }
 
         public class SecondChild : Base
         {
             public string B { get; }
+
+            public override EBase Type => EBase.SecondChild;
         }
 
         public class Nested

--- a/src/NJsonSchema.CodeGeneration.TypeScript/Models/ClassTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Models/ClassTemplateModel.cs
@@ -38,14 +38,9 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Models
             _discriminatorName = discriminatorName;
 
             ClassName = typeName;
-
-            var properties = _schema.ActualProperties.Values;
-            if (settings.TypeStyle != TypeScriptTypeStyle.Interface)
-            {
-                properties = properties.Where(v => v.IsInheritanceDiscriminator == false);
-            }
-
-            Properties = properties
+            Properties = _schema.ActualProperties.Values
+                .Where(v => settings.TypeStyle == TypeScriptTypeStyle.Interface || 
+                            v.IsInheritanceDiscriminator == false)
                 .Select(property => new PropertyModel(this, property, ClassName, _resolver, _settings))
                 .ToList();
         }

--- a/src/NJsonSchema.CodeGeneration.TypeScript/Models/ClassTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Models/ClassTemplateModel.cs
@@ -38,8 +38,14 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Models
             _discriminatorName = discriminatorName;
 
             ClassName = typeName;
-            Properties = _schema.ActualProperties.Values
-                .Where(v => v.IsInheritanceDiscriminator == false)
+
+            var properties = _schema.ActualProperties.Values;
+            if (settings.TypeStyle != TypeScriptTypeStyle.Interface)
+            {
+                properties = properties.Where(v => v.IsInheritanceDiscriminator == false);
+            }
+
+            Properties = properties
                 .Select(property => new PropertyModel(this, property, ClassName, _resolver, _settings))
                 .ToList();
         }

--- a/src/NJsonSchema.Tests/Generation/InheritanceTests.cs
+++ b/src/NJsonSchema.Tests/Generation/InheritanceTests.cs
@@ -315,9 +315,9 @@ namespace NJsonSchema.Tests.Generation
 
         [KnownType(typeof(InheritedClass_WithIntDiscriminant))]
         [JsonConverter(typeof(JsonInheritanceConverter), nameof(Kind))]
-        public class BaseClass_WithIntDiscriminant
+        public class BaseClass_WithObjectDiscriminant
         {
-            public int Kind { get; set; }
+            public object Kind { get; set; }
         }
 
         public class InheritedClass_WithIntDiscriminant : BaseClass_WithStringDiscriminant
@@ -331,7 +331,7 @@ namespace NJsonSchema.Tests.Generation
             //// Arrange
 
             //// Act
-            JsonSchema GetSchema() => JsonSchema.FromType<BaseClass_WithIntDiscriminant>();
+            JsonSchema GetSchema() => JsonSchema.FromType<BaseClass_WithObjectDiscriminant>();
             Action getSchemaAction = () => GetSchema();
 
             //// Assert

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -1114,7 +1114,8 @@ namespace NJsonSchema.Generation
                     if (typeSchema.Properties.TryGetValue(discriminatorName, out var existingProperty))
                     {
                         if (
-                            (existingProperty.ActualTypeSchema.Type & (JsonObjectType.String | JsonObjectType.Integer)) == 0
+                            !existingProperty.ActualTypeSchema.Type.HasFlag(JsonObjectType.Integer)
+                            && !existingProperty.ActualTypeSchema.Type.HasFlag(JsonObjectType.String)
                         )
                         {
                             throw new InvalidOperationException("The JSON discriminator property '" + discriminatorName + "' must be a string|int property on type '" + type.FullName + "' (it is recommended to not implement the discriminator property at all).");

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -1111,10 +1111,16 @@ namespace NJsonSchema.Generation
                     var discriminatorName = TryGetInheritanceDiscriminatorName(discriminatorConverter);
 
                     // Existing property can be discriminator only if it has String type  
-                    if (typeSchema.Properties.TryGetValue(discriminatorName, out JsonSchemaProperty existingProperty) &&
-                        (existingProperty.Type & JsonObjectType.String) == 0)
+                    if (typeSchema.Properties.TryGetValue(discriminatorName, out var existingProperty))
                     {
-                        throw new InvalidOperationException("The JSON discriminator property '" + discriminatorName + "' must be a string property on type '" + type.FullName + "' (it is recommended to not implement the discriminator property at all).");
+                        if (
+                            (existingProperty.ActualTypeSchema.Type & (JsonObjectType.String | JsonObjectType.Integer)) == 0
+                        )
+                        {
+                            throw new InvalidOperationException("The JSON discriminator property '" + discriminatorName + "' must be a string|int property on type '" + type.FullName + "' (it is recommended to not implement the discriminator property at all).");
+                        }
+
+                        existingProperty.IsRequired = true;
                     }
 
                     var discriminator = new OpenApiDiscriminator
@@ -1124,11 +1130,15 @@ namespace NJsonSchema.Generation
                     };
 
                     typeSchema.DiscriminatorObject = discriminator;
-                    typeSchema.Properties[discriminatorName] = new JsonSchemaProperty
+
+                    if (!typeSchema.Properties.ContainsKey(discriminatorName))
                     {
-                        Type = JsonObjectType.String,
-                        IsRequired = true
-                    };
+                        typeSchema.Properties[discriminatorName] = new JsonSchemaProperty
+                        {
+                            Type = JsonObjectType.String,
+                            IsRequired = true
+                        };
+                    }
                 }
                 else
                 {

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -1113,10 +1113,8 @@ namespace NJsonSchema.Generation
                     // Existing property can be discriminator only if it has String type  
                     if (typeSchema.Properties.TryGetValue(discriminatorName, out var existingProperty))
                     {
-                        if (
-                            !existingProperty.ActualTypeSchema.Type.HasFlag(JsonObjectType.Integer)
-                            && !existingProperty.ActualTypeSchema.Type.HasFlag(JsonObjectType.String)
-                        )
+                        if (!existingProperty.ActualTypeSchema.Type.HasFlag(JsonObjectType.Integer) && 
+                            !existingProperty.ActualTypeSchema.Type.HasFlag(JsonObjectType.String))
                         {
                             throw new InvalidOperationException("The JSON discriminator property '" + discriminatorName + "' must be a string|int property on type '" + type.FullName + "' (it is recommended to not implement the discriminator property at all).");
                         }


### PR DESCRIPTION
Hi, this PR allows specifying custom discriminator property (if it is `int`(`enum`) or `string`). This is useful when you want strict control over inheritance objects.

```cs
[JsonConverter(typeof(JsonInheritanceConverter), nameof(Type))]
[KnownType(typeof(OneChild))]
[KnownType(typeof(SecondChild))]
public abstract class Base
{
    public abstract EBase Type { get; }
}

public enum EBase
{
    OneChild,
    SecondChild,
}

public class OneChild : Base
{
    public string A { get; }
    public override EBase Type => EBase.OneChild;
}

public class SecondChild : Base
{
    public string B { get; }
    public override EBase Type => EBase.SecondChild;
}
```

Generates:

```ts
export interface Base {
    Type: EBase;
}

export enum EBase {
    OneChild = 0,
    SecondChild = 1,
}

export interface OneChild extends Base {
    A: string;
    Type: EBase; // it will be useful to have EBase.OneChild here, not part of PR
}

export interface SecondChild extends Base {
    B: string;
    Type: EBase; // EBase.SecondChild here
}
```

The TS result is here, type of the Type is manageable in IDocumentProcessor: https://www.typescriptlang.org/play?#code/PTAEHUFMBsGMHsC2lQBd5oBYoCoE8AHSAZVgCcBLA1UABWgEM8BzM+AVwDsATAGiwoBnUENANQAd0gAjQRVSQAUCEmYKsTKGYUAbpGF4OY0BoadYKdJMoL+gzAzIoz3UNEiPOofEVKVqAHSKymAAmkYI7NCuqGqcANag8ABmIjQUXrFOKBJMggBcISGgoAC0oACCoASMFmgY7p7ehCTkVOle4jUMdRLYTqCc8LEZzCZmoNJODPHFZZXVtZYYkAAeRJTInDQS8po+rf40gnjbDKv8LqD2jpbYoACqAEoAMsK7sUmxkGSCc+VVQQuaTwVb1UBrDYULY7PagbgUZLJH6QbYmJAECjuMigZEMVDsJzCFLNXxtajBDIKMjJHooABCDEEKAA3ooSiUDvlQABRRnMgDcigAvsFUexELz+az2RyAPKcSAAYTU0VAAF5QAAGXiykrESAIHgqrGuTUARl1osUVJ+tLqCuVqtcawUPGE0tAbI5lW5glQlE4zCFPq5UqZkACjpN0SF1ttNLpoANRu4MZdqzd3A9Ea9etA9L9AdGIY5Yb5EYCKfgxudceCRv9SUV6dA3Ojzo1eYq3IARL3deXpVGW86rYpG-B3AFoPBmAAKGtO00ASgbNabS-TADEGFjRm3QB3TV22T3QP3By1uRXmVXDTW02ORevOIIp5HZwut87d-ug2uxQ4A0HhkF4iDwAMDAguwNDfG4ZjMOwDDMJA-CwNA6iJNB8B6CIXi9jyqwMIgNT6L2SQ4r24AOKgADkwgAHKQBIvZBCocrfGQuzMvwqHHKgjgKK40h4KATgQToB7fMy6KIDCwhXPBEiQWqoiGISixMKwHA8EEJRAA