### PR TITLE
Cleanup CSharpJsonSerializerGenerator

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/CSharpJsonSerializerGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/CSharpJsonSerializerGeneratorTests.cs
@@ -6,14 +6,13 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
     public class CSharpJsonSerializerGeneratorTests
     {
         [Fact]
-        public void When_using_SytemTextJson_with_JsonConverters_GenerateJsonSerializerParameterCode_generates_correctly()
+        public void When_using_SytemTextJson_GenerateJsonSerializerParameterCode_generates_correctly()
         {
             //// Arrange
             var additionalJsonConverters = new string[] { "AdditionalConverter1", "AdditionalConverter2" };
             var settings = new CSharpGeneratorSettings
             {
-                JsonLibrary = CSharpJsonLibrary.SystemTextJson,
-                JsonConverters = new string[] { "CustomConverter1", "CustomConverter2" }
+                JsonLibrary = CSharpJsonLibrary.SystemTextJson
             };
 
             //// Act
@@ -21,7 +20,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             Console.WriteLine(output);
 
             //// Assert
-            Assert.Equal(", new System.Text.Json.JsonSerializerOptions(); var converters = new System.Text.Json.Serialization.JsonConverter[] { new CustomConverter1(), new CustomConverter2(), new AdditionalConverter1(), new AdditionalConverter2() }", output);
+            Assert.Equal("new System.Text.Json.JsonSerializerOptions()", output);
         }
 
         [Fact]
@@ -40,7 +39,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             Console.WriteLine(output);
 
             //// Assert
-            Assert.Equal(", new Newtonsoft.Json.JsonConverter[] { new CustomConverter1(), new CustomConverter2(), new AdditionalConverter1(), new AdditionalConverter2() }", output);
+            Assert.Equal("new Newtonsoft.Json.JsonConverter[] { new CustomConverter1(), new CustomConverter2(), new AdditionalConverter1(), new AdditionalConverter2() }", output);
         }
 
         [Fact]
@@ -58,7 +57,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             Console.WriteLine(output);
 
             //// Assert
-            Assert.Equal(", TestJsonSerializerSettingsTransformationMethod(new System.Text.Json.JsonSerializerOptions())", output);
+            Assert.Equal("TestJsonSerializerSettingsTransformationMethod(new System.Text.Json.JsonSerializerOptions())", output);
         }
 
         [Fact]
@@ -79,7 +78,45 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             Console.WriteLine(output);
 
             //// Assert
-            Assert.Equal(", TestJsonSerializerSettingsTransformationMethod(new Newtonsoft.Json.JsonSerializerSettings { PreserveReferencesHandling = Newtonsoft.Json.PreserveReferencesHandling.All, Converters = new Newtonsoft.Json.JsonConverter[] { new CustomConverter1(), new CustomConverter2(), new AdditionalConverter1(), new AdditionalConverter2() } })", output);
+            Assert.Equal("TestJsonSerializerSettingsTransformationMethod(new Newtonsoft.Json.JsonSerializerSettings { PreserveReferencesHandling = Newtonsoft.Json.PreserveReferencesHandling.All, Converters = new Newtonsoft.Json.JsonConverter[] { new CustomConverter1(), new CustomConverter2(), new AdditionalConverter1(), new AdditionalConverter2() } })", output);
+        }
+
+        [Fact]
+        public void When_using_SytemTextJson_with_JsonConverters_GenerateJsonConvertersArrayCode_generates_correctly()
+        {
+            //// Arrange
+            var additionalJsonConverters = new string[] { "AdditionalConverter1", "AdditionalConverter2" };
+            var settings = new CSharpGeneratorSettings
+            {
+                JsonLibrary = CSharpJsonLibrary.SystemTextJson,
+                JsonConverters = new string[] { "CustomConverter1", "CustomConverter2" }
+            };
+
+            //// Act
+            var output = CSharpJsonSerializerGenerator.GenerateJsonConvertersArrayCode(settings, additionalJsonConverters);
+            Console.WriteLine(output);
+
+            //// Assert
+            Assert.Equal("new System.Text.Json.Serialization.JsonConverter[] { new CustomConverter1(), new CustomConverter2(), new AdditionalConverter1(), new AdditionalConverter2() }", output);
+        }
+
+        [Fact]
+        public void When_using_NewtonsoftJson_with_JsonConverters_GenerateJsonConvertersArrayCode_generates_correctly()
+        {
+            //// Arrange
+            var additionalJsonConverters = new string[] { "AdditionalConverter1", "AdditionalConverter2" };
+            var settings = new CSharpGeneratorSettings
+            {
+                JsonLibrary = CSharpJsonLibrary.NewtonsoftJson,
+                JsonConverters = new string[] { "CustomConverter1", "CustomConverter2" }
+            };
+
+            //// Act
+            var output = CSharpJsonSerializerGenerator.GenerateJsonConvertersArrayCode(settings, additionalJsonConverters);
+            Console.WriteLine(output);
+
+            //// Assert
+            Assert.Equal("new Newtonsoft.Json.JsonConverter[] { new CustomConverter1(), new CustomConverter2(), new AdditionalConverter1(), new AdditionalConverter2() }", output);
         }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/GeneralGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/GeneralGeneratorTests.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -385,9 +386,9 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             {
                 Type = JsonObjectType.String
             };
-            
+
             var generator = new CSharpGenerator(schema);
-            
+
             // Act
             var output = generator.GenerateFile("MyClass");
 
@@ -594,7 +595,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
                 ""required"": [ ""dict"" ],
                 ""properties"": {
                     ""dict"": {
-                        ""type"": ""object"", 
+                        ""type"": ""object"",
                         ""additionalProperties"": false,
                         ""patternProperties"": {
                             ""^[a-zA-Z_$][a-zA-Z_$0-9]*$"": {
@@ -686,15 +687,19 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
     }
   }".Replace("\r", string.Empty), schemaJson.Replace("\r", string.Empty));
 
-            Assert.Contains(@"        [Newtonsoft.Json.JsonProperty(""FirstName"", Required = Newtonsoft.Json.Required.Always)]
+            var expected = @"[Newtonsoft.Json.JsonProperty(""FirstName"", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required]
         public string FirstName { get; set; }
-    
+
         [Newtonsoft.Json.JsonProperty(""MiddleName"", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string MiddleName { get; set; }
-    
+
         [Newtonsoft.Json.JsonProperty(""Age"", Required = Newtonsoft.Json.Required.AllowNull)]
-        public int? Age { get; set; }".Replace("\r", string.Empty), code.Replace("\r", string.Empty));
+        public int? Age { get; set; }";
+            var normalizedExpected = Regex.Replace(expected, @"\s+", string.Empty);
+            var normalizedCode = Regex.Replace(code, @"\s+", string.Empty);
+
+            Assert.Contains(normalizedExpected, normalizedCode);
 
             AssertCompile(code);
         }
@@ -851,16 +856,16 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             //// Arrange
             var json =
 @"{
-	""type"": ""object"", 
+	""type"": ""object"",
 	""properties"": {
 		""foo"": {
 			""$ref"": ""#/definitions/Object""
 		}
-	}, 
+	},
 	""definitions"": {
-		""Object"": { 
-			""type"": ""object"", 
-			""properties"": {} 
+		""Object"": {
+			""type"": ""object"",
+			""properties"": {}
 		}
 	}
 }";
@@ -973,7 +978,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             //// Arrange
             var json =
 @"{
-	""type"": ""object"", 
+	""type"": ""object"",
 	""properties"": {
 		""foo"": {
 		  ""type"": ""integer"",
@@ -1003,7 +1008,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             //// Arrange
             var json =
 @"{
-	""type"": ""object"", 
+	""type"": ""object"",
 	""properties"": {
 		""foo"": {
 		  ""type"": ""integer"",
@@ -1033,7 +1038,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             //// Arrange
             var json =
 @"{
-	""type"": ""object"", 
+	""type"": ""object"",
 	""properties"": {
 		""foo"": {
 		  ""type"": ""integer"",
@@ -1064,7 +1069,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             //// Arrange
             var json =
 @"{
-	""type"": ""object"", 
+	""type"": ""object"",
 	""properties"": {
 		""foo"": {
 		  ""type"": ""string"",
@@ -1094,7 +1099,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             //// Arrange
             var json =
 @"{
-	""type"": ""object"", 
+	""type"": ""object"",
 	""properties"": {
 		""foo"": {
 		  ""type"": ""string"",
@@ -1124,7 +1129,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             //// Arrange
             var json =
 @"{
-	""type"": ""object"", 
+	""type"": ""object"",
 	""properties"": {
 		""foo"": {
 		  ""type"": ""string"",
@@ -1154,7 +1159,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             //// Arrange
             var json =
 @"{
-	""type"": ""object"", 
+	""type"": ""object"",
 	""properties"": {
 		""foo"": {
 		  ""type"": ""string"",
@@ -1185,7 +1190,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             //// Arrange
             var json =
 @"{
-	""type"": ""object"", 
+	""type"": ""object"",
 	""properties"": {
 		""foo"": {
 		  ""type"": ""number"",
@@ -1216,7 +1221,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             //// Arrange
             var json =
                 @"{
-	""type"": ""object"", 
+	""type"": ""object"",
 	""properties"": {
 		""foo"": {
 		  ""type"": ""array"",
@@ -1248,7 +1253,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             //// Arrange
             var json =
 @"{
-	""type"": ""object"", 
+	""type"": ""object"",
 	""properties"": {
 		""foo"": {
 		  ""type"": ""string"",
@@ -1278,7 +1283,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             //// Arrange
             var json =
 @"{
-	""type"": ""object"", 
+	""type"": ""object"",
 	""properties"": {
 		""foo"": {
 		  ""type"": ""number"",
@@ -1308,7 +1313,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             //// Arrange
             var json =
                 @"{
-	""type"": ""object"", 
+	""type"": ""object"",
 	""properties"": {
 		""a"": {
 		  ""type"": ""integer"",
@@ -1395,7 +1400,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             //// Arrange
             var json =
 @"{
-	""type"": ""object"", 
+	""type"": ""object"",
 	""properties"": {
 		""a"": {
     		""type"": ""string"",
@@ -1539,7 +1544,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             //// Arrange
             var json =
 @"{
-	""type"": ""object"", 
+	""type"": ""object"",
 	""properties"": {
 		""a"": {
     		""type"": ""string"",
@@ -1571,7 +1576,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             //// Arrange
             var json =
                 @"{
-	""type"": ""object"", 
+	""type"": ""object"",
 	""properties"": {
 		""a"": {
     		""type"": ""string"",
@@ -1762,6 +1767,170 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             }
 
             Assert.Empty(sb.ToString());
+        }
+
+        [Fact]
+        public async Task When_using_SytemTextJson_without_JsonConverters_generates_FromJson_and_ToJson_correctly()
+        {
+            //// Arrange
+            var expectedToJsonMethod =
+@"
+public string ToJson()
+{
+	var options = new System.Text.Json.JsonSerializerOptions();
+	return System.Text.Json.JsonSerializer.Serialize(this, options);
+}
+";
+
+            var expectedFromJsonMethod =
+@"
+public static Person FromJson(string data)
+{
+	var options = new System.Text.Json.JsonSerializerOptions();
+	return System.Text.Json.JsonSerializer.Deserialize<Person>(data, options);
+}
+";
+
+            var generator = await CreateGeneratorAsync();
+            generator.Settings.JsonLibrary = CSharpJsonLibrary.SystemTextJson;
+            generator.Settings.GenerateJsonMethods = true;
+
+            //// Act
+            var output = generator.GenerateFile("MyClass");
+            //Remove the spaces from the string to avoid indentation change errors
+            var normalizedOutput = Regex.Replace(output, @"\s+", string.Empty);
+            var normalizedExpectedToJsonMethod = Regex.Replace(expectedToJsonMethod, @"\s+", string.Empty);
+            var normalizedExpectedFromJsonMethodMethod = Regex.Replace(expectedFromJsonMethod, @"\s+", string.Empty);
+
+            //// Assert
+            Assert.Contains(normalizedExpectedToJsonMethod, normalizedOutput);
+            Assert.Contains(normalizedExpectedFromJsonMethodMethod, normalizedOutput);
+
+            AssertCompile(output);
+        }
+
+        [Fact]
+        public async Task When_using_SytemTextJson_with_JsonConverters_generates_FromJson_and_ToJson_correctly()
+        {
+            //// Arrange
+            var expectedToJsonMethod =
+@"
+public string ToJson()
+{
+	var options = new System.Text.Json.JsonSerializerOptions();
+	var converters = new System.Text.Json.Serialization.JsonConverter[] { new CustomConverter1(), new CustomConverter2() };
+	foreach(var converter in converters)
+		options.Converters.Add(converter);
+	return System.Text.Json.JsonSerializer.Serialize(this, options);
+}
+";
+
+            var expectedFromJsonMethod =
+@"
+public static Person FromJson(string data)
+{
+	var options = new System.Text.Json.JsonSerializerOptions();
+	var converters = new System.Text.Json.Serialization.JsonConverter[] { new CustomConverter1(), new CustomConverter2() };
+	foreach(var converter in converters)
+		options.Converters.Add(converter);
+	return System.Text.Json.JsonSerializer.Deserialize<Person>(data, options);
+}
+";
+
+            var generator = await CreateGeneratorAsync();
+            generator.Settings.JsonLibrary = CSharpJsonLibrary.SystemTextJson;
+            generator.Settings.GenerateJsonMethods = true;
+            generator.Settings.JsonConverters = new[] { "CustomConverter1", "CustomConverter2" };
+
+            //// Act
+            var output = generator.GenerateFile("MyClass");
+            //Remove the spaces from the string to avoid indentation change errors
+            var normalizedOutput = Regex.Replace(output, @"\s+", string.Empty);
+            var normalizedExpectedToJsonMethod = Regex.Replace(expectedToJsonMethod, @"\s+", string.Empty);
+            var normalizedExpectedFromJsonMethodMethod = Regex.Replace(expectedFromJsonMethod, @"\s+", string.Empty);
+
+            //// Assert
+            Assert.Contains(normalizedExpectedToJsonMethod, normalizedOutput);
+            Assert.Contains(normalizedExpectedFromJsonMethodMethod, normalizedOutput);
+
+            AssertCompile(output);
+        }
+
+        [Fact]
+        public async Task When_using_NewtonsoftJson_without_JsonConverters_generates_FromJson_and_ToJson_correctly()
+        {
+            //// Arrange
+            var expectedToJsonMethod =
+@"
+public string ToJson()
+{
+	return Newtonsoft.Json.JsonConvert.SerializeObject(this, new Newtonsoft.Json.JsonSerializerSettings());
+}
+";
+
+            var expectedFromJsonMethod =
+@"
+public static Person FromJson(string data)
+{
+	return Newtonsoft.Json.JsonConvert.DeserializeObject<Person>(data, new Newtonsoft.Json.JsonSerializerSettings());
+}
+";
+
+            var generator = await CreateGeneratorAsync();
+            generator.Settings.JsonLibrary = CSharpJsonLibrary.NewtonsoftJson;
+            generator.Settings.GenerateJsonMethods = true;
+
+            //// Act
+            var output = generator.GenerateFile("MyClass");
+            //Remove the spaces from the string to avoid indentation change errors
+            var normalizedOutput = Regex.Replace(output, @"\s+", string.Empty);
+            var normalizedExpectedToJsonMethod = Regex.Replace(expectedToJsonMethod, @"\s+", string.Empty);
+            var normalizedExpectedFromJsonMethodMethod = Regex.Replace(expectedFromJsonMethod, @"\s+", string.Empty);
+
+            //// Assert
+            Assert.Contains(normalizedExpectedToJsonMethod, normalizedOutput);
+            Assert.Contains(normalizedExpectedFromJsonMethodMethod, normalizedOutput);
+
+            AssertCompile(output);
+        }
+
+        [Fact]
+        public async Task When_using_NewtonsoftJson_with_JsonConverters_generates_FromJson_and_ToJson_correctly()
+        {
+            //// Arrange
+            var expectedToJsonMethod =
+@"
+public string ToJson()
+{
+	return Newtonsoft.Json.JsonConvert.SerializeObject(this, new Newtonsoft.Json.JsonConverter[] { new CustomConverter1(), new CustomConverter2() });
+}
+";
+
+            var expectedFromJsonMethod =
+@"
+public static Person FromJson(string data)
+{
+	return Newtonsoft.Json.JsonConvert.DeserializeObject<Person>(data, new Newtonsoft.Json.JsonConverter[] { new CustomConverter1(), new CustomConverter2() });
+}
+";
+
+            var generator = await CreateGeneratorAsync();
+            generator.Settings.JsonLibrary = CSharpJsonLibrary.NewtonsoftJson;
+            generator.Settings.GenerateJsonMethods = true;
+            generator.Settings.JsonConverters = new[] { "CustomConverter1", "CustomConverter2" };
+
+            //// Act
+            var output = generator.GenerateFile("MyClass");
+            //Remove the spaces from the string to avoid indentation change errors
+            var normalizedOutput = Regex.Replace(output, @"\s+", string.Empty);
+            var normalizedExpectedToJsonMethod = Regex.Replace(expectedToJsonMethod, @"\s+", string.Empty);
+            var normalizedExpectedFromJsonMethodMethod = Regex.Replace(expectedFromJsonMethod, @"\s+", string.Empty);
+
+            //// Assert
+            Assert.Contains(normalizedExpectedToJsonMethod, normalizedOutput);
+            Assert.Contains(normalizedExpectedFromJsonMethodMethod, normalizedOutput);
+
+            AssertCompile(output);
         }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpJsonSerializerGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpJsonSerializerGenerator.cs
@@ -20,10 +20,26 @@ namespace NJsonSchema.CodeGeneration.CSharp
         /// <returns>The code.</returns>
         public static string GenerateJsonSerializerParameterCode(CSharpGeneratorSettings settings, IEnumerable<string> additionalJsonConverters)
         {
-            var jsonConverters = (settings.JsonConverters ?? new string[0]).Concat(additionalJsonConverters ?? new string[0]).ToList();
+            var jsonConverters = GetJsonConverters(settings, additionalJsonConverters);
             var hasJsonConverters = jsonConverters.Any();
 
             return GenerateForJsonLibrary(settings, jsonConverters, hasJsonConverters);
+        }
+
+        /// <summary>Generates the JSON converters array code.</summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="additionalJsonConverters">The additional JSON converters.</param>
+        /// <returns>The code.</returns>
+        public static string GenerateJsonConvertersArrayCode(CSharpGeneratorSettings settings, IEnumerable<string> additionalJsonConverters)
+        {
+            var jsonConverters = GetJsonConverters(settings, additionalJsonConverters);
+
+            return GenerateConverters(jsonConverters, settings.JsonLibrary);
+        }
+
+        private static List<string> GetJsonConverters(CSharpGeneratorSettings settings, IEnumerable<string> additionalJsonConverters)
+        {
+            return (settings.JsonConverters ?? new string[0]).Concat(additionalJsonConverters ?? new string[0]).ToList();
         }
 
         private static string GenerateForJsonLibrary(CSharpGeneratorSettings settings, List<string> jsonConverters, bool hasJsonConverters)
@@ -34,7 +50,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
                 case CSharpJsonLibrary.NewtonsoftJson:
                     if (settings.HandleReferences || useSettingsTransformationMethod)
                     {
-                        return ", " +
+                        return
                             (useSettingsTransformationMethod ? settings.JsonSerializerSettingsTransformationMethod + "(" : string.Empty) +
                             "new Newtonsoft.Json.JsonSerializerSettings { " +
                             (settings.HandleReferences
@@ -50,7 +66,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
                     {
                         if (hasJsonConverters)
                         {
-                            return ", " + GenerateConverters(jsonConverters, settings.JsonLibrary);
+                            return GenerateConverters(jsonConverters, settings.JsonLibrary);
                         }
                         else
                         {
@@ -62,13 +78,10 @@ namespace NJsonSchema.CodeGeneration.CSharp
                     // TODO: add more conditions?
                     if (useSettingsTransformationMethod || hasJsonConverters)
                     {
-                        return ", " +
+                        return
                             (useSettingsTransformationMethod ? settings.JsonSerializerSettingsTransformationMethod + "(" : string.Empty) +
                             "new System.Text.Json.JsonSerializerOptions()" +
-                            (useSettingsTransformationMethod ? ")" : string.Empty) +
-                            (hasJsonConverters
-                                ? "; var converters = " + GenerateConverters(jsonConverters, settings.JsonLibrary)
-                                : string.Empty);
+                            (useSettingsTransformationMethod ? ")" : string.Empty);
                     }
                     else
                     {

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpJsonSerializerGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpJsonSerializerGenerator.cs
@@ -70,12 +70,11 @@ namespace NJsonSchema.CodeGeneration.CSharp
                         }
                         else
                         {
-                            return string.Empty;
+                            return "new Newtonsoft.Json.JsonSerializerSettings()";
                         }
                     }
 
                 case CSharpJsonLibrary.SystemTextJson:
-                    // TODO: add more conditions?
                     if (useSettingsTransformationMethod || hasJsonConverters)
                     {
                         return
@@ -85,7 +84,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
                     }
                     else
                     {
-                        return string.Empty;
+                        return "new System.Text.Json.JsonSerializerOptions()";
                     }
 
                 default: // TODO: possibly add more json converters

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/ClassTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/ClassTemplateModel.cs
@@ -146,6 +146,9 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
         /// <summary>Gets the JSON serializer parameter code.</summary>
         public string JsonSerializerParameterCode => CSharpJsonSerializerGenerator.GenerateJsonSerializerParameterCode(_settings, null);
 
+        /// <summary>Gets the JSON converters array code.</summary>
+        public string JsonConvertersArrayCode => CSharpJsonSerializerGenerator.GenerateJsonConvertersArrayCode(_settings, null);
+
         /// <summary>Gets a value indicating whether the class is deprecated.</summary>
         public bool IsDeprecated => _schema.IsDeprecated;
 

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.FromJson.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.FromJson.liquid
@@ -1,8 +1,8 @@
 ﻿public static {{ ClassName }} FromJson(string data)
 {
 {% if UseSystemTextJson -%}
-    return System.Text.Json.JsonSerializer.Deserialize<{{ ClassName }}>(data{{ JsonSerializerParameterCode }});
+    return System.Text.Json.JsonSerializer.Deserialize<{{ ClassName }}>(data, {{ JsonSerializerParameterCode }});
 {% else -%}
-    return Newtonsoft.Json.JsonConvert.DeserializeObject<{{ ClassName }}>(data{{ JsonSerializerParameterCode }});
+    return Newtonsoft.Json.JsonConvert.DeserializeObject<{{ ClassName }}>(data, {{ JsonSerializerParameterCode }});
 {% endif -%}
 }

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.FromJson.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.FromJson.liquid
@@ -1,7 +1,13 @@
 ﻿public static {{ ClassName }} FromJson(string data)
 {
 {% if UseSystemTextJson -%}
-    return System.Text.Json.JsonSerializer.Deserialize<{{ ClassName }}>(data, {{ JsonSerializerParameterCode }});
+    var options = {{ JsonSerializerParameterCode }};
+{% if JsonConvertersArrayCode contains "System.Text.Json.Serialization.JsonConverter[]" -%}
+    var converters = {{ JsonConvertersArrayCode }};
+    foreach(var converter in converters)
+        options.Converters.Add(converter);
+{% endif -%}
+    return System.Text.Json.JsonSerializer.Deserialize<{{ ClassName }}>(data, options);
 {% else -%}
     return Newtonsoft.Json.JsonConvert.DeserializeObject<{{ ClassName }}>(data, {{ JsonSerializerParameterCode }});
 {% endif -%}

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.ToJson.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.ToJson.liquid
@@ -1,8 +1,8 @@
-﻿public string ToJson() 
+﻿public string ToJson()
 {
 {% if UseSystemTextJson -%}
-    return System.Text.Json.JsonSerializer.Serialize(this{{ JsonSerializerParameterCode }});
+    return System.Text.Json.JsonSerializer.Serialize(this, {{ JsonSerializerParameterCode }});
 {% else -%}
-    return Newtonsoft.Json.JsonConvert.SerializeObject(this{{ JsonSerializerParameterCode }});
+    return Newtonsoft.Json.JsonConvert.SerializeObject(this, {{ JsonSerializerParameterCode }});
 {% endif -%}
 }

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.ToJson.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.ToJson.liquid
@@ -1,7 +1,13 @@
 ﻿public string ToJson()
 {
 {% if UseSystemTextJson -%}
-    return System.Text.Json.JsonSerializer.Serialize(this, {{ JsonSerializerParameterCode }});
+    var options = {{ JsonSerializerParameterCode }};
+{% if JsonConvertersArrayCode contains "System.Text.Json.Serialization.JsonConverter[]" -%}
+    var converters = {{ JsonConvertersArrayCode }};
+    foreach(var converter in converters)
+        options.Converters.Add(converter);
+{% endif -%}
+    return System.Text.Json.JsonSerializer.Serialize(this, options);
 {% else -%}
     return Newtonsoft.Json.JsonConvert.SerializeObject(this, {{ JsonSerializerParameterCode }});
 {% endif -%}


### PR DESCRIPTION
* Remove ", " in `CSharpJsonSerializerGenerator.GenerateForJsonLibrary`
* Add `CSharpJsonSerializerGenerator.GenerateJsonConvertersArrayCode` method
* Fix `FromJson` and `ToJson`

Instead of #1339

---

Added the tests below:

To **GeneralGeneratorTests:**

- [x] `When_using_SytemTextJson_without_JsonConverters_generates_FromJson_and_ToJson_correctly`;
- [x] `When_using_SytemTextJson_with_JsonConverters_generates_FromJson_and_ToJson_correctly`;
- [x] `When_using_NewtonsoftJson_without_JsonConverters_generates_FromJson_and_ToJson_correctly`;
- [x] `When_using_NewtonsoftJson_with_JsonConverters_generates_FromJson_and_ToJson_correctly`.