### PR TITLE
Ignore case for discriminator

### DIFF
--- a/src/NJsonSchema/Converters/JsonInheritanceConverter.cs
+++ b/src/NJsonSchema/Converters/JsonInheritanceConverter.cs
@@ -163,7 +163,7 @@ namespace NJsonSchema.Converters
                 return null;
             }
 
-            var discriminator = jObject.GetValue(_discriminator).Value<string>();
+            var discriminator = jObject.GetValue(this._discriminator, StringComparison.OrdinalIgnoreCase).Value<string>();
             var subtype = GetDiscriminatorType(jObject, objectType, discriminator);
 
             var objectContract = serializer.ContractResolver.ResolveContract(subtype) as JsonObjectContract;


### PR DESCRIPTION
Currently Json.Net by default allows deserialize both `"foo":1` and `"Foo":1` into `class Root { public int Foo {get;set;} }`, but surprisingly JsonInheritanceConverter - doesn't.

Maybe it worth to add a constructor argument for specifying which StringComparison should it use but I think ignore case by default could be enough.