### PR TITLE
Fixed preservation of BaseTypeName in GenerateTypes

### DIFF
--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/InheritanceTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/InheritanceTests.cs
@@ -319,5 +319,34 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
             //// Assert
             Assert.DoesNotContain("SkillLevel2", code);
         }
+
+
+        [Fact]
+        public async Task When_class_has_baseclass_and_extension_code_baseclass_is_preserved() {
+            //// Arrange
+            string extensionCode = @"
+import * as generated from ""./generated"";
+
+export class ExceptionBase extends generated.ExceptionBase {
+    xyz: boolean; 
+}
+            ";
+
+            var schema = JsonSchema.FromType<ExceptionContainer>();
+            var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings {
+                ExtensionCode = extensionCode,
+                ExtendedClasses = new[] { "ExceptionBase" },
+            });
+
+            //// Act
+            var output = generator.GenerateTypes(schema, null);
+
+            //// Assert
+            var outputArray = output.ToArray();
+            Assert.Equal(4, outputArray.Length);
+
+            Assert.Equal("Exception", outputArray[0].BaseTypeName);
+            Assert.Contains("xyz: boolean", outputArray[0].Code);
+        }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptGenerator.cs
@@ -74,7 +74,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                     if (index != -1)
                     {
                         var code = classCode.Insert(index, extensionCode.GetExtensionClassBody(artifact.TypeName).Trim() + "\n\n    ");
-                        yield return new CodeArtifact(artifact.TypeName, artifact.Type, artifact.Language, artifact.Category, code);
+                        yield return new CodeArtifact(artifact.TypeName, artifact.BaseTypeName, artifact.Type, artifact.Language, artifact.Category, code);
                     }
                     else
                     {
@@ -82,7 +82,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                         index = classCode.IndexOf("{", index, StringComparison.Ordinal) + 1;
 
                         var code = classCode.Insert(index, "\n    " + extensionCode.GetExtensionClassBody(artifact.TypeName).Trim() + "\n");
-                        yield return new CodeArtifact(artifact.TypeName, artifact.Type, artifact.Language, artifact.Category, code);
+                        yield return new CodeArtifact(artifact.TypeName, artifact.BaseTypeName, artifact.Type, artifact.Language, artifact.Category, code);
                     }
                 }
                 else


### PR DESCRIPTION
Changed creation of CodeArtifacts in GenerateTypes so that BaseTypeName is preserved when extension code is present. Fixes Issue #1247.