### PR TITLE
Do correct luxon Duration deserialization

### DIFF
--- a/src/NJsonSchema.CodeGeneration.TypeScript/DataConversionGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/DataConversionGenerator.cs
@@ -118,6 +118,10 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                     return "";
 
                 case TypeScriptDateTimeType.Luxon:
+                    if (typeSchema.Format == JsonFormatStrings.TimeSpan)
+                    {
+                        return "Duration.fromISO";
+                    }
                     return "DateTime.fromISO";
 
                 case TypeScriptDateTimeType.DayJS:


### PR DESCRIPTION
Luxon's `DateTime.fromISO` does not parse ISO8601 Duration strings:

![image](https://user-images.githubusercontent.com/2920951/107982678-7c860b80-6f92-11eb-8838-b62ad96d1c90.png)
