### PR TITLE
#915: Adding support to get default value as string literal for System.DateTime

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/ValueGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/ValueGeneratorTests.cs
@@ -64,5 +64,34 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             /// Assert
             Assert.Contains("public int? PageSize { get; set; } = 10;", code);
         }
+
+        [Fact]
+        public async Task When_property_is_string_and_format_is_date_time_then_assign_default_value()
+        {
+            /// Arrange
+            var json = @"{
+                ""type"": ""object"",
+                ""properties"": {
+	                ""dateTime"": {
+		                ""type"": ""string"",
+		                ""format"": ""date-time"",
+		                ""default"": ""31.12.9999 23:59:59""
+	                }
+                }
+            }";
+            var schema = await JsonSchema.FromJsonAsync(json);
+
+            /// Act
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings
+            {
+                ClassStyle = CSharpClassStyle.Poco,
+                SchemaType = SchemaType.Swagger2,
+                DateTimeType = "System.DateTime"
+            });
+            var code = generator.GenerateFile("MyClass");
+
+            /// Assert
+            Assert.Contains("public System.DateTime? DateTime { get; set; } = System.DateTime.Parse(\"31.12.9999 23:59:59\");", code);
+        }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpValueGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpValueGenerator.cs
@@ -50,6 +50,12 @@ namespace NJsonSchema.CodeGeneration.CSharp
                         var stringLiteral = GetDefaultAsStringLiteral(schema);
                         return $"new {targetType}({stringLiteral})";
                     }
+
+                    if (targetType == "System.DateTime" || targetType == "System.DateTime?")
+                    {
+                        var stringLiteral = GetDefaultAsStringLiteral(schema);
+                        return $"System.DateTime.Parse({stringLiteral})";
+                    }
                 }
 
                 var isOptional = (schema as JsonSchemaProperty)?.IsRequired == false;


### PR DESCRIPTION
This would allow to specify default values for DateTime properties.
For example:
```
endDate:
    type: string
    format: date-time
    default: DateTime.MaxValue

endOfYear2019:
    type: string
    format: date-time
    default: new DateTime(2019, 12, 31)
```