### PR TITLE
support cancellation token for async methods without breaking change

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/ValidationAttributesTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/ValidationAttributesTests.cs
@@ -269,8 +269,8 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             Assert.Null(schema.Properties["value"].Minimum);
             Assert.Equal(-100000000m, schema.Properties["value"].ActualSchema.Minimum);
             Assert.Equal(100000000m, schema.Properties["value"].ActualSchema.Maximum);
-            Assert.Equal(true, schema.Properties["value"].ActualSchema.IsExclusiveMaximum);
-            Assert.Equal(true, schema.Properties["value"].ActualSchema.IsExclusiveMinimum);
+            Assert.True(schema.Properties["value"].ActualSchema.IsExclusiveMaximum);
+            Assert.True(schema.Properties["value"].ActualSchema.IsExclusiveMinimum);
 
             // expect the integer to be converted to an int64
             Assert.Contains("[System.ComponentModel.DataAnnotations.Range(-99999999, 99999999)]\n" +
@@ -314,8 +314,8 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             Assert.Null(schema.Properties["value"].Minimum);
             Assert.Equal(-100000000.5m, schema.Properties["value"].ActualSchema.Minimum);
             Assert.Equal(100000000.5m, schema.Properties["value"].ActualSchema.Maximum);
-            Assert.Equal(true, schema.Properties["value"].ActualSchema.IsExclusiveMaximum);
-            Assert.Equal(true, schema.Properties["value"].ActualSchema.IsExclusiveMinimum);
+            Assert.True(schema.Properties["value"].ActualSchema.IsExclusiveMaximum);
+            Assert.True(schema.Properties["value"].ActualSchema.IsExclusiveMinimum);
 
             // expect the integer to be converted to an int64
             Assert.Contains("[System.ComponentModel.DataAnnotations.Range(-100000000.4999D, 100000000.4999D)]\n" +

--- a/src/NJsonSchema.Tests/Generation/AttributeGenerationTests.cs
+++ b/src/NJsonSchema.Tests/Generation/AttributeGenerationTests.cs
@@ -67,7 +67,7 @@ namespace NJsonSchema.Tests.Generation
 
             //// Assert
             Assert.Equal(5.5m, property.Minimum);
-            Assert.Equal(null, property.Maximum);
+            Assert.Null(property.Maximum);
         }
 
         [Fact]

--- a/src/NJsonSchema.Tests/Generation/SchemaGenerationTests.cs
+++ b/src/NJsonSchema.Tests/Generation/SchemaGenerationTests.cs
@@ -32,7 +32,7 @@ namespace NJsonSchema.Tests.Generation
             var schemaData = schema.ToJson();
 
             //// Assert
-            Assert.Equal(false, schema.Properties["Bar"].ActualTypeSchema.AllowAdditionalProperties);
+            Assert.False(schema.Properties["Bar"].ActualTypeSchema.AllowAdditionalProperties);
         }
 
         [Fact]
@@ -59,7 +59,7 @@ namespace NJsonSchema.Tests.Generation
             var schemaData = schema.ToJson();
 
             //// Assert
-            Assert.Equal(true, schema.Properties["Dictionary"].ActualSchema.AllowAdditionalProperties);
+            Assert.True(schema.Properties["Dictionary"].ActualSchema.AllowAdditionalProperties);
             Assert.Equal(JsonObjectType.String, schema.Properties["Dictionary"].ActualSchema.AdditionalPropertiesSchema.ActualSchema.Type);
             // "#/definitions/ref_7de8187d_d860_41fa_a17b_3f395c053cae"
         }
@@ -86,13 +86,13 @@ namespace NJsonSchema.Tests.Generation
         [Fact]
         public async Task When_default_value_is_set_on_property_then_default_is_set_in_schema()
         {
-            //// Arrange
+            // Arrange
             var schema = JsonSchema.FromType<DefaultTests>();
 
-            //// Act
+            // Act
             var property = schema.Properties["Number"];
 
-            //// Assert
+            // Assert
             Assert.Equal(10, property.Default);
         }
 
@@ -104,7 +104,7 @@ namespace NJsonSchema.Tests.Generation
         [Fact]
         public async Task When_dictionary_value_is_null_then_string_values_are_allowed()
         {
-            //// Arrange
+            // Arrange
             var schema = JsonSchema.FromType<DictTest>();
             var schemaData = schema.ToJson();
 
@@ -114,21 +114,21 @@ namespace NJsonSchema.Tests.Generation
                 }
             }";
 
-            //// Act
+            // Act
             var errors = schema.Validate(data);
 
-            //// Assert
+            // Assert
             Assert.Equal(0, errors.Count);
         }
 
         [Fact]
         public async Task When_type_is_enumerable_it_should_not_stackoverflow_on_JSON_generation()
         {
-            //// Generate JSON
+            // Generate JSON
             var schema = JsonSchema.FromType<IEnumerable<Tuple<string, string>>>();
             var json = schema.ToJson();
 
-            //// Should be reached and not StackOverflowed
+            // Should be reached and not StackOverflowed
             Assert.True(!string.IsNullOrEmpty(json));
         }
 
@@ -142,11 +142,11 @@ namespace NJsonSchema.Tests.Generation
         [Fact]
         public async Task When_property_is_object_then_it_should_not_be_a_dictonary_but_any()
         {
-            /// Act
+            // Act
             var schema = JsonSchema.FromType<FilterDto>();
             var json = schema.ToJson();
 
-            /// Assert
+            // Assert
             var property = schema.Properties["Value"].ActualTypeSchema;
             Assert.True(property.IsAnyType);
             Assert.False(property.IsDictionary);
@@ -162,11 +162,11 @@ namespace NJsonSchema.Tests.Generation
         [Fact]
         public async Task When_property_is_static_then_it_is_ignored()
         {
-            /// Act
+            // Act
             var schema = JsonSchema.FromType<ClassWithStaticProperty>();
             var json = schema.ToJson();
 
-            /// Assert
+            // Assert
             Assert.Equal(1, schema.ActualProperties.Count);
             Assert.True(schema.ActualProperties.ContainsKey("Bar"));
         }

--- a/src/NJsonSchema.Yaml/JsonAndYamlReferenceResolver.cs
+++ b/src/NJsonSchema.Yaml/JsonAndYamlReferenceResolver.cs
@@ -7,8 +7,8 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
-using NJsonSchema.Generation;
 using NJsonSchema.References;
 
 namespace NJsonSchema.Yaml
@@ -38,7 +38,7 @@ namespace NJsonSchema.Yaml
         /// <param name="filePath">The file path.</param>
         /// <returns>The resolved JSON Schema.</returns>
         /// <exception cref="NotSupportedException">The System.IO.File API is not available on this platform.</exception>
-        public override async Task<IJsonReference> ResolveFileReferenceAsync(string filePath)
+        public override async Task<IJsonReference> ResolveFileReferenceAsync(string filePath, CancellationToken cancellationToken = default)
         {
             return await JsonSchemaYaml.FromFileAsync(filePath, schema => this).ConfigureAwait(false);
         }
@@ -46,9 +46,9 @@ namespace NJsonSchema.Yaml
         /// <summary>Resolves an URL reference.</summary>
         /// <param name="url">The URL.</param>
         /// <exception cref="NotSupportedException">The HttpClient.GetAsync API is not available on this platform.</exception>
-        public override async Task<IJsonReference> ResolveUrlReferenceAsync(string url)
+        public override async Task<IJsonReference> ResolveUrlReferenceAsync(string url, CancellationToken cancellationToken = default)
         {
-            return await JsonSchemaYaml.FromUrlAsync(url, schema => this).ConfigureAwait(false);
+            return await JsonSchemaYaml.FromUrlAsync(url, schema => this, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/NJsonSchema.Yaml/JsonSchemaYaml.cs
+++ b/src/NJsonSchema.Yaml/JsonSchemaYaml.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Dynamic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -44,7 +45,7 @@ namespace NJsonSchema.Yaml
         /// <param name="documentPath">The document path (URL or file path) for resolving relative document references.</param>
         /// <param name="referenceResolverFactory">The JSON reference resolver factory.</param>
         /// <returns>The JSON Schema.</returns>
-        public static async Task<JsonSchema> FromYamlAsync(string data, string documentPath, Func<JsonSchema, JsonReferenceResolver> referenceResolverFactory)
+        public static async Task<JsonSchema> FromYamlAsync(string data, string documentPath, Func<JsonSchema, JsonReferenceResolver> referenceResolverFactory, CancellationToken cancellationToken = default)
         {
             var deserializer = new DeserializerBuilder().Build();
             var yamlObject = deserializer.Deserialize(new StringReader(data));
@@ -53,7 +54,7 @@ namespace NJsonSchema.Yaml
                 .Build();
 
             var json = serializer.Serialize(yamlObject);
-            return await JsonSchema.FromJsonAsync(json, documentPath, referenceResolverFactory).ConfigureAwait(false);
+            return await JsonSchema.FromJsonAsync(json, documentPath, referenceResolverFactory, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>Converts the JSON Schema to YAML.</summary>
@@ -81,7 +82,7 @@ namespace NJsonSchema.Yaml
         /// <param name="filePath">The file path.</param>
         /// <param name="referenceResolverFactory">The JSON reference resolver factory.</param>
         /// <returns>The <see cref="JsonSchema" />.</returns>
-        public static async Task<JsonSchema> FromFileAsync(string filePath, Func<JsonSchema, JsonReferenceResolver> referenceResolverFactory)
+        public static async Task<JsonSchema> FromFileAsync(string filePath, Func<JsonSchema, JsonReferenceResolver> referenceResolverFactory, CancellationToken cancellationToken = default)
         {
             var data = DynamicApis.FileReadAllText(filePath);
             return await FromYamlAsync(data, filePath, referenceResolverFactory).ConfigureAwait(false);
@@ -91,10 +92,10 @@ namespace NJsonSchema.Yaml
         /// <param name="url">The URL.</param>
         /// <param name="referenceResolverFactory">The JSON reference resolver factory.</param>
         /// <returns>The <see cref="JsonSchema"/>.</returns>
-        public static async Task<JsonSchema> FromUrlAsync(string url, Func<JsonSchema, JsonReferenceResolver> referenceResolverFactory)
+        public static async Task<JsonSchema> FromUrlAsync(string url, Func<JsonSchema, JsonReferenceResolver> referenceResolverFactory, CancellationToken cancellationToken = default)
         {
             var data = await DynamicApis.HttpGetAsync(url).ConfigureAwait(false);
-            return await FromYamlAsync(data, url, referenceResolverFactory).ConfigureAwait(false);
+            return await FromYamlAsync(data, url, referenceResolverFactory, cancellationToken).ConfigureAwait(false);
         }
 
         private static string ConvertYamlToJson(string data)

--- a/src/NJsonSchema/Infrastructure/JsonSchemaSerialization.cs
+++ b/src/NJsonSchema/Infrastructure/JsonSchemaSerialization.cs
@@ -8,6 +8,7 @@
 
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -81,10 +82,12 @@ namespace NJsonSchema.Infrastructure
         /// <param name="documentPath">The document path.</param>
         /// <param name="referenceResolverFactory">The reference resolver factory.</param>
         /// <param name="contractResolver">The contract resolver.</param>
+        /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>The deserialized schema.</returns>
         public static async Task<T> FromJsonAsync<T>(string json, SchemaType schemaType, string documentPath,
-            Func<T, JsonReferenceResolver> referenceResolverFactory, IContractResolver contractResolver)
+            Func<T, JsonReferenceResolver> referenceResolverFactory, IContractResolver contractResolver, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             CurrentSchemaType = schemaType;
 
             var schema = FromJson<T>(json, contractResolver);

--- a/src/NJsonSchema/Infrastructure/JsonSchemaSerialization.cs
+++ b/src/NJsonSchema/Infrastructure/JsonSchemaSerialization.cs
@@ -82,10 +82,24 @@ namespace NJsonSchema.Infrastructure
         /// <param name="documentPath">The document path.</param>
         /// <param name="referenceResolverFactory">The reference resolver factory.</param>
         /// <param name="contractResolver">The contract resolver.</param>
+        /// <returns>The deserialized schema.</returns>
+        [Obsolete("Use FromJsonAsync with cancellation token instead")]
+        public static async Task<T> FromJsonAsync<T>(string json, SchemaType schemaType, string documentPath,
+            Func<T, JsonReferenceResolver> referenceResolverFactory, IContractResolver contractResolver)
+        {
+            return await FromJsonAsync(json, schemaType, documentPath, referenceResolverFactory, contractResolver, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>Deserializes JSON data to a schema with reference handling.</summary>
+        /// <param name="json">The JSON data.</param>
+        /// <param name="schemaType">The schema type.</param>
+        /// <param name="documentPath">The document path.</param>
+        /// <param name="referenceResolverFactory">The reference resolver factory.</param>
+        /// <param name="contractResolver">The contract resolver.</param>
         /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>The deserialized schema.</returns>
         public static async Task<T> FromJsonAsync<T>(string json, SchemaType schemaType, string documentPath,
-            Func<T, JsonReferenceResolver> referenceResolverFactory, IContractResolver contractResolver, CancellationToken cancellationToken = default)
+        Func<T, JsonReferenceResolver> referenceResolverFactory, IContractResolver contractResolver, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             CurrentSchemaType = schemaType;

--- a/src/NJsonSchema/JsonSchema.cs
+++ b/src/NJsonSchema/JsonSchema.cs
@@ -12,6 +12,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Namotion.Reflection;
 using Newtonsoft.Json;
@@ -134,71 +135,79 @@ namespace NJsonSchema
 
         /// <summary>Loads a JSON Schema from a given file path (only available in .NET 4.x).</summary>
         /// <param name="filePath">The file path.</param>
+        /// <param name="cancellationToken">Cancellation token instance</param>
         /// <returns>The JSON Schema.</returns>
-        public static async Task<JsonSchema> FromFileAsync(string filePath)
+        public static async Task<JsonSchema> FromFileAsync(string filePath, CancellationToken cancellationToken = default)
         {
             var factory = JsonReferenceResolver.CreateJsonReferenceResolverFactory(new DefaultTypeNameGenerator());
-            return await FromFileAsync(filePath, factory).ConfigureAwait(false);
+            return await FromFileAsync(filePath, factory, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>Loads a JSON Schema from a given file path (only available in .NET 4.x).</summary>
         /// <param name="filePath">The file path.</param>
         /// <param name="referenceResolverFactory">The JSON reference resolver factory.</param>
+        /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>The JSON Schema.</returns>
         /// <exception cref="NotSupportedException">The System.IO.File API is not available on this platform.</exception>
-        public static async Task<JsonSchema> FromFileAsync(string filePath, Func<JsonSchema, JsonReferenceResolver> referenceResolverFactory)
+        public static async Task<JsonSchema> FromFileAsync(string filePath, Func<JsonSchema, JsonReferenceResolver> referenceResolverFactory, CancellationToken cancellationToken = default)
         {
             var data = DynamicApis.FileReadAllText(filePath);
-            return await FromJsonAsync(data, filePath, referenceResolverFactory).ConfigureAwait(false);
+            return await FromJsonAsync(data, filePath, referenceResolverFactory, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>Loads a JSON Schema from a given URL (only available in .NET 4.x).</summary>
         /// <param name="url">The URL to the document.</param>
+        /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>The JSON Schema.</returns>
         /// <exception cref="NotSupportedException">The HttpClient.GetAsync API is not available on this platform.</exception>
-        public static async Task<JsonSchema> FromUrlAsync(string url)
+        public static async Task<JsonSchema> FromUrlAsync(string url, CancellationToken cancellationToken = default)
         {
             var factory = JsonReferenceResolver.CreateJsonReferenceResolverFactory(new DefaultTypeNameGenerator());
-            return await FromUrlAsync(url, factory).ConfigureAwait(false);
+            return await FromUrlAsync(url, factory, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>Loads a JSON Schema from a given URL (only available in .NET 4.x).</summary>
         /// <param name="url">The URL to the document.</param>
         /// <param name="referenceResolverFactory">The JSON reference resolver factory.</param>
+        /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>The JSON Schema.</returns>
         /// <exception cref="NotSupportedException">The HttpClient.GetAsync API is not available on this platform.</exception>
-        public static async Task<JsonSchema> FromUrlAsync(string url, Func<JsonSchema, JsonReferenceResolver> referenceResolverFactory)
+        public static async Task<JsonSchema> FromUrlAsync(string url, Func<JsonSchema, JsonReferenceResolver> referenceResolverFactory, CancellationToken cancellationToken = default)
         {
-            var data = await DynamicApis.HttpGetAsync(url).ConfigureAwait(false);
-            return await FromJsonAsync(data, url, referenceResolverFactory).ConfigureAwait(false);
+            var data = await DynamicApis.HttpGetAsync(url).ConfigureAwait(false); 
+            return await FromJsonAsync(data, url, referenceResolverFactory,cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>Deserializes a JSON string to a <see cref="JsonSchema"/>. </summary>
         /// <param name="data">The JSON string. </param>
+        /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>The JSON Schema.</returns>
-        public static async Task<JsonSchema> FromJsonAsync(string data)
+        public static async Task<JsonSchema> FromJsonAsync(string data, CancellationToken cancellationToken = default)
         {
-            return await FromJsonAsync(data, null).ConfigureAwait(false);
+            return await FromJsonAsync(data, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>Deserializes a JSON string to a <see cref="JsonSchema"/>. </summary>
         /// <param name="data">The JSON string. </param>
         /// <param name="documentPath">The document path (URL or file path) for resolving relative document references.</param>
+        /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>The JSON Schema.</returns>
-        public static async Task<JsonSchema> FromJsonAsync(string data, string documentPath)
+        public static async Task<JsonSchema> FromJsonAsync(string data, string documentPath, CancellationToken cancellationToken = default)
         {
             var factory = JsonReferenceResolver.CreateJsonReferenceResolverFactory(new DefaultTypeNameGenerator());
-            return await FromJsonAsync(data, documentPath, factory).ConfigureAwait(false);
+            return await FromJsonAsync(data, documentPath, factory, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>Deserializes a JSON string to a <see cref="JsonSchema" />.</summary>
         /// <param name="data">The JSON string.</param>
         /// <param name="documentPath">The document path (URL or file path) for resolving relative document references.</param>
         /// <param name="referenceResolverFactory">The JSON reference resolver factory.</param>
+        /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>The JSON Schema.</returns>
-        public static async Task<JsonSchema> FromJsonAsync(string data, string documentPath, Func<JsonSchema, JsonReferenceResolver> referenceResolverFactory)
+        public static async Task<JsonSchema> FromJsonAsync(string data, string documentPath, Func<JsonSchema, 
+            JsonReferenceResolver> referenceResolverFactory, CancellationToken cancellationToken = default)
         {
-            return await JsonSchemaSerialization.FromJsonAsync(data, SerializationSchemaType, documentPath, referenceResolverFactory, ContractResolver.Value).ConfigureAwait(false);
+            return await JsonSchemaSerialization.FromJsonAsync(data, SerializationSchemaType, documentPath, referenceResolverFactory, ContractResolver.Value, cancellationToken).ConfigureAwait(false);
         }
 
         internal static JsonSchema FromJsonWithCurrentSettings(object obj)

--- a/src/NJsonSchema/Visitors/AsyncJsonSchemaVisitorBase.cs
+++ b/src/NJsonSchema/Visitors/AsyncJsonSchemaVisitorBase.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Threading;
 using System.Threading.Tasks;
 using NJsonSchema.References;
 
@@ -18,19 +19,21 @@ namespace NJsonSchema.Visitors
         /// <param name="schema">The visited schema.</param>
         /// <param name="path">The path.</param>
         /// <param name="typeNameHint">The type name hint.</param>
+        /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>The task.</returns>
-        protected abstract Task<JsonSchema> VisitSchemaAsync(JsonSchema schema, string path, string typeNameHint);
+        protected abstract Task<JsonSchema> VisitSchemaAsync(JsonSchema schema, string path, string typeNameHint, CancellationToken cancellationToken);
 
         /// <summary>Called when a <see cref="IJsonReference"/> is visited.</summary>
         /// <param name="reference">The visited schema.</param>
         /// <param name="path">The path.</param>
         /// <param name="typeNameHint">The type name hint.</param>
+        /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>The task.</returns>
-        protected override async Task<IJsonReference> VisitJsonReferenceAsync(IJsonReference reference, string path, string typeNameHint)
+        protected override async Task<IJsonReference> VisitJsonReferenceAsync(IJsonReference reference, string path, string typeNameHint, CancellationToken cancellationToken)
         {
             if (reference is JsonSchema schema)
             {
-                return await VisitSchemaAsync(schema, path, typeNameHint).ConfigureAwait(false);
+                return await VisitSchemaAsync(schema, path, typeNameHint, cancellationToken).ConfigureAwait(false);
             }
 
             return reference;


### PR DESCRIPTION
- add Cancellation token support with default cancellation token to do not have breaking change 
- Fix warnings inside of unit test asserts 
- remove / for comments to fix warnings
- tag methods without cancellation token as obsolete  
#1273 
