### PR TITLE
fix(NJsonSchema.CodeGeneration.TypeScript): add explicit '| null' in createInstance return type

### DIFF
--- a/src/NJsonSchema.CodeGeneration.TypeScript/Templates/Class.liquid
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Templates/Class.liquid
@@ -93,7 +93,7 @@
 {% endif -%}
     }
 
-    static fromJS(data: any{% if HandleReferences %}, _mappings?: any{% endif %}): {{ ClassName }} {
+    static fromJS(data: any{% if HandleReferences %}, _mappings?: any{% endif %}): {{ ClassName }}{% if HandleReferences %} | null{% endif %} {
         data = typeof data === 'object' ? data : {};
 {% if HandleReferences -%}
 {%   if HasBaseDiscriminator -%}

--- a/src/NJsonSchema.CodeGeneration.TypeScript/Templates/File.ReferenceHandling.liquid
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Templates/File.ReferenceHandling.liquid
@@ -41,7 +41,7 @@
     return json;
 }
 
-function createInstance<T>(data: any, mappings: any, type: any): T {
+function createInstance<T>(data: any, mappings: any, type: any): T | null {
   if (!mappings)
     mappings = [];
   if (!data)

--- a/src/NJsonSchema.CodeGeneration.TypeScript/Templates/KnockoutClass.liquid
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Templates/KnockoutClass.liquid
@@ -37,7 +37,7 @@
         }
     }
 
-    static fromJS(data: any{% if HandleReferences %}, _mappings?: any{% endif %}): {{ ClassName }} {
+    static fromJS(data: any{% if HandleReferences %}, _mappings?: any{% endif %}): {{ ClassName }}{% if HandleReferences %} | null{% endif %} {
 {% if HandleReferences -%}
 {%   if HasBaseDiscriminator -%}
 {%     for derivedClass in DerivedClasses -%}


### PR DESCRIPTION
When compiling the generated TypeScript code with strict null checking enabled, the return type of `createInstance` is highlighted as an error as its return type is `T` even though `null` can be returned.

This PR adds `| null` to the return type.