### PR TITLE
Fix IsDate expression for referenced schema

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
@@ -278,7 +278,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
         public bool IsStringEnum => _property.ActualTypeSchema.IsEnumeration && _property.ActualTypeSchema.Type.HasFlag(JsonObjectType.String);
 
         /// <summary>Gets a value indicating whether the property should be formatted like a date.</summary>
-        public bool IsDate => _property.Format == JsonFormatStrings.Date;
+        public bool IsDate => _property.ActualSchema.Format == JsonFormatStrings.Date;
 
         /// <summary>Gets a value indicating whether the property is deprecated.</summary>
         public bool IsDeprecated => _property.IsDeprecated;


### PR DESCRIPTION
Modified PropertyModel.IsDate expression to respect referenced schema if any by reading Format through JsonSchemaProperty.ActualSchema.

[Fixes #2939](https://github.com/RicoSuter/NSwag/issues/2939)