### PR TITLE
Fix System.Text.Json.Serialization.JsonStringEnumConverter parameter for System.Text.Json.Serialization.JsonConverter

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
@@ -76,7 +76,7 @@
 {%   endif -%}
 {%   if property.IsStringEnum -%}
 {%     if UseSystemTextJson -%}
-    [System.Text.Json.Serialization.JsonConverter(System.Text.Json.Serialization.JsonStringEnumConverter)]
+    [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
 {%     else -%}
     [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
 {%     endif -%}
@@ -98,11 +98,11 @@
         get { return {{ property.FieldName }}; }
 {%     if property.HasSetter -%}
 {%         if RenderInpc -%}
-        {{PropertySetterAccessModifier}}set 
+        {{PropertySetterAccessModifier}}set
         {
             if ({{ property.FieldName }} != value)
             {
-                {{ property.FieldName }} = value; 
+                {{ property.FieldName }} = value;
                 RaisePropertyChanged();
             }
         }


### PR DESCRIPTION
Small fix: from `[System.Text.Json.Serialization.JsonConverter(System.Text.Json.Serialization.JsonStringEnumConverter)]` to `[System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]`