### PR TITLE
Fix generation of integer in case of min and max

### DIFF
--- a/src/NJsonSchema.Tests/Generation/SampleJsonDataGeneratorTests.cs
+++ b/src/NJsonSchema.Tests/Generation/SampleJsonDataGeneratorTests.cs
@@ -241,5 +241,58 @@ namespace NJsonSchema.Tests.Generation
             Assert.Equal(42, testJson.SelectToken("body.numberContent.value").Value<int>());
         }
 
+        //exclusiveMaximum
+
+        [Fact]
+        public async Task PropertyExclusiveMinimumDefiniton()
+        {
+            //// Arrange
+            var data = @"{
+                ""$schema"": ""http://json-schema.org/draft-04/schema#"",
+                ""title"": ""test schema"",
+                ""type"": ""object"",
+                ""required"": [
+                  ""body""
+                ],
+                ""properties"": {
+                  ""body"": {
+                    ""$ref"": ""#/definitions/body""
+                  }
+                },
+                ""definitions"": {
+                  ""body"": {
+                    ""type"": ""object"",
+                    ""additionalProperties"": false,
+                    ""properties"": {
+                      ""numberContent"": {
+                        ""$ref"": ""#/definitions/numberContent""
+                      }
+                    }
+                  },
+                  ""numberContent"": {
+                    ""type"": ""object"",
+                    ""additionalProperties"": false,
+                    ""properties"": {
+                      ""value"": {
+                        ""type"": ""number"",
+                        ""maximum"": 5.0,
+                        ""minimum"": 1.0,
+                        ""exclusiveMinimum"" : true
+                      }
+                    }
+                  }
+                }
+              }";
+            var generator = new SampleJsonDataGenerator();
+            var schema = await JsonSchema.FromJsonAsync(data);
+            //// Act
+            var testJson = generator.Generate(schema);
+
+            //// Assert
+            var validationResult = schema.Validate(testJson);
+            Assert.NotNull(validationResult);
+            Assert.Equal(0, validationResult.Count);
+            Assert.Equal(1.1, testJson.SelectToken("body.numberContent.value").Value<double>());
+        }
     }
 }

--- a/src/NJsonSchema.Tests/Generation/SampleJsonDataGeneratorTests.cs
+++ b/src/NJsonSchema.Tests/Generation/SampleJsonDataGeneratorTests.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json.Linq;
 using NJsonSchema.Generation;
 using System.ComponentModel;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace NJsonSchema.Tests.Generation
@@ -85,6 +86,109 @@ namespace NJsonSchema.Tests.Generation
 
             //// Assert
             Assert.Equal(new JArray(new int[] { 1, 2, 3 }), obj.GetValue(nameof(Measurements.Weights)));
+        }
+
+        [Fact]
+        public async Task PropertyWithIntegerMinimumDefiniton()
+        {
+            //// Arrange
+            var data = @"{
+                ""$schema"": ""http://json-schema.org/draft-04/schema#"",
+                ""title"": ""test schema"",
+                ""type"": ""object"",
+                ""required"": [
+                  ""body""
+                ],
+                ""properties"": {
+                  ""body"": {
+                    ""$ref"": ""#/definitions/body""
+                  }
+                },
+                ""definitions"": {
+                  ""body"": {
+                    ""type"": ""object"",
+                    ""additionalProperties"": false,
+                    ""properties"": {
+                      ""numberContent"": {
+                        ""$ref"": ""#/definitions/numberContent""
+                      }
+                    }
+                  },
+                  ""numberContent"": {
+                    ""type"": ""object"",
+                    ""additionalProperties"": false,
+                    ""properties"": {
+                      ""value"": {
+                        ""type"": ""integer"",
+                        ""maximum"": 5,
+                        ""minimum"": 1
+                      }
+                    }
+                  }
+                }
+              }";
+            var generator = new SampleJsonDataGenerator();
+            var schema = await JsonSchema.FromJsonAsync(data);
+            //// Act
+            var testJson = generator.Generate(schema);
+
+            //// Assert
+            var validationResult = schema.Validate(testJson);
+            Assert.NotNull(validationResult);
+            Assert.Equal(0, validationResult.Count);
+            Assert.Equal(1, testJson.SelectToken("body.numberContent.value").Value<int>());
+        }
+
+
+        [Fact]
+        public async Task PropertyWithFloatMinimumDefiniton()
+        {
+            //// Arrange
+            var data = @"{
+                ""$schema"": ""http://json-schema.org/draft-04/schema#"",
+                ""title"": ""test schema"",
+                ""type"": ""object"",
+                ""required"": [
+                  ""body""
+                ],
+                ""properties"": {
+                  ""body"": {
+                    ""$ref"": ""#/definitions/body""
+                  }
+                },
+                ""definitions"": {
+                  ""body"": {
+                    ""type"": ""object"",
+                    ""additionalProperties"": false,
+                    ""properties"": {
+                      ""numberContent"": {
+                        ""$ref"": ""#/definitions/numberContent""
+                      }
+                    }
+                  },
+                  ""numberContent"": {
+                    ""type"": ""object"",
+                    ""additionalProperties"": false,
+                    ""properties"": {
+                      ""value"": {
+                        ""type"": ""number"",
+                        ""maximum"": 5.0,
+                        ""minimum"": 1.0
+                      }
+                    }
+                  }
+                }
+              }";
+            var generator = new SampleJsonDataGenerator();
+            var schema = await JsonSchema.FromJsonAsync(data);
+            //// Act
+            var testJson = generator.Generate(schema);
+
+            //// Assert
+            var validationResult = schema.Validate(testJson);
+            Assert.NotNull(validationResult);
+            Assert.Equal(0, validationResult.Count);
+            Assert.Equal(1.0, testJson.SelectToken("body.numberContent.value").Value<float>());
         }
 
     }

--- a/src/NJsonSchema.Tests/Generation/SampleJsonDataGeneratorTests.cs
+++ b/src/NJsonSchema.Tests/Generation/SampleJsonDataGeneratorTests.cs
@@ -191,5 +191,55 @@ namespace NJsonSchema.Tests.Generation
             Assert.Equal(1.0, testJson.SelectToken("body.numberContent.value").Value<float>());
         }
 
+        [Fact]
+        public async Task PropertyWithDefaultDefiniton()
+        {
+            //// Arrange
+            var data = @"{
+                ""$schema"": ""http://json-schema.org/draft-04/schema#"",
+                ""title"": ""test schema"",
+                ""type"": ""object"",
+                ""required"": [
+                  ""body""
+                ],
+                ""properties"": {
+                  ""body"": {
+                    ""$ref"": ""#/definitions/body""
+                  }
+                },
+                ""definitions"": {
+                  ""body"": {
+                    ""type"": ""object"",
+                    ""additionalProperties"": false,
+                    ""properties"": {
+                      ""numberContent"": {
+                        ""$ref"": ""#/definitions/numberContent""
+                      }
+                    }
+                  },
+                  ""numberContent"": {
+                    ""type"": ""object"",
+                    ""additionalProperties"": false,
+                    ""properties"": {
+                      ""value"": {
+                        ""type"": ""number"",
+                        ""default"": 42,
+                      }
+                    }
+                  }
+                }
+              }";
+            var generator = new SampleJsonDataGenerator();
+            var schema = await JsonSchema.FromJsonAsync(data);
+            //// Act
+            var testJson = generator.Generate(schema);
+
+            //// Assert
+            var validationResult = schema.Validate(testJson);
+            Assert.NotNull(validationResult);
+            Assert.Equal(0, validationResult.Count);
+            Assert.Equal(42, testJson.SelectToken("body.numberContent.value").Value<int>());
+        }
+
     }
 }

--- a/src/NJsonSchema/Generation/SampleJsonDataGenerator.cs
+++ b/src/NJsonSchema/Generation/SampleJsonDataGenerator.cs
@@ -78,32 +78,17 @@ namespace NJsonSchema.Generation
                 {
                     return JToken.FromObject(schema.Enumeration.First());
                 }
-                else if (schema.Type.HasFlag(JsonObjectType.Integer) || schema.Type.HasFlag(JsonObjectType.Number))
+                else if (schema.Type.HasFlag(JsonObjectType.Integer))
                 {
-                    if (schema.Minimum.HasValue || schema.Maximum.HasValue)
-                    {
-                        return JToken.FromObject(schema.Minimum.HasValue ? Convert.ToInt32(schema.Minimum) : Convert.ToInt32(schema.Maximum));
-                    }
-                    return JToken.FromObject(0);
+                    return HandleIntegerType(schema);
+                }
+                else if (schema.Type.HasFlag(JsonObjectType.Number))
+                {
+                    return HandleNumberType(schema);
                 }
                 else if (schema.Type.HasFlag(JsonObjectType.String))
                 {
-                    if (schema.Format == JsonFormatStrings.Date)
-                    {
-                        return JToken.FromObject(DateTimeOffset.UtcNow.ToString("yyyy-MM-dd"));
-                    }
-                    else if (schema.Format == JsonFormatStrings.DateTime)
-                    {
-                        return JToken.FromObject(DateTimeOffset.UtcNow.ToString("o"));
-                    }
-                    else if (property != null)
-                    {
-                        return JToken.FromObject(property.Name);
-                    }
-                    else
-                    {
-                        return JToken.FromObject("");
-                    }
+                    return HandleStringType(schema, property);
                 }
                 else if (schema.Type.HasFlag(JsonObjectType.Boolean))
                 {
@@ -112,6 +97,59 @@ namespace NJsonSchema.Generation
             }
 
             return null;
+        }
+        private static JToken HandleNumberType(JsonSchema schema)
+        {
+            if (schema.ExclusiveMinimumRaw != null)
+            {
+                return JToken.FromObject(float.Parse(schema.Minimum.ToString()) + 0.1);
+            }
+            else if (schema.ExclusiveMinimum != null)
+            {
+                return JToken.FromObject(float.Parse(schema.ExclusiveMinimum.ToString()));
+            }
+            else if (schema.Minimum.HasValue)
+            {
+                return float.Parse(schema.Minimum.ToString());
+            }
+            return JToken.FromObject(0.0);
+        }
+
+        private static JToken HandleIntegerType(JsonSchema schema)
+        {
+            if (schema.ExclusiveMinimumRaw != null)
+            {
+                return JToken.FromObject(Convert.ToInt32(schema.ExclusiveMinimumRaw));
+            }
+            else if (schema.ExclusiveMinimum != null)
+            {
+                return JToken.FromObject(Convert.ToInt32(schema.ExclusiveMinimum));
+            }
+            else if (schema.Minimum.HasValue)
+            {
+                return Convert.ToInt32(schema.Minimum);
+            }
+            return JToken.FromObject(0);
+        }
+
+        private JToken HandleStringType(JsonSchema schema, JsonSchemaProperty property)
+        {
+            if (schema.Format == JsonFormatStrings.Date)
+            {
+                return JToken.FromObject(DateTimeOffset.UtcNow.ToString("yyyy-MM-dd"));
+            }
+            else if (schema.Format == JsonFormatStrings.DateTime)
+            {
+                return JToken.FromObject(DateTimeOffset.UtcNow.ToString("o"));
+            }
+            else if (property != null)
+            {
+                return JToken.FromObject(property.Name);
+            }
+            else
+            {
+                return JToken.FromObject("");
+            }
         }
     }
 }

--- a/src/NJsonSchema/Generation/SampleJsonDataGenerator.cs
+++ b/src/NJsonSchema/Generation/SampleJsonDataGenerator.cs
@@ -80,6 +80,10 @@ namespace NJsonSchema.Generation
                 }
                 else if (schema.Type.HasFlag(JsonObjectType.Integer) || schema.Type.HasFlag(JsonObjectType.Number))
                 {
+                    if (schema.Minimum.HasValue || schema.Maximum.HasValue)
+                    {
+                        return JToken.FromObject(schema.Minimum.HasValue ? Convert.ToInt32(schema.Minimum) : Convert.ToInt32(schema.Maximum));
+                    }
                     return JToken.FromObject(0);
                 }
                 else if (schema.Type.HasFlag(JsonObjectType.String))


### PR DESCRIPTION
this pr fix the issue of generating sample json data of a given json schema with minimum and maximum of integer values. 
- added unit tests for integer type 
- added unit test for number type 
- add unit test in case default value is set