### PR TITLE
Create benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ src/packages/Newtonsoft.Json**
 **.sln.ide/**
 **.vs/**
 .vscode/
+.idea/
 
 /src/NJsonSchema.sln.GhostDoc.xml
 
@@ -20,3 +21,4 @@ src/packages/Newtonsoft.Json**
 *.vspx
 /src/TestResults
 /src/.cr/*
+/src/NJsonSchema.Benchmark/BenchmarkDotNet.Artifacts*

--- a/src/NJsonSchema.Benchmark/CsharpGeneratorBenchmark.cs
+++ b/src/NJsonSchema.Benchmark/CsharpGeneratorBenchmark.cs
@@ -1,0 +1,27 @@
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using NJsonSchema.CodeGeneration.CSharp;
+
+namespace NJsonSchema.Benchmark
+{
+    [MemoryDiagnoser]
+    public class CsharpGeneratorBenchmark
+    {
+        private string _json;
+        private JsonSchema _schema;
+        
+        [GlobalSetup]
+        public async Task Setup()
+        {
+            _json = await JsonSchemaBenchmark.ReadJson();
+            _schema = await JsonSchema.FromJsonAsync(_json);
+        }
+        
+        [Benchmark]
+        public void GenerateFile()
+        {
+            var generator = new CSharpGenerator(_schema, new CSharpGeneratorSettings());
+            generator.GenerateFile();
+        }
+    }
+}

--- a/src/NJsonSchema.Benchmark/JsonSchemaBenchmark.cs
+++ b/src/NJsonSchema.Benchmark/JsonSchemaBenchmark.cs
@@ -1,0 +1,32 @@
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace NJsonSchema.Benchmark
+{
+    [MemoryDiagnoser]
+    public class JsonSchemaBenchmark
+    {
+        private string _json;
+        
+        [GlobalSetup]
+        public async Task Setup()
+        {
+            _json = await ReadJson();
+        }
+
+        internal static Task<string> ReadJson()
+        {
+            var assembly = typeof(JsonSchemaBenchmark).Assembly;
+            var file = assembly.GetManifestResourceNames().First(x => x.Contains("LargeSchema.json"));
+            return new StreamReader(assembly.GetManifestResourceStream(file)).ReadToEndAsync();
+        }
+
+        [Benchmark]
+        public Task<JsonSchema> FromJsonAsync()
+        {
+            return JsonSchema.FromJsonAsync(_json);
+        }
+    }
+}

--- a/src/NJsonSchema.Benchmark/JsonSchemaGeneratorBenchmark.cs
+++ b/src/NJsonSchema.Benchmark/JsonSchemaGeneratorBenchmark.cs
@@ -1,0 +1,14 @@
+using BenchmarkDotNet.Attributes;
+
+namespace NJsonSchema.Benchmark
+{
+    [MemoryDiagnoser]
+    public class JsonSchemaGeneratorBenchmark
+    {
+        [Benchmark]
+        public void GenerateFile()
+        {
+            JsonSchema.FromType<SchemaGenerationBenchmarks.Container>();
+        }
+    }
+}

--- a/src/NJsonSchema.Benchmark/LargeSchema.json
+++ b/src/NJsonSchema.Benchmark/LargeSchema.json
@@ -1,0 +1,162 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Person",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "FirstName",
+        "LastName"
+    ],
+    "properties": {
+        "FirstName": {
+            "type": "string"
+        },
+        "MiddleName": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "MiddleName1": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "MiddleName2": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "MiddleName3": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "MiddleName4": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "MiddleName5": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "MiddleName6": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "MiddleName7": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "MiddleName8": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "MiddleName9": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "LastName": {
+            "type": "string"
+        },
+        "Gender": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/Gender"
+                }
+            ]
+        },
+        "NumberWithRange": {
+            "type": "integer",
+            "format": "int32",
+            "maximum": 5.0,
+            "minimum": 2.0
+        },
+        "Birthday": {
+            "type": "string",
+            "format": "date-time"
+        },
+        "Company": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/Company"
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "Cars": {
+            "type": [
+                "array",
+                "null"
+            ],
+            "items": {
+                "$ref": "#/definitions/Car"
+            }
+        }
+    },
+    "definitions": {
+        "Gender": {
+            "type": "integer",
+            "description": "",
+            "x-enumNames": [
+                "Male",
+                "Female"
+            ],
+            "enum": [
+                0,
+                1
+            ]
+        },
+        "Company": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            }
+        },
+        "Car": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "Manufacturer": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Company"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/src/NJsonSchema.Benchmark/NJsonSchema.Benchmark.csproj
+++ b/src/NJsonSchema.Benchmark/NJsonSchema.Benchmark.csproj
@@ -1,20 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp5.0</TargetFrameworks>
+    <TargetFramework>net5.0</TargetFramework>
+    <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Schema.json" />
+    <EmbeddedResource Include="*.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="NBench" Version="1.0.4" />
-    <PackageReference Include="Pro.NBench.xUnit" Version="1.0.4" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="NBench" Version="2.0.1" />
+    <PackageReference Include="Pro.NBench.xUnit" Version="2.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\NJsonSchema.CodeGeneration.CSharp\NJsonSchema.CodeGeneration.CSharp.csproj" />
+    <ProjectReference Include="..\NJsonSchema.CodeGeneration.TypeScript\NJsonSchema.CodeGeneration.TypeScript.csproj" />
     <ProjectReference Include="..\NJsonSchema.Tests\NJsonSchema.Tests.csproj" />
     <ProjectReference Include="..\NJsonSchema\NJsonSchema.csproj" />
   </ItemGroup>

--- a/src/NJsonSchema.Benchmark/Program.cs
+++ b/src/NJsonSchema.Benchmark/Program.cs
@@ -1,0 +1,18 @@
+namespace NJsonSchema.Benchmark
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            // RunCsharpBenchmark();
+            BenchmarkDotNet.Running.BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).RunAllJoined();
+        }
+
+        private static void RunCsharpBenchmark()
+        {
+            var benchmark = new CsharpGeneratorBenchmark();
+            benchmark.Setup().GetAwaiter().GetResult();
+            benchmark.GenerateFile();
+        }
+    }
+}

--- a/src/NJsonSchema.Benchmark/TypeScriptGeneratorBenchmark.cs
+++ b/src/NJsonSchema.Benchmark/TypeScriptGeneratorBenchmark.cs
@@ -1,0 +1,27 @@
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using NJsonSchema.CodeGeneration.TypeScript;
+
+namespace NJsonSchema.Benchmark
+{
+    [MemoryDiagnoser]
+    public class TypeScriptGeneratorBenchmark
+    {
+        private string _json;
+        private JsonSchema _schema;
+        
+        [GlobalSetup]
+        public async Task Setup()
+        {
+            _json = await JsonSchemaBenchmark.ReadJson();
+            _schema = await JsonSchema.FromJsonAsync(_json);
+        }
+        
+        [Benchmark]
+        public void GenerateFile()
+        {
+            var generator = new TypeScriptGenerator(_schema, new TypeScriptGeneratorSettings());
+            generator.GenerateFile();
+        }
+    }
+}


### PR DESCRIPTION
As I've worked with Fluid integration I've also created a baseline of benchmarks to tests against to validate improvements. I think it would be beneficial to have this in repo to aid with other PRs (I've found some other performance problems besides the template library).

Using BenchmarkDotNet with memory diagnoser to get trustworthy reports easily via command line, `dotnet run -c Relese` for benchmark projects. The xUnit test cases still seem to work as expected at least with Rider.