### PR TITLE
Fixed typo in template for Text.Json.Serialization.JsonPropertyName

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
@@ -49,7 +49,7 @@
     /// <summary>{{ property.Description | csharpdocs }}</summary>
 {%   endif -%}
 {% if UseSystemTextJson -%}
-    [System.Text.Json.Serialization.JsonPropertyName("{{ property.Name }}"]
+    [System.Text.Json.Serialization.JsonPropertyName("{{ property.Name }}")]
 {%   if property.IsStringEnumArray -%}
     // TODO(system.text.json): Add string enum item converter
 {%   endif -%}


### PR DESCRIPTION
Just a small fix of typo, introduced by [this](https://github.com/RicoSuter/NJsonSchema/commit/19a01a0d38e1a919f658f50229a0a28c6c316897) commit, that leads to code like `[System.Text.Json.Serialization.JsonPropertyName("type"]` and compilation errors.
