### PR TITLE
Support Array default

### DIFF
--- a/src/NJsonSchema.Tests/Generation/SampleJsonDataGeneratorTests.cs
+++ b/src/NJsonSchema.Tests/Generation/SampleJsonDataGeneratorTests.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json.Linq;
 using NJsonSchema.Generation;
+using System.ComponentModel;
 using Xunit;
 
 namespace NJsonSchema.Tests.Generation
@@ -26,6 +27,12 @@ namespace NJsonSchema.Tests.Generation
         public class Student : Person
         {
             public string Course { get; set; }
+        }
+
+        public class Measurements
+        {
+            [DefaultValue(new int[] {1,2,3})]
+            public int[] Weights;
         }
 
         [Fact]
@@ -64,5 +71,21 @@ namespace NJsonSchema.Tests.Generation
             Assert.NotNull(obj.Property(nameof(Person.MainAddress)));
             Assert.NotNull(obj.Property(nameof(Person.Addresses)));
         }
+
+        [Fact]
+        public void Default_values_are_set_for_arrays()
+        {
+            //// Arrange
+            var schema = JsonSchema.FromType<Measurements>();
+            var generator = new SampleJsonDataGenerator();
+
+            //// Act
+            var token = generator.Generate(schema);
+            var obj = token as JObject;
+
+            //// Assert
+            Assert.Equal(new JArray(new int[] { 1, 2, 3 }), obj.GetValue(nameof(Measurements.Weights)));
+        }
+
     }
 }

--- a/src/NJsonSchema/Generation/SampleJsonDataGenerator.cs
+++ b/src/NJsonSchema/Generation/SampleJsonDataGenerator.cs
@@ -46,6 +46,10 @@ namespace NJsonSchema.Generation
                 }
                 return obj;
             }
+            else if (schema.Default != null)
+            {
+                return JToken.FromObject(schema.Default);
+            }
             else if (schema.Type.HasFlag(JsonObjectType.Array))
             {
                 if (schema.Item != null)
@@ -70,11 +74,7 @@ namespace NJsonSchema.Generation
             }
             else
             {
-                if (schema.Default != null)
-                {
-                    return JToken.FromObject(schema.Default);
-                }
-                else if (schema.IsEnumeration)
+                if (schema.IsEnumeration)
                 {
                     return JToken.FromObject(schema.Enumeration.First());
                 }


### PR DESCRIPTION
When using ToSampleJson() the arrays will be populated with
the default value of the item.
```
{
  "$schema": "http://json-schema.org/draft-04/schema#",
  "title": "Foo",
  "type": "object",
  "additionalProperties": false,
  "properties": {
    "arr": {
      "type": [
        "array",
        "null"
      ],
      "default": [1,2,3],
      "items": {
        "type": "integer",
        "format": "int32"
      }
    }
  }
}
```
Results in:
`{{
  "arr": [
    0
  ]
}}`

This PR will instead populate it by the default if it exists. 
`
{{
  "arr": [
    1,2,3
  ]
}}
`