### PR TITLE
Reduce memory allocations

### DIFF
--- a/src/NJsonSchema.Benchmark/Program.cs
+++ b/src/NJsonSchema.Benchmark/Program.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Runtime.CompilerServices;
 
 namespace NJsonSchema.Benchmark
@@ -7,7 +6,7 @@ namespace NJsonSchema.Benchmark
     {
         public static void Main(string[] args)
         {
-            //RunCsharpBenchmark();
+            // RunCsharpBenchmark();
             BenchmarkDotNet.Running.BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).RunAllJoined();
         }
 
@@ -16,15 +15,15 @@ namespace NJsonSchema.Benchmark
             var benchmark = new CsharpGeneratorBenchmark();
             benchmark.Setup().GetAwaiter().GetResult();
             benchmark.GenerateFile();
-            ExecuteBenchmarkMultiple(benchmark.GenerateFile);
+            RunCode(benchmark);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ExecuteBenchmarkMultiple(Action a)
+        private static void RunCode(CsharpGeneratorBenchmark benchmark)
         {
             for (int i = 0; i < 100; ++i)
             {
-                a();
+                benchmark.GenerateFile();
             }
         }
     }

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpGenerator.cs
@@ -122,13 +122,24 @@ namespace NJsonSchema.CodeGeneration.CSharp
             return new CodeArtifact(typeName, model.BaseClassName, CodeArtifactType.Class, CodeArtifactLanguage.CSharp, CodeArtifactCategory.Contract, template);
         }
 
-        private void RenamePropertyWithSameNameAsClass(string typeName, IEnumerable<PropertyModel> properties)
+        private static void RenamePropertyWithSameNameAsClass(string typeName, IEnumerable<PropertyModel> properties)
         {
-            var propertyWithSameNameAsClass = properties.SingleOrDefault(p => p.PropertyName == typeName);
+            var propertyModels = properties as PropertyModel[] ?? properties.ToArray();
+            PropertyModel propertyWithSameNameAsClass = null;
+            foreach (var p in propertyModels)
+            {
+                if (p.PropertyName == typeName)
+                {
+                    propertyWithSameNameAsClass = p;
+                    break;
+                }
+            }
+
             if (propertyWithSameNameAsClass != null)
             {
                 var number = 1;
-                while (properties.Any(p => p.PropertyName == typeName + number))
+                var candidate = typeName + number;
+                while (propertyModels.Any(p => p.PropertyName == candidate))
                 {
                     number++;
                 }

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
@@ -81,7 +81,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
                 schema.ActualDiscriminator == null &&
                 schema.InheritedSchema == null && // not in inheritance hierarchy
                 schema.AllOf.Count == 0 &&
-                !Types.Keys.Contains(schema) &&
+                !Types.ContainsKey(schema) &&
                 !schema.HasReference)
             {
                 return markAsNullableType ? Settings.AnyType + "?" : Settings.AnyType;

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
@@ -95,17 +95,17 @@ namespace NJsonSchema.CodeGeneration.CSharp
                     JsonObjectType.String;
             }
 
-            if (type.HasFlag(JsonObjectType.Number))
+            if (type.IsNumber())
             {
                 return ResolveNumber(schema.ActualTypeSchema, isNullable);
             }
 
-            if (type.HasFlag(JsonObjectType.Integer) && !schema.ActualTypeSchema.IsEnumeration)
+            if (type.IsInteger() && !schema.ActualTypeSchema.IsEnumeration)
             {
                 return ResolveInteger(schema.ActualTypeSchema, isNullable, typeNameHint);
             }
 
-            if (type.HasFlag(JsonObjectType.Boolean))
+            if (type.IsBoolean())
             {
                 return ResolveBoolean(isNullable);
             }
@@ -118,14 +118,14 @@ namespace NJsonSchema.CodeGeneration.CSharp
                 return "byte[]" + nullableReferenceType;
             }
 
-            if (type.HasFlag(JsonObjectType.String) && !schema.ActualTypeSchema.IsEnumeration)
+            if (type.IsString() && !schema.ActualTypeSchema.IsEnumeration)
             {
                 return ResolveString(schema.ActualTypeSchema, isNullable, typeNameHint);
             }
 
             // Type generating schemas
 
-            if (schema.Type.HasFlag(JsonObjectType.Array))
+            if (schema.Type.IsArray())
             {
                 return ResolveArrayOrTuple(schema) + nullableReferenceType;
             }

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpValueGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpValueGenerator.cs
@@ -63,8 +63,8 @@ namespace NJsonSchema.CodeGeneration.CSharp
                 schema = schema.ActualSchema;
                 if (schema != null && allowsNull == false && isOptional == false)
                 {
-                    if (schema.Type.HasFlag(JsonObjectType.Array) ||
-                        schema.Type.HasFlag(JsonObjectType.Object))
+                    if (schema.Type.IsArray() ||
+                        schema.Type.IsObject())
                     {
                         targetType = !string.IsNullOrEmpty(_settings.DictionaryInstanceType)
                             ? targetType.Replace(_settings.DictionaryType + "<", _settings.DictionaryInstanceType + "<")
@@ -106,7 +106,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
                     case JsonFormatStrings.Decimal:
                         return ConvertNumberToString(value) + "M";
                     default:
-                        return type.HasFlag(JsonObjectType.Integer) ?
+                        return type.IsInteger() ?
                             ConvertNumberToString(value) :
                             ConvertNumberToString(value) + "D";
                 }

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/EnumTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/EnumTemplateModel.cs
@@ -63,7 +63,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                     var value = _schema.Enumeration.ElementAt(i);
                     if (value != null)
                     {
-                        if (_schema.Type.HasFlag(JsonObjectType.Integer))
+                        if (_schema.Type.IsInteger())
                         {
                             var name = _schema.EnumerationNames.Count > i ?
                                 _schema.EnumerationNames.ElementAt(i) : "_" + value;

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
@@ -55,7 +55,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
 
         /// <summary>Gets or sets a value indicating whether empty strings are allowed.</summary>
         public bool AllowEmptyStrings =>
-            _property.ActualTypeSchema.Type.HasFlag(JsonObjectType.String) &&
+            _property.ActualTypeSchema.Type.IsString() &&
             (_property.MinLength == null || _property.MinLength == 0);
 
         /// <summary>Gets a value indicating whether this is an array property which cannot be null.</summary>
@@ -106,9 +106,9 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                 }
 
                 return _property.ActualTypeSchema.IsAnyType ||
-                       _property.ActualTypeSchema.Type.HasFlag(JsonObjectType.Object) ||
-                       _property.ActualTypeSchema.Type.HasFlag(JsonObjectType.String) ||
-                       _property.ActualTypeSchema.Type.HasFlag(JsonObjectType.Array);
+                       _property.ActualTypeSchema.Type.IsObject() ||
+                       _property.ActualTypeSchema.Type.IsString() ||
+                       _property.ActualTypeSchema.Type.IsArray();
             }
         }
 
@@ -122,7 +122,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                     return false;
                 }
 
-                if (!_property.ActualTypeSchema.Type.HasFlag(JsonObjectType.Number) && !_property.ActualTypeSchema.Type.HasFlag(JsonObjectType.Integer))
+                if (!_property.ActualTypeSchema.Type.IsNumber() && !_property.ActualTypeSchema.Type.IsInteger())
                 {
                     return false;
                 }
@@ -211,7 +211,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                     return false; // handled by RequiredAttribute
                 }
 
-                return _property.ActualTypeSchema.Type.HasFlag(JsonObjectType.String) &&
+                return _property.ActualTypeSchema.Type.IsString() &&
                        (_property.ActualSchema.MinLength.HasValue || _property.ActualSchema.MaxLength.HasValue);
             }
         }
@@ -232,7 +232,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                     return false;
                 }
 
-                return _property.ActualTypeSchema.Type.HasFlag(JsonObjectType.Array) && _property.ActualSchema.MinItems > 0;
+                return _property.ActualTypeSchema.Type.IsArray() && _property.ActualSchema.MinItems > 0;
             }
         }
 
@@ -249,7 +249,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                     return false;
                 }
 
-                return _property.ActualTypeSchema.Type.HasFlag(JsonObjectType.Array) && _property.ActualSchema.MaxItems > 0;
+                return _property.ActualTypeSchema.Type.IsArray() && _property.ActualSchema.MaxItems > 0;
             }
         }
 
@@ -266,7 +266,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                     return false;
                 }
 
-                return _property.ActualTypeSchema.Type.HasFlag(JsonObjectType.String) &&
+                return _property.ActualTypeSchema.Type.IsString() &&
                        !string.IsNullOrEmpty(_property.ActualSchema.Pattern);
             }
         }
@@ -275,7 +275,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
         public string RegularExpressionValue => _property.ActualSchema.Pattern?.Replace("\"", "\"\"");
 
         /// <summary>Gets a value indicating whether the property type is string enum.</summary>
-        public bool IsStringEnum => _property.ActualTypeSchema.IsEnumeration && _property.ActualTypeSchema.Type.HasFlag(JsonObjectType.String);
+        public bool IsStringEnum => _property.ActualTypeSchema.IsEnumeration && _property.ActualTypeSchema.Type.IsString();
 
         /// <summary>Gets a value indicating whether the property should be formatted like a date.</summary>
         public bool IsDate => _property.ActualSchema.Format == JsonFormatStrings.Date;

--- a/src/NJsonSchema.CodeGeneration.CSharp/NJsonSchema.CodeGeneration.CSharp.csproj
+++ b/src/NJsonSchema.CodeGeneration.CSharp/NJsonSchema.CodeGeneration.CSharp.csproj
@@ -31,4 +31,9 @@
   <ItemGroup>
     <None Include="NuGetIcon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\NJsonSchema\Infrastructure\EnumExtensions.cs">
+      <Link>EnumExtensions.cs</Link>
+    </Compile>
+  </ItemGroup>
 </Project>

--- a/src/NJsonSchema.CodeGeneration.TypeScript/Models/EnumTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Models/EnumTemplateModel.cs
@@ -57,12 +57,12 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Models
                     {
                         var name = _schema.EnumerationNames.Count > i ?
                             _schema.EnumerationNames.ElementAt(i) :
-                            _schema.Type.HasFlag(JsonObjectType.Integer) ? "_" + value : value.ToString();
+                            _schema.Type.IsInteger() ? "_" + value : value.ToString();
 
                         entries.Add(new EnumerationItemModel
                         {
                             Name = _settings.EnumNameGenerator.Generate(i, name, value, _schema),
-                            Value = _schema.Type.HasFlag(JsonObjectType.Integer) ?
+                            Value = _schema.Type.IsInteger() ?
                                 value.ToString() :
                                 (_settings.TypeScriptVersion < 2.4m ? "<any>" : "") + "\"" + value + "\"",
                         });

--- a/src/NJsonSchema.CodeGeneration.TypeScript/Models/PropertyModel.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Models/PropertyModel.cs
@@ -71,13 +71,13 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Models
                 if (IsArray)
                 {
                     return _resolver.SupportsConstructorConversion(_property.ActualTypeSchema?.Item) &&
-                        _property.ActualTypeSchema?.Item.ActualSchema.Type.HasFlag(JsonObjectType.Object) == true;
+                        _property.ActualTypeSchema?.Item.ActualSchema.Type.IsObject() == true;
                 }
 
                 if (IsDictionary)
                 {
                     return _resolver.SupportsConstructorConversion(_property.ActualTypeSchema?.AdditionalPropertiesSchema) &&
-                        _property.ActualTypeSchema?.AdditionalPropertiesSchema.ActualSchema.Type.HasFlag(JsonObjectType.Object) == true;
+                        _property.ActualTypeSchema?.AdditionalPropertiesSchema.ActualSchema.Type.IsObject() == true;
                 }
 
                 return _resolver.SupportsConstructorConversion(_property) &&

--- a/src/NJsonSchema.CodeGeneration.TypeScript/NJsonSchema.CodeGeneration.TypeScript.csproj
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/NJsonSchema.CodeGeneration.TypeScript.csproj
@@ -30,4 +30,9 @@
   <ItemGroup>
     <None Include="NuGetIcon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\NJsonSchema\Infrastructure\EnumExtensions.cs">
+      <Link>EnumExtensions.cs</Link>
+    </Compile>
+  </ItemGroup>
 </Project>

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
@@ -101,22 +101,22 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                     JsonObjectType.String;
             }
 
-            if (type.HasFlag(JsonObjectType.Number))
+            if (type.IsNumber())
             {
                 return "number";
             }
 
-            if (type.HasFlag(JsonObjectType.Integer) && !schema.ActualTypeSchema.IsEnumeration)
+            if (type.IsInteger() && !schema.ActualTypeSchema.IsEnumeration)
             {
                 return ResolveInteger(schema.ActualTypeSchema, typeNameHint);
             }
 
-            if (type.HasFlag(JsonObjectType.Boolean))
+            if (type.IsBoolean())
             {
                 return "boolean";
             }
 
-            if (type.HasFlag(JsonObjectType.String) && !schema.ActualTypeSchema.IsEnumeration)
+            if (type.IsString() && !schema.ActualTypeSchema.IsEnumeration)
             {
                 return ResolveString(schema.ActualTypeSchema, typeNameHint);
             }
@@ -133,7 +133,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                 return GetOrGenerateTypeName(schema, typeNameHint);
             }
 
-            if (schema.Type.HasFlag(JsonObjectType.Array))
+            if (schema.Type.IsArray())
             {
                 return ResolveArrayOrTuple(schema, typeNameHint, addInterfacePrefix);
             }
@@ -142,7 +142,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
             {
                 var prefix = addInterfacePrefix &&
                     SupportsConstructorConversion(schema.AdditionalPropertiesSchema) &&
-                    schema.AdditionalPropertiesSchema?.ActualSchema.Type.HasFlag(JsonObjectType.Object) == true ? "I" : "";
+                    schema.AdditionalPropertiesSchema?.ActualSchema.Type.IsObject() == true ? "I" : "";
 
                 var valueType = ResolveDictionaryValueType(schema, "any");
                 if (valueType != "any")
@@ -298,7 +298,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
         {
             if (schema.Item != null)
             {
-                var isObject = schema.Item?.ActualSchema.Type.HasFlag(JsonObjectType.Object) == true;
+                var isObject = schema.Item?.ActualSchema.Type.IsObject() == true;
                 var isDictionary = schema.Item?.ActualSchema.IsDictionary == true;
                 var prefix = addInterfacePrefix && SupportsConstructorConversion(schema.Item) && isObject && !isDictionary ? "I" : "";
 

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
@@ -87,7 +87,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
             if (schema.ActualTypeSchema.IsAnyType &&
                 schema.InheritedSchema == null && // not in inheritance hierarchy
                 schema.AllOf.Count == 0 &&
-                !Types.Keys.Contains(schema) &&
+                !Types.ContainsKey(schema) &&
                 !schema.HasReference)
             {
                 return "any";
@@ -165,7 +165,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                         {
                             return $"{{ [key in {keyType}]?: {valueType}; }}";
                         }
-                        
+
                         throw new ArgumentOutOfRangeException(nameof(Settings.EnumStyle), Settings.EnumStyle, "Unknown enum style");
                     }
 

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptValueGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptValueGenerator.cs
@@ -44,7 +44,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
             {
                 if (schema.Default != null && useSchemaDefault)
                 {
-                    if (schema.Type.HasFlag(JsonObjectType.String) && 
+                    if (schema.Type.IsString() && 
                         _supportedFormatStrings.Contains(schema.Format))
                     {
                         return GetDefaultAsStringLiteral(schema);

--- a/src/NJsonSchema.CodeGeneration/JsonSchemaGraphUtilities.cs
+++ b/src/NJsonSchema.CodeGeneration/JsonSchemaGraphUtilities.cs
@@ -25,7 +25,7 @@ namespace NJsonSchema.CodeGeneration
             return visitor.DerivedSchemas;
         }
 
-        private class DerivedSchemaVisitor : JsonSchemaVisitorBase
+        private sealed class DerivedSchemaVisitor : JsonSchemaVisitorBase
         {
             private readonly JsonSchema _baseSchema;
 

--- a/src/NJsonSchema.CodeGeneration/Models/PropertyModelBase.cs
+++ b/src/NJsonSchema.CodeGeneration/Models/PropertyModelBase.cs
@@ -65,7 +65,7 @@ namespace NJsonSchema.CodeGeneration.Models
             _property.ActualTypeSchema.IsArray &&
             _property.ActualTypeSchema.Item != null &&
             _property.ActualTypeSchema.Item.ActualSchema.IsEnumeration &&
-            _property.ActualTypeSchema.Item.ActualSchema.Type.HasFlag(JsonObjectType.String);
+            _property.ActualTypeSchema.Item.ActualSchema.Type.IsString();
 
         /// <summary>Gets the property extension data.</summary>
         public IDictionary<string, object> ExtensionData => _property.ExtensionData;

--- a/src/NJsonSchema.CodeGeneration/NJsonSchema.CodeGeneration.csproj
+++ b/src/NJsonSchema.CodeGeneration/NJsonSchema.CodeGeneration.csproj
@@ -16,4 +16,9 @@
   <ItemGroup>
     <None Include="NuGetIcon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\NJsonSchema\Infrastructure\EnumExtensions.cs">
+      <Link>EnumExtensions.cs</Link>
+    </Compile>
+  </ItemGroup>
 </Project>

--- a/src/NJsonSchema.CodeGeneration/TypeResolverBase.cs
+++ b/src/NJsonSchema.CodeGeneration/TypeResolverBase.cs
@@ -125,7 +125,7 @@ namespace NJsonSchema.CodeGeneration
                    !schema.IsArray &&
                    (schema.IsEnumeration ||
                     schema.Type == JsonObjectType.None ||
-                    schema.Type.HasFlag(JsonObjectType.Object));
+                    schema.Type.IsObject());
         }
 
         /// <summary>Resolves the type of the dictionary value of the given schema (must be a dictionary schema).</summary>

--- a/src/NJsonSchema.CodeGeneration/ValueGeneratorBase.cs
+++ b/src/NJsonSchema.CodeGeneration/ValueGeneratorBase.cs
@@ -55,24 +55,24 @@ namespace NJsonSchema.CodeGeneration
             }
 
             var actualSchema = schema is JsonSchemaProperty ? ((JsonSchemaProperty)schema).ActualTypeSchema : schema.ActualSchema;
-            if (actualSchema.IsEnumeration && !actualSchema.Type.HasFlag(JsonObjectType.Object) && actualSchema.Type != JsonObjectType.None)
+            if (actualSchema.IsEnumeration && !actualSchema.Type.IsObject() && actualSchema.Type != JsonObjectType.None)
             {
                 return GetEnumDefaultValue(schema, actualSchema, typeNameHint, typeResolver);
             }
 
-            if (schema.Type.HasFlag(JsonObjectType.String) && _unsupportedFormatStrings.Contains(schema.Format) == false)
+            if (schema.Type.IsString() && _unsupportedFormatStrings.Contains(schema.Format) == false)
             {
                 return GetDefaultAsStringLiteral(schema);
             }
             // TODO: Add conversion for format string, e.g. in C# DateTime.Parse()
 
-            if (schema.Type.HasFlag(JsonObjectType.Boolean))
+            if (schema.Type.IsBoolean())
             {
                 return schema.Default.ToString().ToLowerInvariant();
             }
 
-            if (schema.Type.HasFlag(JsonObjectType.Integer) ||
-                schema.Type.HasFlag(JsonObjectType.Number))
+            if (schema.Type.IsInteger() ||
+                schema.Type.IsNumber())
             {
                 return GetNumericValue(schema.Type, schema.Default, schema.Format);
             }

--- a/src/NJsonSchema/Collections/ObservableCollectionExtensions.cs
+++ b/src/NJsonSchema/Collections/ObservableCollectionExtensions.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Runtime.CompilerServices;
+
+// ReSharper disable ForCanBeConvertedToForeach
+// ReSharper disable LoopCanBeConvertedToQuery
+// ReSharper disable once CheckNamespace
+
+namespace NJsonSchema
+{
+    /// <summary>
+    /// Performance helpers avoiding struct enumerator building and generally faster accessing.
+    /// </summary>
+    internal static class ObservableCollectionExtensions
+    {
+        public static int Count<T>(this ObservableCollection<T> collection, Func<T, bool> predicate)
+        {
+            var count = 0;
+            for (var i = 0; i < collection.Count; ++i)
+            {
+                if (predicate(collection[i]))
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+
+        public static T ElementAt<T>(this ObservableCollection<T> collection, int index)
+        {
+            return collection[index];
+        }
+
+        public static T First<T>(this ObservableCollection<T> collection)
+        {
+            if (collection.Count > 0)
+            {
+                return collection[0];
+            }
+
+            ThrowNoMatchingElement();
+            return default;
+        }
+
+        public static T First<T>(this ObservableCollection<T> collection, Func<T, bool> predicate)
+        {
+            for (var i = 0; i < collection.Count; ++i)
+            {
+                var arg = collection[i];
+                if (predicate(arg))
+                {
+                    return arg;
+                }
+            }
+
+            ThrowNoMatchingElement();
+            return default;
+        }
+
+        public static T FirstOrDefault<T>(this ObservableCollection<T> collection, Func<T, bool> predicate) where T : class
+        {
+            for (var i = 0; i < collection.Count; ++i)
+            {
+                var arg = collection[i];
+                if (predicate(arg))
+                {
+                    return arg;
+                }
+            }
+
+            return null;
+        }
+
+        public static T FirstOrDefault<T>(this ObservableCollection<T> collection) where T : class
+        {
+            if (collection.Count > 0)
+            {
+                return collection[0];
+            }
+            return null;
+        }
+
+        public static bool Any<T>(this ObservableCollection<T> collection)
+        {
+            return collection.Count > 0;
+        }
+
+        public static bool Any<T>(this ObservableCollection<T> collection, Func<T, bool> predicate)
+        {
+            for (var i = 0; i < collection.Count; ++i)
+            {
+                if (predicate(collection[i]))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowNoMatchingElement()
+        {
+            throw new InvalidOperationException("Collection contains no matching element");
+        }
+    }
+}

--- a/src/NJsonSchema/Collections/ObservableDictionary.cs
+++ b/src/NJsonSchema/Collections/ObservableDictionary.cs
@@ -25,7 +25,7 @@ namespace NJsonSchema.Collections
         , IReadOnlyDictionary<TKey, TValue>
 #endif
     {
-        private IDictionary<TKey, TValue> _dictionary;
+        private Dictionary<TKey, TValue> _dictionary;
 
         /// <summary>Initializes a new instance of the <see cref="ObservableDictionary{TKey, TValue}"/> class. </summary>
         public ObservableDictionary()
@@ -354,10 +354,9 @@ namespace NJsonSchema.Collections
 
         #region IEnumerable<KeyValuePair<TKey,TValue>> interface
 
-        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
-        {
-            return Dictionary.GetEnumerator();
-        }
+        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() => GetEnumerator();
+
+        public Dictionary<TKey, TValue>.Enumerator GetEnumerator() => _dictionary.GetEnumerator();
 
         #endregion
 

--- a/src/NJsonSchema/Collections/ObservableDictionary.cs
+++ b/src/NJsonSchema/Collections/ObservableDictionary.cs
@@ -18,7 +18,7 @@ namespace NJsonSchema.Collections
     /// <summary>An implementation of an observable dictionary. </summary>
     /// <typeparam name="TKey">The type of the key. </typeparam>
     /// <typeparam name="TValue">The type of the value. </typeparam>
-    internal class ObservableDictionary<TKey, TValue> :
+    internal sealed class ObservableDictionary<TKey, TValue> :
         IDictionary<TKey, TValue>, INotifyCollectionChanged,
         INotifyPropertyChanged, IDictionary
 #if !LEGACY
@@ -70,9 +70,6 @@ namespace NJsonSchema.Collections
             _dictionary = new Dictionary<TKey, TValue>(capacity, comparer);
         }
 
-        /// <summary>Gets the underlying dictonary. </summary>
-        protected IDictionary<TKey, TValue> Dictionary => _dictionary;
-
         /// <summary>Adds multiple key-value pairs the the dictionary. </summary>
         /// <param name="items">The key-value pairs. </param>
         public void AddRange(IDictionary<TKey, TValue> items)
@@ -84,16 +81,16 @@ namespace NJsonSchema.Collections
 
             if (items.Count > 0)
             {
-                if (Dictionary.Count > 0)
+                if (_dictionary.Count > 0)
                 {
-                    if (items.Keys.Any(k => Dictionary.ContainsKey(k)))
+                    if (items.Keys.Any(k => _dictionary.ContainsKey(k)))
                     {
                         throw new ArgumentException("An item with the same key has already been added.");
                     }
 
                     foreach (var item in items)
                     {
-                        Dictionary.Add(item);
+                        _dictionary.Add(item.Key, item.Value);
                     }
                 }
                 else
@@ -109,10 +106,10 @@ namespace NJsonSchema.Collections
         /// <param name="key">The key. </param>
         /// <param name="value">The value. </param>
         /// <param name="add">If true and key already exists then an exception is thrown. </param>
-        protected virtual void Insert(TKey key, TValue value, bool add)
+        private void Insert(TKey key, TValue value, bool add)
         {
             TValue item;
-            if (Dictionary.TryGetValue(key, out item))
+            if (_dictionary.TryGetValue(key, out item))
             {
                 if (add)
                 {
@@ -124,18 +121,18 @@ namespace NJsonSchema.Collections
                     return;
                 }
 
-                Dictionary[key] = value;
+                _dictionary[key] = value;
                 OnCollectionChanged(NotifyCollectionChangedAction.Replace, new KeyValuePair<TKey, TValue>(key, value),
                     new KeyValuePair<TKey, TValue>(key, item));
             }
             else
             {
-                Dictionary[key] = value;
+                _dictionary[key] = value;
                 OnCollectionChanged(NotifyCollectionChangedAction.Add, new KeyValuePair<TKey, TValue>(key, value));
             }
         }
 
-        protected virtual void OnPropertyChanged(string propertyName)
+        private void OnPropertyChanged(string propertyName)
         {
             var copy = PropertyChanged;
             if (copy != null)
@@ -144,7 +141,7 @@ namespace NJsonSchema.Collections
             }
         }
 
-        protected void OnCollectionChanged()
+        private void OnCollectionChanged()
         {
             OnPropertyChanged();
             var copy = CollectionChanged;
@@ -154,7 +151,7 @@ namespace NJsonSchema.Collections
             }
         }
 
-        protected void OnCollectionChanged(NotifyCollectionChangedAction action, KeyValuePair<TKey, TValue> changedItem)
+        private void OnCollectionChanged(NotifyCollectionChangedAction action, KeyValuePair<TKey, TValue> changedItem)
         {
             OnPropertyChanged();
             var copy = CollectionChanged;
@@ -164,7 +161,7 @@ namespace NJsonSchema.Collections
             }
         }
 
-        protected void OnCollectionChanged(NotifyCollectionChangedAction action, KeyValuePair<TKey, TValue> newItem,
+        private void OnCollectionChanged(NotifyCollectionChangedAction action, KeyValuePair<TKey, TValue> newItem,
             KeyValuePair<TKey, TValue> oldItem)
         {
             OnPropertyChanged();
@@ -175,7 +172,7 @@ namespace NJsonSchema.Collections
             }
         }
 
-        protected void OnCollectionChanged(NotifyCollectionChangedAction action, IList newItems)
+        private void OnCollectionChanged(NotifyCollectionChangedAction action, IList newItems)
         {
             OnPropertyChanged();
             var copy = CollectionChanged;
@@ -202,14 +199,14 @@ namespace NJsonSchema.Collections
 
         public bool ContainsKey(TKey key)
         {
-            return Dictionary.ContainsKey(key);
+            return _dictionary.ContainsKey(key);
         }
 
-        public ICollection<TKey> Keys => Dictionary.Keys;
+        public ICollection<TKey> Keys => _dictionary.Keys;
 
-        ICollection IDictionary.Values => ((IDictionary) Dictionary).Values;
+        ICollection IDictionary.Values => ((IDictionary) _dictionary).Values;
 
-        ICollection IDictionary.Keys => ((IDictionary) Dictionary).Keys;
+        ICollection IDictionary.Keys => ((IDictionary) _dictionary).Keys;
 
 #if !LEGACY
 
@@ -217,7 +214,7 @@ namespace NJsonSchema.Collections
 
 #endif
 
-        public virtual bool Remove(TKey key)
+        public bool Remove(TKey key)
         {
             if (key == null)
             {
@@ -225,9 +222,9 @@ namespace NJsonSchema.Collections
             }
 
             TValue value;
-            Dictionary.TryGetValue(key, out value);
+            _dictionary.TryGetValue(key, out value);
 
-            var removed = Dictionary.Remove(key);
+            var removed = _dictionary.Remove(key);
             if (removed)
             {
                 OnCollectionChanged();
@@ -239,7 +236,7 @@ namespace NJsonSchema.Collections
 
         public bool TryGetValue(TKey key, out TValue value)
         {
-            return Dictionary.TryGetValue(key, out value);
+            return _dictionary.TryGetValue(key, out value);
         }
 
 #if !LEGACY
@@ -248,11 +245,11 @@ namespace NJsonSchema.Collections
 
 #endif
 
-        public ICollection<TValue> Values => Dictionary.Values;
+        public ICollection<TValue> Values => _dictionary.Values;
 
         public TValue this[TKey key]
         {
-            get => Dictionary[key];
+            get => _dictionary[key];
             set => Insert(key, value, false);
         }
 
@@ -272,9 +269,9 @@ namespace NJsonSchema.Collections
 
         public void Clear()
         {
-            if (Dictionary.Count > 0)
+            if (_dictionary.Count > 0)
             {
-                Dictionary.Clear();
+                _dictionary.Clear();
                 OnCollectionChanged();
             }
         }
@@ -284,12 +281,12 @@ namespace NJsonSchema.Collections
             var pairs = keyValuePairs.ToList();
             foreach (var pair in pairs)
             {
-                Dictionary[pair.Key] = pair.Value;
+                _dictionary[pair.Key] = pair.Value;
             }
 
-            foreach (var key in Dictionary.Keys.Where(k => !pairs.Any(p => Equals(p.Key, k))).ToArray())
+            foreach (var key in _dictionary.Keys.Where(k => !pairs.Any(p => Equals(p.Key, k))).ToArray())
             {
-                Dictionary.Remove(key);
+                _dictionary.Remove(key);
             }
 
             OnCollectionChanged();
@@ -307,7 +304,7 @@ namespace NJsonSchema.Collections
 
         IDictionaryEnumerator IDictionary.GetEnumerator()
         {
-            return ((IDictionary) Dictionary).GetEnumerator();
+            return ((IDictionary) _dictionary).GetEnumerator();
         }
 
         public void Remove(object key)
@@ -319,25 +316,25 @@ namespace NJsonSchema.Collections
 
         public bool Contains(KeyValuePair<TKey, TValue> item)
         {
-            return Dictionary.Contains(item);
+            return _dictionary.Contains(item);
         }
 
         public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
         {
-            Dictionary.CopyTo(array, arrayIndex);
+            ((IDictionary) _dictionary).CopyTo(array, arrayIndex);
         }
 
         public void CopyTo(Array array, int index)
         {
-            ((IDictionary) Dictionary).CopyTo(array, index);
+            ((IDictionary) _dictionary).CopyTo(array, index);
         }
 
-        public int Count => Dictionary.Count;
+        public int Count => _dictionary.Count;
 
         public bool IsSynchronized { get; private set; }
         public object SyncRoot { get; private set; }
 
-        public bool IsReadOnly => Dictionary.IsReadOnly;
+        public bool IsReadOnly => ((IDictionary) _dictionary).IsReadOnly;
 
         object IDictionary.this[object key]
         {
@@ -364,7 +361,7 @@ namespace NJsonSchema.Collections
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return ((IEnumerable) Dictionary).GetEnumerator();
+            return ((IEnumerable) _dictionary).GetEnumerator();
         }
 
         #endregion

--- a/src/NJsonSchema/ConversionUtilities.cs
+++ b/src/NJsonSchema/ConversionUtilities.cs
@@ -162,13 +162,17 @@ namespace NJsonSchema
         }
 
 
+        private static readonly char[] _whiteSpaceChars = { '\n', '\r', '\t', ' ' };
+
         /// <summary>Trims white spaces from the text.</summary>
         /// <param name="text">The text.</param>
         /// <returns>The updated text.</returns>
         public static string TrimWhiteSpaces(string text)
         {
-            return text?.Trim('\n', '\r', '\t', ' ');
+            return text?.Trim(_whiteSpaceChars);
         }
+
+        private static readonly char[] _lineBreakTrimChars = { '\n', '\t', ' ' };
 
         /// <summary>Removes the line breaks from the text.</summary>
         /// <param name="text">The text.</param>
@@ -180,7 +184,7 @@ namespace NJsonSchema
                 .Replace("\n ", "\n")
                 .Replace("  \n", " \n")
                 .Replace("\n", "")
-                .Trim('\n', '\t', ' ');
+                .Trim(_lineBreakTrimChars);
         }
 
         /// <summary>Singularizes the given noun in plural.</summary>

--- a/src/NJsonSchema/ConversionUtilities.cs
+++ b/src/NJsonSchema/ConversionUtilities.cs
@@ -9,6 +9,7 @@
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
@@ -58,8 +59,7 @@ namespace NJsonSchema
                 return string.Empty;
             }
 
-            input = ConvertDashesToCamelCase(
-                (input[0].ToString().ToUpperInvariant() + (input.Length > 1 ? input.Substring(1) : ""))
+            input = ConvertDashesToCamelCase(Capitalize(input)
                 .Replace(" ", "_")
                 .Replace("/", "_"));
 
@@ -69,6 +69,20 @@ namespace NJsonSchema
             }
 
             return input;
+        }
+
+        [MethodImpl((MethodImplOptions) 256)]
+        private static string Capitalize(string input)
+        {
+            if (char.IsUpper(input[0]))
+            {
+                return input;
+            }
+            if (input.Length == 1)
+            {
+                return char.ToUpperInvariant(input[0]).ToString();
+            }
+            return char.ToUpperInvariant(input[0]) + input.Substring(1);
         }
 
         /// <summary>Converts the string to a string literal which can be used in C# or TypeScript code.</summary>

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -142,7 +142,7 @@ namespace NJsonSchema.Generation
                 schema.Title = Settings.SchemaNameGenerator.Generate(typeDescription.ContextualType.OriginalType);
             }
 
-            if (typeDescription.Type.HasFlag(JsonObjectType.Object))
+            if (typeDescription.Type.IsObject())
             {
                 if (typeDescription.IsDictionary)
                 {
@@ -168,7 +168,7 @@ namespace NJsonSchema.Generation
             {
                 GenerateEnum(schema, typeDescription, schemaResolver);
             }
-            else if (typeDescription.Type.HasFlag(JsonObjectType.Array)) // TODO: Add support for tuples?
+            else if (typeDescription.Type.IsArray()) // TODO: Add support for tuples?
             {
                 GenerateArray(schema, typeDescription, schemaResolver);
             }
@@ -304,7 +304,7 @@ namespace NJsonSchema.Generation
             }
             else
             {
-                referencingSchema.AllOf.Add(new JsonSchema
+                referencingSchema._allOf.Add(new JsonSchema
                 {
                     Reference = referencedSchema.ActualSchema
                 });
@@ -363,7 +363,7 @@ namespace NJsonSchema.Generation
             if (defaultValueAttribute != null)
             {
                 if (typeDescription.IsEnum &&
-                    typeDescription.Type.HasFlag(JsonObjectType.String))
+                    typeDescription.Type.IsString())
                 {
                     schema.Default = defaultValueAttribute.Value?.ToString();
                 }
@@ -546,7 +546,7 @@ namespace NJsonSchema.Generation
                 ApplyAdditionalProperties(schema, type, schemaResolver);
             }
 
-            if (!schema.Type.HasFlag(JsonObjectType.Array))
+            if (!schema.Type.IsArray())
             {
                 typeDescription.ApplyType(schema);
             }
@@ -1085,18 +1085,18 @@ namespace NJsonSchema.Generation
                                     schemaResolver.AppendSchema(baseSchema.ActualSchema, Settings.SchemaNameGenerator.Generate(baseType));
                                 }
 
-                                schema.AllOf.Add(new JsonSchema
+                                schema._allOf.Add(new JsonSchema
                                 {
                                     Reference = baseSchema.ActualSchema
                                 });
                             }
                             else
                             {
-                                schema.AllOf.Add(baseSchema);
+                                schema._allOf.Add(baseSchema);
                             }
 
                             // First schema is the (referenced) base schema, second is the type schema itself
-                            schema.AllOf.Add(actualSchema);
+                            schema._allOf.Add(actualSchema);
                             return actualSchema;
                         }
                         else
@@ -1144,8 +1144,8 @@ namespace NJsonSchema.Generation
                     // Existing property can be discriminator only if it has String type
                     if (typeSchema.Properties.TryGetValue(discriminatorName, out var existingProperty))
                     {
-                        if (!existingProperty.ActualTypeSchema.Type.HasFlag(JsonObjectType.Integer) &&
-                            !existingProperty.ActualTypeSchema.Type.HasFlag(JsonObjectType.String))
+                        if (!existingProperty.ActualTypeSchema.Type.IsInteger() &&
+                            !existingProperty.ActualTypeSchema.Type.IsString())
                         {
                             throw new InvalidOperationException("The JSON discriminator property '" + discriminatorName + "' must be a string|int property on type '" + type.FullName + "' (it is recommended to not implement the discriminator property at all).");
                         }

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -246,8 +246,8 @@ namespace NJsonSchema.Generation
                         {
                             if (schema.Type == JsonObjectType.None)
                             {
-                                schema.OneOf.Add(new JsonSchema { Type = JsonObjectType.None });
-                                schema.OneOf.Add(new JsonSchema { Type = JsonObjectType.Null });
+                                schema._oneOf.Add(new JsonSchema { Type = JsonObjectType.None });
+                                schema._oneOf.Add(new JsonSchema { Type = JsonObjectType.Null });
                             }
                             else
                             {
@@ -279,7 +279,7 @@ namespace NJsonSchema.Generation
             {
                 if (Settings.SchemaType == SchemaType.JsonSchema)
                 {
-                    referencingSchema.OneOf.Add(new JsonSchema { Type = JsonObjectType.Null });
+                    referencingSchema._oneOf.Add(new JsonSchema { Type = JsonObjectType.Null });
                 }
                 else if (Settings.SchemaType == SchemaType.OpenApi3 || Settings.GenerateCustomNullableProperties)
                 {
@@ -291,13 +291,13 @@ namespace NJsonSchema.Generation
             var useDirectReference = Settings.AllowReferencesWithProperties ||
                 !JsonConvert.DeserializeObject<JObject>(JsonConvert.SerializeObject(referencingSchema)).Properties().Any(); // TODO: Improve performance
 
-            if (useDirectReference && referencingSchema.OneOf.Count == 0)
+            if (useDirectReference && referencingSchema._oneOf.Count == 0)
             {
                 referencingSchema.Reference = referencedSchema.ActualSchema;
             }
             else if (Settings.SchemaType != SchemaType.Swagger2)
             {
-                referencingSchema.OneOf.Add(new JsonSchema
+                referencingSchema._oneOf.Add(new JsonSchema
                 {
                     Reference = referencedSchema.ActualSchema
                 });

--- a/src/NJsonSchema/Generation/JsonSchemaGeneratorSettings.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGeneratorSettings.cs
@@ -80,7 +80,7 @@ namespace NJsonSchema.Generation
         /// <summary>Gets or sets a value indicating whether to ignore properties with the <see cref="ObsoleteAttribute"/>.</summary>
         public bool IgnoreObsoleteProperties { get; set; }
 
-        /// <summary>Gets or sets a value indicating whether to use $ref references even if additional properties are 
+        /// <summary>Gets or sets a value indicating whether to use $ref references even if additional properties are
         /// defined on the object (otherwise allOf/oneOf with $ref is used, default: false).</summary>
         public bool AllowReferencesWithProperties { get; set; }
 
@@ -203,20 +203,22 @@ namespace NJsonSchema.Generation
                 return null;
             }
 
-            if (!_cachedContracts.ContainsKey(key))
+            if (!_cachedContracts.TryGetValue(key, out var contract))
             {
                 lock (_cachedContracts)
                 {
-                    if (!_cachedContracts.ContainsKey(key))
+                    if (!_cachedContracts.TryGetValue(key, out contract))
                     {
-                        _cachedContracts[key] = !type.GetTypeInfo().IsGenericTypeDefinition ?
-                            ActualContractResolver.ResolveContract(type) :
-                            null;
+                        contract = !type.GetTypeInfo().IsGenericTypeDefinition
+                            ? ActualContractResolver.ResolveContract(type)
+                            : null;
+
+                        _cachedContracts[key] = contract;
                     }
                 }
             }
 
-            return _cachedContracts[key];
+            return contract;
         }
 
         /// <summary>Gets the actual computed <see cref="GenerateAbstractSchemas"/> setting based on the global setting and the JsonSchemaAbstractAttribute attribute.</summary>

--- a/src/NJsonSchema/Generation/JsonTypeDescription.cs
+++ b/src/NJsonSchema/Generation/JsonTypeDescription.cs
@@ -84,7 +84,7 @@ namespace NJsonSchema.Generation
         public bool IsNullable { get; set; }
 
         /// <summary>Gets a value indicating whether this is a complex type (i.e. object, dictionary or array).</summary>
-        public bool IsComplexType => IsDictionary || Type.HasFlag(JsonObjectType.Object) || Type.HasFlag(JsonObjectType.Array);
+        public bool IsComplexType => IsDictionary || Type.IsObject() || Type.IsArray();
 
         /// <summary>Gets a value indicating whether this is an any type (e.g. object).</summary>
         public bool IsAny => Type == JsonObjectType.None;
@@ -100,7 +100,7 @@ namespace NJsonSchema.Generation
                 return typeMapper.UseReference;
             }
 
-            return !IsDictionary && (Type.HasFlag(JsonObjectType.Object) || IsEnum);
+            return !IsDictionary && (Type.IsObject() || IsEnum);
         }
 
         /// <summary>Applies the type and format to the given schema.</summary>

--- a/src/NJsonSchema/Generation/SampleJsonDataGenerator.cs
+++ b/src/NJsonSchema/Generation/SampleJsonDataGenerator.cs
@@ -58,6 +58,7 @@ namespace NJsonSchema.Generation
 
                 var schemas = new[] { schema }.Concat(schema.AllOf.Select(x => x.ActualSchema));
                 var properties = GetPropertiesToGenerate(schemas);
+
                 var obj = new JObject();
                 foreach (var p in properties)
                 {

--- a/src/NJsonSchema/Generation/SampleJsonDataGenerator.cs
+++ b/src/NJsonSchema/Generation/SampleJsonDataGenerator.cs
@@ -52,8 +52,7 @@ namespace NJsonSchema.Generation
                 return null;
             }
 
-            if (schema.Type.HasFlag(JsonObjectType.Object) ||
-                GetPropertiesToGenerate(schema.AllOf).Any())
+            if (schema.Type.IsObject() || GetPropertiesToGenerate(schema.AllOf).Any())
             {
                 usedSchemas.Add(schema);
 
@@ -70,7 +69,7 @@ namespace NJsonSchema.Generation
             {
                 return JToken.FromObject(schema.Default);
             }
-            else if (schema.Type.HasFlag(JsonObjectType.Array))
+            else if (schema.Type.IsArray())
             {
                 if (schema.Item != null)
                 {
@@ -98,19 +97,19 @@ namespace NJsonSchema.Generation
                 {
                     return JToken.FromObject(schema.Enumeration.First());
                 }
-                else if (schema.Type.HasFlag(JsonObjectType.Integer))
+                else if (schema.Type.IsInteger())
                 {
                     return HandleIntegerType(schema);
                 }
-                else if (schema.Type.HasFlag(JsonObjectType.Number))
+                else if (schema.Type.IsNumber())
                 {
                     return HandleNumberType(schema);
                 }
-                else if (schema.Type.HasFlag(JsonObjectType.String))
+                else if (schema.Type.IsString())
                 {
                     return HandleStringType(schema, property);
                 }
-                else if (schema.Type.HasFlag(JsonObjectType.Boolean))
+                else if (schema.Type.IsBoolean())
                 {
                     return JToken.FromObject(false);
                 }

--- a/src/NJsonSchema/Infrastructure/DictionaryProxy.cs
+++ b/src/NJsonSchema/Infrastructure/DictionaryProxy.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace NJsonSchema.Infrastructure
 {
-    internal class DictionaryProxy<TKey, TInterface, TImplementation> : IDictionary<TKey, TInterface>
+    internal sealed class DictionaryProxy<TKey, TInterface, TImplementation> : IDictionary<TKey, TInterface>
         where TImplementation : TInterface
     {
         private readonly IDictionary<TKey, TImplementation> _dictionary;

--- a/src/NJsonSchema/Infrastructure/EnumExtensions.cs
+++ b/src/NJsonSchema/Infrastructure/EnumExtensions.cs
@@ -1,0 +1,39 @@
+// intentionally root name space to light up faster helpers
+
+using System.Runtime.CompilerServices;
+
+namespace NJsonSchema
+{
+    internal static class EnumExtensions
+    {
+        // for older frameworks
+        private const MethodImplOptions OptionAggressiveInlining = (MethodImplOptions) 256;
+
+        [MethodImpl(OptionAggressiveInlining)]
+        public static bool IsNull(this JsonObjectType type) => (type & JsonObjectType.Null) != 0;
+
+        [MethodImpl(OptionAggressiveInlining)]
+        public static bool IsNumber(this JsonObjectType type) => (type & JsonObjectType.Number) != 0;
+
+        [MethodImpl(OptionAggressiveInlining)]
+        public static bool IsObject(this JsonObjectType type) => (type & JsonObjectType.Object) != 0;
+
+        [MethodImpl(OptionAggressiveInlining)]
+        public static bool IsArray(this JsonObjectType type) => (type & JsonObjectType.Array) != 0;
+
+        [MethodImpl(OptionAggressiveInlining)]
+        public static bool IsInteger(this JsonObjectType type) => (type & JsonObjectType.Integer) != 0;
+
+        [MethodImpl(OptionAggressiveInlining)]
+        public static bool IsString(this JsonObjectType type) => (type & JsonObjectType.String) != 0;
+
+        [MethodImpl(OptionAggressiveInlining)]
+        public static bool IsBoolean(this JsonObjectType type) => (type & JsonObjectType.Boolean) != 0;
+
+        [MethodImpl(OptionAggressiveInlining)]
+        public static bool IsFile(this JsonObjectType type) => (type & JsonObjectType.File) != 0;
+
+        [MethodImpl(OptionAggressiveInlining)]
+        public static bool IsNone(this JsonObjectType type) => type == JsonObjectType.None;
+    }
+}

--- a/src/NJsonSchema/Infrastructure/IgnoreEmptyCollectionsContractResolver.cs
+++ b/src/NJsonSchema/Infrastructure/IgnoreEmptyCollectionsContractResolver.cs
@@ -14,7 +14,7 @@ using Newtonsoft.Json.Serialization;
 
 namespace NJsonSchema.Infrastructure
 {
-    internal class IgnoreEmptyCollectionsContractResolver : PropertyRenameAndIgnoreSerializerContractResolver
+    internal sealed class IgnoreEmptyCollectionsContractResolver : PropertyRenameAndIgnoreSerializerContractResolver
     {
         protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
         {

--- a/src/NJsonSchema/JsonExtensionObject.cs
+++ b/src/NJsonSchema/JsonExtensionObject.cs
@@ -24,7 +24,7 @@ namespace NJsonSchema
     }
 
     /// <summary>Deserializes all JSON Schemas in the extension data property.</summary>
-    internal class ExtensionDataDeserializationConverter : JsonConverter
+    internal sealed class ExtensionDataDeserializationConverter : JsonConverter
     {
         public override bool CanRead => true;
 

--- a/src/NJsonSchema/JsonSchema.Reference.cs
+++ b/src/NJsonSchema/JsonSchema.Reference.cs
@@ -19,7 +19,7 @@ namespace NJsonSchema
         /// <exception cref="InvalidOperationException">Cyclic references detected.</exception>
         /// <exception cref="InvalidOperationException">The schema reference path has not been resolved.</exception>
         [JsonIgnore]
-        public virtual JsonSchema ActualSchema => GetActualSchema(new List<JsonSchema>());
+        public virtual JsonSchema ActualSchema => GetActualSchema(new List<JsonSchema>()); // we use list here there are usually very when items
 
         /// <summary>Gets the type actual schema (e.g. the shared schema of a property, parameter, etc.).</summary>
         /// <exception cref="InvalidOperationException">Cyclic references detected.</exception>
@@ -84,14 +84,14 @@ namespace NJsonSchema
 
         /// <exception cref="InvalidOperationException">Cyclic references detected.</exception>
         /// <exception cref="InvalidOperationException">The schema reference path has not been resolved.</exception>
-        private JsonSchema GetActualSchema(IList<JsonSchema> checkedSchemas)
+        private JsonSchema GetActualSchema(List<JsonSchema> checkedSchemas)
         {
             if (checkedSchemas.Contains(this))
             {
                 throw new InvalidOperationException("Cyclic references detected.");
             }
 
-            if (((IJsonReferenceBase)this).ReferencePath != null && Reference == null)
+            if (Reference == null && ((IJsonReferenceBase)this).ReferencePath != null)
             {
                 throw new InvalidOperationException("The schema reference path '" + ((IJsonReferenceBase)this).ReferencePath + "' has not been resolved.");
             }
@@ -102,17 +102,17 @@ namespace NJsonSchema
 
                 if (HasAllOfSchemaReference)
                 {
-                    return _allOf.First().GetActualSchema(checkedSchemas);
+                    return _allOf[0].GetActualSchema(checkedSchemas);
                 }
 
                 if (HasOneOfSchemaReference)
                 {
-                    return _oneOf.First().GetActualSchema(checkedSchemas);
+                    return _oneOf[0].GetActualSchema(checkedSchemas);
                 }
 
                 if (HasAnyOfSchemaReference)
                 {
-                    return _anyOf.First().GetActualSchema(checkedSchemas);
+                    return _anyOf[0].GetActualSchema(checkedSchemas);
                 }
 
                 return Reference.GetActualSchema(checkedSchemas);

--- a/src/NJsonSchema/JsonSchema.Reference.cs
+++ b/src/NJsonSchema/JsonSchema.Reference.cs
@@ -8,7 +8,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 using NJsonSchema.References;
 
@@ -31,12 +30,12 @@ namespace NJsonSchema
             get
             {
                 var schema = Reference != null ? Reference : this;
-                if (schema.AllOf.Count > 1 && schema.AllOf.Count(s => !s.HasReference && !s.IsDictionary) == 1)
+                if (schema._allOf.Count > 1 && schema._allOf.Count(s => !s.HasReference && !s.IsDictionary) == 1)
                 {
-                    return schema.AllOf.First(s => !s.HasReference && !s.IsDictionary).ActualSchema;
+                    return schema._allOf.First(s => !s.HasReference && !s.IsDictionary).ActualSchema;
                 }
 
-                return schema.OneOf.FirstOrDefault(o => !o.IsNullable(SchemaType.JsonSchema))?.ActualSchema ?? ActualSchema;
+                return schema._oneOf.FirstOrDefault(o => !o.IsNullable(SchemaType.JsonSchema))?.ActualSchema ?? ActualSchema;
             }
         }
 
@@ -46,39 +45,39 @@ namespace NJsonSchema
 
         /// <summary>Gets a value indicating whether this is an allOf schema reference.</summary>
         [JsonIgnore]
-        public bool HasAllOfSchemaReference => AllOf.Count == 1 &&
-                                               AllOf.Any(s => s.HasReference) &&
+        public bool HasAllOfSchemaReference => _allOf.Count == 1 &&
+                                               _allOf.Any(s => s.HasReference) &&
                                                Type == JsonObjectType.None &&
-                                               AnyOf.Count == 0 &&
-                                               OneOf.Count == 0 &&
-                                               Properties.Count == 0 &&
-                                               PatternProperties.Count == 0 &&
+                                               _anyOf.Count == 0 &&
+                                               _oneOf.Count == 0 &&
+                                               _properties.Count == 0 &&
+                                               _patternProperties.Count == 0 &&
                                                AdditionalPropertiesSchema == null &&
                                                MultipleOf == null &&
                                                IsEnumeration == false;
 
         /// <summary>Gets a value indicating whether this is an oneOf schema reference.</summary>
         [JsonIgnore]
-        public bool HasOneOfSchemaReference => OneOf.Count == 1 &&
-                                               OneOf.Any(s => s.HasReference) &&
+        public bool HasOneOfSchemaReference => _oneOf.Count == 1 &&
+                                               _oneOf.Any(s => s.HasReference) &&
                                                Type == JsonObjectType.None &&
-                                               AnyOf.Count == 0 &&
-                                               AllOf.Count == 0 &&
-                                               Properties.Count == 0 &&
-                                               PatternProperties.Count == 0 &&
+                                               _anyOf.Count == 0 &&
+                                               _allOf.Count == 0 &&
+                                               _properties.Count == 0 &&
+                                               _patternProperties.Count == 0 &&
                                                AdditionalPropertiesSchema == null &&
                                                MultipleOf == null &&
                                                IsEnumeration == false;
 
         /// <summary>Gets a value indicating whether this is an anyOf schema reference.</summary>
         [JsonIgnore]
-        public bool HasAnyOfSchemaReference => AnyOf.Count == 1 &&
-                                               AnyOf.Any(s => s.HasReference) &&
+        public bool HasAnyOfSchemaReference => _anyOf.Count == 1 &&
+                                               _anyOf.Any(s => s.HasReference) &&
                                                Type == JsonObjectType.None &&
-                                               AllOf.Count == 0 &&
-                                               OneOf.Count == 0 &&
-                                               Properties.Count == 0 &&
-                                               PatternProperties.Count == 0 &&
+                                               _allOf.Count == 0 &&
+                                               _oneOf.Count == 0 &&
+                                               _properties.Count == 0 &&
+                                               _patternProperties.Count == 0 &&
                                                AdditionalPropertiesSchema == null &&
                                                MultipleOf == null &&
                                                IsEnumeration == false;
@@ -103,17 +102,17 @@ namespace NJsonSchema
 
                 if (HasAllOfSchemaReference)
                 {
-                    return AllOf.First().GetActualSchema(checkedSchemas);
+                    return _allOf.First().GetActualSchema(checkedSchemas);
                 }
 
                 if (HasOneOfSchemaReference)
                 {
-                    return OneOf.First().GetActualSchema(checkedSchemas);
+                    return _oneOf.First().GetActualSchema(checkedSchemas);
                 }
 
                 if (HasAnyOfSchemaReference)
                 {
-                    return AnyOf.First().GetActualSchema(checkedSchemas);
+                    return _anyOf.First().GetActualSchema(checkedSchemas);
                 }
 
                 return Reference.GetActualSchema(checkedSchemas);
@@ -143,7 +142,7 @@ namespace NJsonSchema
                 if (value != null)
                 {
                     // only $ref property is allowed when schema is a reference
-                    // TODO: Fix all SchemaReference assignments so that this code is not needed 
+                    // TODO: Fix all SchemaReference assignments so that this code is not needed
                     Type = JsonObjectType.None;
                 }
             }

--- a/src/NJsonSchema/JsonSchema.Serialization.cs
+++ b/src/NJsonSchema/JsonSchema.Serialization.cs
@@ -225,7 +225,7 @@ namespace NJsonSchema
                     if (AllowAdditionalProperties &&
                         (Type.IsObject() || Type == JsonObjectType.None) &&
                         !HasReference &&
-                        !AllOf.Any() &&
+                        !_allOf.Any() &&
                         !GetType().IsAssignableToTypeName("OpenApiParameter", TypeNameStyle.Name))
                     {
                         return new JObject(); // bool is not allowed in Swagger2
@@ -355,7 +355,7 @@ namespace NJsonSchema
         [JsonProperty("properties", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         internal IDictionary<string, JsonSchemaProperty> PropertiesRaw
         {
-            get => Properties != null && Properties.Count > 0 ? Properties : null;
+            get => _properties != null && _properties.Count > 0 ? Properties : null;
             set
             {
                 Properties = value != null ?
@@ -369,7 +369,7 @@ namespace NJsonSchema
         {
             get
             {
-                return PatternProperties != null && PatternProperties.Count > 0 ?
+                return _patternProperties != null && _patternProperties.Count > 0 ?
                     PatternProperties.ToDictionary(p => p.Key, p => p.Value) : null;
             }
             set
@@ -405,63 +405,63 @@ namespace NJsonSchema
         [JsonProperty("allOf", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         internal ICollection<JsonSchema> AllOfRaw
         {
-            get { return AllOf != null && AllOf.Count > 0 ? AllOf : null; }
+            get { return _allOf != null && _allOf.Count > 0 ? AllOf : null; }
             set { AllOf = value != null ? new ObservableCollection<JsonSchema>(value) : new ObservableCollection<JsonSchema>(); }
         }
 
         [JsonProperty("anyOf", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         internal ICollection<JsonSchema> AnyOfRaw
         {
-            get { return AnyOf != null && AnyOf.Count > 0 ? AnyOf : null; }
+            get { return _anyOf != null && _anyOf.Count > 0 ? AnyOf : null; }
             set { AnyOf = value != null ? new ObservableCollection<JsonSchema>(value) : new ObservableCollection<JsonSchema>(); }
         }
 
         [JsonProperty("oneOf", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         internal ICollection<JsonSchema> OneOfRaw
         {
-            get { return OneOf != null && OneOf.Count > 0 ? OneOf : null; }
+            get { return _oneOf != null && _oneOf.Count > 0 ? OneOf : null; }
             set { OneOf = value != null ? new ObservableCollection<JsonSchema>(value) : new ObservableCollection<JsonSchema>(); }
         }
 
-        private void RegisterProperties(IDictionary<string, JsonSchemaProperty> oldCollection, IDictionary<string, JsonSchemaProperty> newCollection)
+        private void RegisterProperties(ObservableDictionary<string, JsonSchemaProperty> oldCollection, ObservableDictionary<string, JsonSchemaProperty> newCollection)
         {
             if (oldCollection != null)
             {
-                ((ObservableDictionary<string, JsonSchemaProperty>)oldCollection).CollectionChanged -= InitializeSchemaCollection;
+                oldCollection.CollectionChanged -= InitializeSchemaCollection;
             }
 
             if (newCollection != null)
             {
-                ((ObservableDictionary<string, JsonSchemaProperty>)newCollection).CollectionChanged += InitializeSchemaCollection;
+                newCollection.CollectionChanged += InitializeSchemaCollection;
                 InitializeSchemaCollection(newCollection, null);
             }
         }
 
-        private void RegisterSchemaDictionary<T>(IDictionary<string, T> oldCollection, IDictionary<string, T> newCollection)
+        private void RegisterSchemaDictionary<T>(ObservableDictionary<string, T> oldCollection, ObservableDictionary<string, T> newCollection)
             where T : JsonSchema
         {
             if (oldCollection != null)
             {
-                ((ObservableDictionary<string, T>)oldCollection).CollectionChanged -= InitializeSchemaCollection;
+                oldCollection.CollectionChanged -= InitializeSchemaCollection;
             }
 
             if (newCollection != null)
             {
-                ((ObservableDictionary<string, T>)newCollection).CollectionChanged += InitializeSchemaCollection;
+                newCollection.CollectionChanged += InitializeSchemaCollection;
                 InitializeSchemaCollection(newCollection, null);
             }
         }
 
-        private void RegisterSchemaCollection(ICollection<JsonSchema> oldCollection, ICollection<JsonSchema> newCollection)
+        private void RegisterSchemaCollection(ObservableCollection<JsonSchema> oldCollection, ObservableCollection<JsonSchema> newCollection)
         {
             if (oldCollection != null)
             {
-                ((ObservableCollection<JsonSchema>)oldCollection).CollectionChanged -= InitializeSchemaCollection;
+                oldCollection.CollectionChanged -= InitializeSchemaCollection;
             }
 
             if (newCollection != null)
             {
-                ((ObservableCollection<JsonSchema>)newCollection).CollectionChanged += InitializeSchemaCollection;
+                newCollection.CollectionChanged += InitializeSchemaCollection;
                 InitializeSchemaCollection(newCollection, null);
             }
         }

--- a/src/NJsonSchema/JsonSchema.Serialization.cs
+++ b/src/NJsonSchema/JsonSchema.Serialization.cs
@@ -223,7 +223,7 @@ namespace NJsonSchema
                 if (JsonSchemaSerialization.CurrentSchemaType == SchemaType.Swagger2)
                 {
                     if (AllowAdditionalProperties &&
-                        (Type.HasFlag(JsonObjectType.Object) || Type == JsonObjectType.None) &&
+                        (Type.IsObject() || Type == JsonObjectType.None) &&
                         !HasReference &&
                         !AllOf.Any() &&
                         !GetType().IsAssignableToTypeName("OpenApiParameter", TypeNameStyle.Name))

--- a/src/NJsonSchema/JsonSchema.cs
+++ b/src/NJsonSchema/JsonSchema.cs
@@ -57,6 +57,8 @@ namespace NJsonSchema
         /// <summary>Initializes a new instance of the <see cref="JsonSchema"/> class. </summary>
         public JsonSchema()
         {
+            _initializeSchemaCollectionEventHandler = InitializeSchemaCollection;
+
             Initialize();
 
             if (JsonSchemaSerialization.CurrentSchemaType == SchemaType.Swagger2)

--- a/src/NJsonSchema/JsonSchema.cs
+++ b/src/NJsonSchema/JsonSchema.cs
@@ -32,8 +32,7 @@ namespace NJsonSchema
 
         private const SchemaType SerializationSchemaType = SchemaType.JsonSchema;
 
-        private static Lazy<PropertyRenameAndIgnoreSerializerContractResolver> ContractResolver = new Lazy<PropertyRenameAndIgnoreSerializerContractResolver>(
-            () => CreateJsonSerializerContractResolver(SerializationSchemaType));
+        private static readonly Lazy<PropertyRenameAndIgnoreSerializerContractResolver> ContractResolver = new(() => CreateJsonSerializerContractResolver(SerializationSchemaType));
 
         private ObservableDictionary<string, JsonSchemaProperty> _properties;
         private ObservableDictionary<string, JsonSchemaProperty> _patternProperties;
@@ -47,7 +46,7 @@ namespace NJsonSchema
 
         private JsonObjectType _type;
         private JsonSchema _item;
-        private ObservableCollection<JsonSchema> _items;
+        internal ObservableCollection<JsonSchema> _items;
 
         private bool _allowAdditionalItems = true;
         private JsonSchema _additionalItemsSchema = null;

--- a/src/NJsonSchema/JsonSchemaReferenceUtilities.cs
+++ b/src/NJsonSchema/JsonSchemaReferenceUtilities.cs
@@ -34,7 +34,7 @@ namespace NJsonSchema
         /// <param name="rootObject">The root object.</param>
         /// <param name="contractResolver">The contract resolver.</param>
         /// <param name="cancellationToken">The cancellation token</param>
-        public static async Task UpdateSchemaReferencesAsync(object rootObject, JsonReferenceResolver referenceResolver, 
+        public static async Task UpdateSchemaReferencesAsync(object rootObject, JsonReferenceResolver referenceResolver,
                 IContractResolver contractResolver, CancellationToken cancellationToken = default)
         {
             var updater = new JsonReferenceUpdater(rootObject, referenceResolver, contractResolver);
@@ -70,7 +70,7 @@ namespace NJsonSchema
             }
         }
 
-        private class JsonReferenceUpdater : AsyncJsonReferenceVisitorBase
+        private sealed class JsonReferenceUpdater : AsyncJsonReferenceVisitorBase
         {
             private readonly object _rootObject;
             private readonly JsonReferenceResolver _referenceResolver;
@@ -121,7 +121,7 @@ namespace NJsonSchema
             }
         }
 
-        private class JsonReferencePathUpdater : JsonReferenceVisitorBase
+        private sealed class JsonReferencePathUpdater : JsonReferenceVisitorBase
         {
             private readonly object _rootObject;
             private readonly Dictionary<IJsonReference, IJsonReference> _schemaReferences;

--- a/src/NJsonSchema/OpenApiDiscriminator.cs
+++ b/src/NJsonSchema/OpenApiDiscriminator.cs
@@ -62,7 +62,7 @@ namespace NJsonSchema
         /// See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#discriminator-object and
         /// issue https://github.com/RicoSuter/NSwag/issues/1684
         /// </summary>
-        private class DiscriminatorMappingConverter : JsonConverter
+        private sealed class DiscriminatorMappingConverter : JsonConverter
         {
             public override bool CanConvert(Type objectType)
             {

--- a/src/NJsonSchema/Validation/JsonSchemaValidator.cs
+++ b/src/NJsonSchema/Validation/JsonSchemaValidator.cs
@@ -175,9 +175,9 @@ namespace NJsonSchema.Validation
 
         private void ValidateOneOf(JToken token, JsonSchema schema, string propertyName, string propertyPath, List<ValidationError> errors)
         {
-            if (schema.OneOf.Count > 0)
+            if (schema._oneOf.Count > 0)
             {
-                var propertyErrors = schema.OneOf.ToDictionary(s => s, s => Validate(token, s));
+                var propertyErrors = schema._oneOf.ToDictionary(s => s, s => Validate(token, s));
                 if (propertyErrors.Count(s => s.Value.Count == 0) != 1)
                 {
                     errors.Add(new ChildSchemaValidationError(ValidationErrorKind.NotOneOf, propertyName, propertyPath, propertyErrors, token, schema));
@@ -195,7 +195,7 @@ namespace NJsonSchema.Validation
 
         private void ValidateNull(JToken token, JsonSchema schema, JsonObjectType type, string propertyName, string propertyPath, List<ValidationError> errors)
         {
-            if (type.HasFlag(JsonObjectType.Null) && token != null && token.Type != JTokenType.Null)
+            if (type.IsNull() && token != null && token.Type != JTokenType.Null)
             {
                 errors.Add(new ValidationError(ValidationErrorKind.NullExpected, propertyName, propertyPath, token, schema));
             }
@@ -251,7 +251,7 @@ namespace NJsonSchema.Validation
                     }
                 }
             }
-            else if (type.HasFlag(JsonObjectType.String))
+            else if (type.IsString())
             {
                 errors.Add(new ValidationError(ValidationErrorKind.StringExpected, propertyName, propertyPath, token, schema));
             }
@@ -259,7 +259,7 @@ namespace NJsonSchema.Validation
 
         private void ValidateNumber(JToken token, JsonSchema schema, JsonObjectType type, string propertyName, string propertyPath, List<ValidationError> errors)
         {
-            if (type.HasFlag(JsonObjectType.Number) && token.Type != JTokenType.Float && token.Type != JTokenType.Integer)
+            if (type.IsNumber() && token.Type != JTokenType.Float && token.Type != JTokenType.Integer)
             {
                 errors.Add(new ValidationError(ValidationErrorKind.NumberExpected, propertyName, propertyPath, token, schema));
             }
@@ -329,7 +329,7 @@ namespace NJsonSchema.Validation
 
         private void ValidateInteger(JToken token, JsonSchema schema, JsonObjectType type, string propertyName, string propertyPath, List<ValidationError> errors)
         {
-            if (type.HasFlag(JsonObjectType.Integer) && token.Type != JTokenType.Integer)
+            if (type.IsInteger() && token.Type != JTokenType.Integer)
             {
                 errors.Add(new ValidationError(ValidationErrorKind.IntegerExpected, propertyName, propertyPath, token, schema));
             }
@@ -337,7 +337,7 @@ namespace NJsonSchema.Validation
 
         private void ValidateBoolean(JToken token, JsonSchema schema, JsonObjectType type, string propertyName, string propertyPath, List<ValidationError> errors)
         {
-            if (type.HasFlag(JsonObjectType.Boolean) && token.Type != JTokenType.Boolean)
+            if (type.IsBoolean() && token.Type != JTokenType.Boolean)
             {
                 errors.Add(new ValidationError(ValidationErrorKind.BooleanExpected, propertyName, propertyPath, token, schema));
             }
@@ -345,7 +345,7 @@ namespace NJsonSchema.Validation
 
         private void ValidateObject(JToken token, JsonSchema schema, JsonObjectType type, string propertyName, string propertyPath, List<ValidationError> errors)
         {
-            if (type.HasFlag(JsonObjectType.Object) && !(token is JObject))
+            if (type.IsObject() && !(token is JObject))
             {
                 errors.Add(new ValidationError(ValidationErrorKind.ObjectExpected, propertyName, propertyPath, token, schema));
             }
@@ -354,7 +354,7 @@ namespace NJsonSchema.Validation
         private void ValidateProperties(JToken token, JsonSchema schema, SchemaType schemaType, string propertyName, string propertyPath, List<ValidationError> errors)
         {
             var obj = token as JObject;
-            if (obj == null && schema.Type.HasFlag(JsonObjectType.Null))
+            if (obj == null && schema.Type.IsNull())
             {
                 return;
             }
@@ -517,7 +517,7 @@ namespace NJsonSchema.Validation
                     ValidateAdditionalItems(item, schema, schemaType, index, propertyPath, errors);
                 }
             }
-            else if (type.HasFlag(JsonObjectType.Array))
+            else if (type.IsArray())
             {
                 errors.Add(new ValidationError(ValidationErrorKind.ArrayExpected, propertyName, propertyPath, token, schema));
             }

--- a/src/NJsonSchema/Validation/JsonSchemaValidator.cs
+++ b/src/NJsonSchema/Validation/JsonSchemaValidator.cs
@@ -151,9 +151,9 @@ namespace NJsonSchema.Validation
 
         private void ValidateAnyOf(JToken token, JsonSchema schema, string propertyName, string propertyPath, List<ValidationError> errors)
         {
-            if (schema.AnyOf.Count > 0)
+            if (schema._anyOf.Count > 0)
             {
-                var propertyErrors = schema.AnyOf.ToDictionary(s => s, s => Validate(token, s));
+                var propertyErrors = schema._anyOf.ToDictionary(s => s, s => Validate(token, s));
                 if (propertyErrors.All(s => s.Value.Count != 0))
                 {
                     errors.Add(new ChildSchemaValidationError(ValidationErrorKind.NotAnyOf, propertyName, propertyPath, propertyErrors, token, schema));
@@ -163,9 +163,9 @@ namespace NJsonSchema.Validation
 
         private void ValidateAllOf(JToken token, JsonSchema schema, string propertyName, string propertyPath, List<ValidationError> errors)
         {
-            if (schema.AllOf.Count > 0)
+            if (schema._allOf.Count > 0)
             {
-                var propertyErrors = schema.AllOf.ToDictionary(s => s, s => Validate(token, s));
+                var propertyErrors = schema._allOf.ToDictionary(s => s, s => Validate(token, s));
                 if (propertyErrors.Any(s => s.Value.Count != 0))
                 {
                     errors.Add(new ChildSchemaValidationError(ValidationErrorKind.NotAllOf, propertyName, propertyPath, propertyErrors, token, schema));

--- a/src/NJsonSchema/Visitors/AsyncJsonReferenceVisitorBase.cs
+++ b/src/NJsonSchema/Visitors/AsyncJsonReferenceVisitorBase.cs
@@ -124,22 +124,22 @@ namespace NJsonSchema.Visitors
                     await VisitAsync(schema.Items.ElementAt(i), path + "/items[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(schema.Items, index, (JsonSchema)o), cancellationToken).ConfigureAwait(false);
                 }
 
-                for (var i = 0; i < schema.AllOf.Count; i++)
+                for (var i = 0; i < schema._allOf.Count; i++)
                 {
                     var index = i;
-                    await VisitAsync(schema.AllOf.ElementAt(i), path + "/allOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(schema.AllOf, index, (JsonSchema)o), cancellationToken).ConfigureAwait(false);
+                    await VisitAsync(schema._allOf.ElementAt(i), path + "/allOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(schema.AllOf, index, (JsonSchema)o), cancellationToken).ConfigureAwait(false);
                 }
 
-                for (var i = 0; i < schema.AnyOf.Count; i++)
+                for (var i = 0; i < schema._anyOf.Count; i++)
                 {
                     var index = i;
-                    await VisitAsync(schema.AnyOf.ElementAt(i), path + "/anyOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(schema.AnyOf, index, (JsonSchema)o), cancellationToken).ConfigureAwait(false);
+                    await VisitAsync(schema._anyOf.ElementAt(i), path + "/anyOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(schema.AnyOf, index, (JsonSchema)o), cancellationToken).ConfigureAwait(false);
                 }
 
                 for (var i = 0; i < schema._oneOf.Count; i++)
                 {
                     var index = i;
-                    await VisitAsync(schema._oneOf.ElementAt(i), path + "/oneOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(schema._oneOf, index, (JsonSchema)o), cancellationToken).ConfigureAwait(false);
+                    await VisitAsync(schema._oneOf.ElementAt(i), path + "/oneOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(schema.OneOf, index, (JsonSchema)o), cancellationToken).ConfigureAwait(false);
                 }
 
                 if (schema.Not != null)

--- a/src/NJsonSchema/Visitors/AsyncJsonReferenceVisitorBase.cs
+++ b/src/NJsonSchema/Visitors/AsyncJsonReferenceVisitorBase.cs
@@ -96,7 +96,7 @@ namespace NJsonSchema.Visitors
             if (obj is JsonSchema schema)
             {
                 // Do not follow as the root object might be different than _rootObject, fixes https://github.com/RicoSuter/NJsonSchema/issues/588
-                // i.e. we should only visit the objects which might be references but not resolve 
+                // i.e. we should only visit the objects which might be references but not resolve
                 // because usually the resolved object is touched in another path (not via reference)
                 //if (schema.Reference != null)
                 //{
@@ -118,28 +118,32 @@ namespace NJsonSchema.Visitors
                     await VisitAsync(schema.Item, path + "/items", null, checkedObjects, o => schema.Item = (JsonSchema)o, cancellationToken).ConfigureAwait(false);
                 }
 
-                for (var i = 0; i < schema.Items.Count; i++)
+                var items = schema._items;
+                for (var i = 0; i < items.Count; i++)
                 {
                     var index = i;
-                    await VisitAsync(schema.Items.ElementAt(i), path + "/items[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(schema.Items, index, (JsonSchema)o), cancellationToken).ConfigureAwait(false);
+                    await VisitAsync(items[i], path + "/items[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(items, index, (JsonSchema)o), cancellationToken).ConfigureAwait(false);
                 }
 
-                for (var i = 0; i < schema._allOf.Count; i++)
+                var allOf = schema._allOf;
+                for (var i = 0; i < allOf.Count; i++)
                 {
                     var index = i;
-                    await VisitAsync(schema._allOf.ElementAt(i), path + "/allOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(schema.AllOf, index, (JsonSchema)o), cancellationToken).ConfigureAwait(false);
+                    await VisitAsync(allOf[i], path + "/allOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(allOf, index, (JsonSchema)o), cancellationToken).ConfigureAwait(false);
                 }
 
-                for (var i = 0; i < schema._anyOf.Count; i++)
+                var anyOf = schema._anyOf;
+                for (var i = 0; i < anyOf.Count; i++)
                 {
                     var index = i;
-                    await VisitAsync(schema._anyOf.ElementAt(i), path + "/anyOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(schema.AnyOf, index, (JsonSchema)o), cancellationToken).ConfigureAwait(false);
+                    await VisitAsync(anyOf[i], path + "/anyOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(anyOf, index, (JsonSchema)o), cancellationToken).ConfigureAwait(false);
                 }
 
-                for (var i = 0; i < schema._oneOf.Count; i++)
+                var oneOf = schema._oneOf;
+                for (var i = 0; i < oneOf.Count; i++)
                 {
                     var index = i;
-                    await VisitAsync(schema._oneOf.ElementAt(i), path + "/oneOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(schema.OneOf, index, (JsonSchema)o), cancellationToken).ConfigureAwait(false);
+                    await VisitAsync(oneOf[i], path + "/oneOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(oneOf, index, (JsonSchema)o), cancellationToken).ConfigureAwait(false);
                 }
 
                 if (schema.Not != null)
@@ -254,16 +258,16 @@ namespace NJsonSchema.Visitors
             }
         }
 
-        private void ReplaceOrDelete<T>(ICollection<T> collection, int index, T obj)
+        private static void ReplaceOrDelete<T>(ObservableCollection<T> collection, int index, T obj)
         {
-            ((Collection<T>)collection).RemoveAt(index);
+            collection.RemoveAt(index);
             if (obj != null)
             {
-                ((Collection<T>)collection).Insert(index, obj);
+                collection.Insert(index, obj);
             }
         }
 
-        private void ReplaceOrDelete(IList collection, int index, object obj)
+        private static void ReplaceOrDelete(IList collection, int index, object obj)
         {
             collection.RemoveAt(index);
             if (obj != null)

--- a/src/NJsonSchema/Visitors/AsyncJsonReferenceVisitorBase.cs
+++ b/src/NJsonSchema/Visitors/AsyncJsonReferenceVisitorBase.cs
@@ -136,10 +136,10 @@ namespace NJsonSchema.Visitors
                     await VisitAsync(schema.AnyOf.ElementAt(i), path + "/anyOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(schema.AnyOf, index, (JsonSchema)o), cancellationToken).ConfigureAwait(false);
                 }
 
-                for (var i = 0; i < schema.OneOf.Count; i++)
+                for (var i = 0; i < schema._oneOf.Count; i++)
                 {
                     var index = i;
-                    await VisitAsync(schema.OneOf.ElementAt(i), path + "/oneOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(schema.OneOf, index, (JsonSchema)o), cancellationToken).ConfigureAwait(false);
+                    await VisitAsync(schema._oneOf.ElementAt(i), path + "/oneOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(schema._oneOf, index, (JsonSchema)o), cancellationToken).ConfigureAwait(false);
                 }
 
                 if (schema.Not != null)

--- a/src/NJsonSchema/Visitors/JsonReferenceVisitorBase.cs
+++ b/src/NJsonSchema/Visitors/JsonReferenceVisitorBase.cs
@@ -104,22 +104,22 @@ namespace NJsonSchema.Visitors
                     Visit(schema.Items.ElementAt(i), path + "/items[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(schema.Items, index, (JsonSchema)o));
                 }
 
-                for (var i = 0; i < schema.AllOf.Count; i++)
+                for (var i = 0; i < schema._allOf.Count; i++)
                 {
                     var index = i;
-                    Visit(schema.AllOf.ElementAt(i), path + "/allOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(schema.AllOf, index, (JsonSchema)o));
+                    Visit(schema._allOf.ElementAt(i), path + "/allOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(schema.AllOf, index, (JsonSchema)o));
                 }
 
-                for (var i = 0; i < schema.AnyOf.Count; i++)
+                for (var i = 0; i < schema._anyOf.Count; i++)
                 {
                     var index = i;
-                    Visit(schema.AnyOf.ElementAt(i), path + "/anyOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(schema.AnyOf, index, (JsonSchema)o));
+                    Visit(schema._anyOf.ElementAt(i), path + "/anyOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(schema.AnyOf, index, (JsonSchema)o));
                 }
 
                 for (var i = 0; i < schema._oneOf.Count; i++)
                 {
                     var index = i;
-                    Visit(schema._oneOf.ElementAt(i), path + "/oneOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(schema._oneOf, index, (JsonSchema)o));
+                    Visit(schema._oneOf.ElementAt(i), path + "/oneOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(schema.OneOf, index, (JsonSchema)o));
                 }
 
                 if (schema.Not != null)
@@ -234,7 +234,7 @@ namespace NJsonSchema.Visitors
             }
         }
 
-        private void ReplaceOrDelete<T>(ICollection<T> collection, int index, T obj)
+        private static void ReplaceOrDelete<T>(ICollection<T> collection, int index, T obj)
         {
             ((Collection<T>)collection).RemoveAt(index);
             if (obj != null)
@@ -243,7 +243,7 @@ namespace NJsonSchema.Visitors
             }
         }
 
-        private void ReplaceOrDelete(IList collection, int index, object obj)
+        private static void ReplaceOrDelete(IList collection, int index, object obj)
         {
             collection.RemoveAt(index);
             if (obj != null)

--- a/src/NJsonSchema/Visitors/JsonReferenceVisitorBase.cs
+++ b/src/NJsonSchema/Visitors/JsonReferenceVisitorBase.cs
@@ -116,10 +116,10 @@ namespace NJsonSchema.Visitors
                     Visit(schema.AnyOf.ElementAt(i), path + "/anyOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(schema.AnyOf, index, (JsonSchema)o));
                 }
 
-                for (var i = 0; i < schema.OneOf.Count; i++)
+                for (var i = 0; i < schema._oneOf.Count; i++)
                 {
                     var index = i;
-                    Visit(schema.OneOf.ElementAt(i), path + "/oneOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(schema.OneOf, index, (JsonSchema)o));
+                    Visit(schema._oneOf.ElementAt(i), path + "/oneOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(schema._oneOf, index, (JsonSchema)o));
                 }
 
                 if (schema.Not != null)

--- a/src/NJsonSchema/Visitors/JsonReferenceVisitorBase.cs
+++ b/src/NJsonSchema/Visitors/JsonReferenceVisitorBase.cs
@@ -98,28 +98,32 @@ namespace NJsonSchema.Visitors
                     Visit(schema.Item, path + "/items", null, checkedObjects, o => schema.Item = (JsonSchema)o);
                 }
 
-                for (var i = 0; i < schema.Items.Count; i++)
+                var items = schema._items;
+                for (var i = 0; i < items.Count; i++)
                 {
                     var index = i;
-                    Visit(schema.Items.ElementAt(i), path + "/items[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(schema.Items, index, (JsonSchema)o));
+                    Visit(items[i], path + "/items[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(items, index, (JsonSchema)o));
                 }
 
-                for (var i = 0; i < schema._allOf.Count; i++)
+                var allOf = schema._allOf;
+                for (var i = 0; i < allOf.Count; i++)
                 {
                     var index = i;
-                    Visit(schema._allOf.ElementAt(i), path + "/allOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(schema.AllOf, index, (JsonSchema)o));
+                    Visit(allOf[i], path + "/allOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(allOf, index, (JsonSchema)o));
                 }
 
-                for (var i = 0; i < schema._anyOf.Count; i++)
+                var anyOf = schema._anyOf;
+                for (var i = 0; i < anyOf.Count; i++)
                 {
                     var index = i;
-                    Visit(schema._anyOf.ElementAt(i), path + "/anyOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(schema.AnyOf, index, (JsonSchema)o));
+                    Visit(anyOf[i], path + "/anyOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(anyOf, index, (JsonSchema)o));
                 }
 
-                for (var i = 0; i < schema._oneOf.Count; i++)
+                var oneOf = schema._oneOf;
+                for (var i = 0; i < oneOf.Count; i++)
                 {
                     var index = i;
-                    Visit(schema._oneOf.ElementAt(i), path + "/oneOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(schema.OneOf, index, (JsonSchema)o));
+                    Visit(oneOf[i], path + "/oneOf[" + i + "]", null, checkedObjects, o => ReplaceOrDelete(oneOf, index, (JsonSchema)o));
                 }
 
                 if (schema.Not != null)
@@ -234,12 +238,12 @@ namespace NJsonSchema.Visitors
             }
         }
 
-        private static void ReplaceOrDelete<T>(ICollection<T> collection, int index, T obj)
+        private static void ReplaceOrDelete<T>(ObservableCollection<T> collection, int index, T obj)
         {
-            ((Collection<T>)collection).RemoveAt(index);
+            collection.RemoveAt(index);
             if (obj != null)
             {
-                ((Collection<T>)collection).Insert(index, obj);
+                collection.Insert(index, obj);
             }
         }
 


### PR DESCRIPTION
* avoid enum HasFlag as it allocates
* avoid interface dispatch for collections that are accessed a lot
* remove some LINQ that slows things down
* avoid delegate allocations for each collection setup, use delegate stored in a field (preserves `this` context)
* avoid string.Split(params char[]) trap by supplying fixed char array