### PR TITLE
root element of external schema ref files cannot be same name as any property of JsonSchema

### DIFF
--- a/src/NJsonSchema.Yaml.Tests/NJsonSchema.Yaml.Tests.csproj
+++ b/src/NJsonSchema.Yaml.Tests/NJsonSchema.Yaml.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <PropertyGroup>
       <DocumentationFile>bin\Debug\$(TargetFramework)\NJsonSchema.Yaml.Tests.xml</DocumentationFile>
-  </PropertyGroup>  
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NSwag.Core.Yaml" Version="13.10.2" />
@@ -35,6 +35,9 @@
     </Content>  
     <Content Include="References\YamlReferencesTest\json_schema_with_json_reference.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>  
+    <Content Include="References\YamlReferencesTest\schema_with_indirect_subreference_to_title.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="References\YamlReferencesTest\yaml_schema_with_json_reference.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -54,6 +57,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="References\YamlReferencesTest\common-items\schemas.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="References\YamlReferencesTest\schema_named_title.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="References\YamlReferencesTest\yaml_spec_with_yaml_schema_refs.yaml">

--- a/src/NJsonSchema.Yaml.Tests/References/YamlReferencesTest/schema_named_title.yaml
+++ b/src/NJsonSchema.Yaml.Tests/References/YamlReferencesTest/schema_named_title.yaml
@@ -1,0 +1,3 @@
+﻿---
+Title:
+  type: object

--- a/src/NJsonSchema.Yaml.Tests/References/YamlReferencesTest/schema_with_indirect_subreference_to_title.yaml
+++ b/src/NJsonSchema.Yaml.Tests/References/YamlReferencesTest/schema_with_indirect_subreference_to_title.yaml
@@ -1,0 +1,4 @@
+type: object
+properties:
+  titleProperty:
+    $ref: 'schema_named_title.yaml#/Title'

--- a/src/NJsonSchema.Yaml.Tests/References/YamlReferencesTests.cs
+++ b/src/NJsonSchema.Yaml.Tests/References/YamlReferencesTests.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using NSwag;
 using System.Threading.Tasks;
 using Xunit;
+using Newtonsoft.Json;
 
 namespace NJsonSchema.Yaml.Tests.References
 {
@@ -60,6 +61,21 @@ namespace NJsonSchema.Yaml.Tests.References
             Assert.True(Unauthorized.Content.ContainsKey(problemType));
             Assert.NotNull(Unauthorized.Content[problemType]);
             Assert.NotNull(Unauthorized.Schema);
+        }
+
+        [Fact]
+        public async Task When_document_has_indirect_external_ref_to_a_schema_named_title_then_it_is_loaded()
+        {
+            //// Arrange
+            var path = GetTestDirectory() + "/References/YamlReferencesTest/schema_with_indirect_subreference_to_title.yaml";
+
+            //// Act
+            var schema = await JsonSchemaYaml.FromFileAsync(path);
+            var json = schema.ToJson();
+
+            //// Assert
+            Assert.Equal(1, schema.Definitions.Count);
+            Assert.True(schema.Definitions.ContainsKey("Title"));
         }
 
         private string GetTestDirectory()


### PR DESCRIPTION
No solution, just a failing test case to reproduce the problem.