### PR TITLE
Fix _readTypeProperty jObject.GetValue(_discriminator) returned null.

### DIFF
--- a/src/NJsonSchema/Converters/JsonInheritanceConverter.cs
+++ b/src/NJsonSchema/Converters/JsonInheritanceConverter.cs
@@ -163,7 +163,7 @@ namespace NJsonSchema.Converters
                 return null;
             }
 
-            var discriminator = jObject.GetValue(_discriminator).Value<string>();
+            var discriminator = jObject.GetValue(_discriminator)?.Value<string>();
             var subtype = GetDiscriminatorType(jObject, objectType, discriminator);
 
             var objectContract = serializer.ContractResolver.ResolveContract(subtype) as JsonObjectContract;


### PR DESCRIPTION
Fix _readTypeProperty jObject.GetValue(_discriminator) returned null.