### PR TITLE
Add schema title property to ClassTemplateModelBase

### DIFF
--- a/src/NJsonSchema.CodeGeneration/Models/ClassTemplateModelBase.cs
+++ b/src/NJsonSchema.CodeGeneration/Models/ClassTemplateModelBase.cs
@@ -37,7 +37,7 @@ namespace NJsonSchema.CodeGeneration.Models
         /// <summary>
         /// Gets the original title of the class (schema title).
         /// </summary>
-        public virtual string SchemaTitle { get; }
+        public string SchemaTitle { get; }
 
         /// <summary>Gets a value indicating whether this class represents a JSON object with fixed amount of properties.</summary>
         public bool IsObject => _schema.ActualTypeSchema.IsObject;

--- a/src/NJsonSchema.CodeGeneration/Models/ClassTemplateModelBase.cs
+++ b/src/NJsonSchema.CodeGeneration/Models/ClassTemplateModelBase.cs
@@ -27,10 +27,17 @@ namespace NJsonSchema.CodeGeneration.Models
             _schema = schema;
             _rootObject = rootObject;
             _resolver = resolver;
+
+            SchemaTitle = _schema?.Title;
         }
 
         /// <summary>Gets the class.</summary>
         public abstract string ClassName { get; }
+        
+        /// <summary>
+        /// Gets the original title of the class (schema title).
+        /// </summary>
+        public virtual string SchemaTitle { get; }
 
         /// <summary>Gets a value indicating whether this class represents a JSON object with fixed amount of properties.</summary>
         public bool IsObject => _schema.ActualTypeSchema.IsObject;


### PR DESCRIPTION
I added a property "SchemaTitle" to ClassTemplateModelBase. The reason is that the "ClassName" is not the original one from the swagger file any more (at least the first character is always capitalized). We need the original unchanged title from the Swagger file in the class.liquid file so that we can add a custom attribute with it to the resulting code file on generation.