### PR TITLE
Allow any attribute called JsonExtensionDataAttribute to mark property as an extension

### DIFF
--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -752,7 +752,7 @@ namespace NJsonSchema.Generation
             where TSchemaType : JsonSchema, new()
         {
             var extensionDataProperty = type.GetContextualProperties()
-                .FirstOrDefault(p => p.GetContextAttribute<JsonExtensionDataAttribute>() != null);
+                .FirstOrDefault(p => p.ContextAttributes.Any(a => a.GetType().Name == "JsonExtensionDataAttribute"));
 
             if (extensionDataProperty != null)
             {


### PR DESCRIPTION
We're using .NET Core 3.1 and `ProblemDetails` are generated as following:

```csharp

[System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.1.21.0 (Newtonsoft.Json v12.0.0.0)")]
public partial class ProblemDetails 
{
    [Newtonsoft.Json.JsonProperty("type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
    public string Type { get; set; }

    [Newtonsoft.Json.JsonProperty("title", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
    public string Title { get; set; }

    [Newtonsoft.Json.JsonProperty("status", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
    public int? Status { get; set; }

    [Newtonsoft.Json.JsonProperty("detail", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
    public string Detail { get; set; }

    [Newtonsoft.Json.JsonProperty("instance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
    public string Instance { get; set; }

    [Newtonsoft.Json.JsonProperty("extensions", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
    public System.Collections.Generic.IDictionary<string, object> Extensions { get; set; }
}
```

`Extensions` property is not recognized as an extension because .NET Core 3.1 uses `System.Text.Json.Serialization.JsonExtensionDataAttribute` instead of `Newtonsoft.Json.JsonExtensionDataAttribute`.

As a workaround we've created a partial class with the following content:

```csharp
public partial class ProblemDetails
{
    [JsonExtensionData]
    public IDictionary<string, object> AdditionalProperties { get; set; }
}
```