### PR TITLE
Use Luxon DateTime.toFormat function in TypeScript generated code

### DIFF
--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/DateCodeGenerationTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/DateCodeGenerationTests.cs
@@ -77,6 +77,46 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
         }
 
         [Fact]
+        public async Task When_date_handling_is_luxon_then_datetime_property_is_generated_in_class()
+        {
+            //// Arrange
+            var schema = await JsonSchema.FromJsonAsync(Json);
+
+            //// Act
+            var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings
+            {
+                TypeStyle = TypeScriptTypeStyle.Class,
+                DateTimeType = TypeScriptDateTimeType.Luxon
+            });
+            var code = generator.GenerateFile("MyClass");
+
+            //// Assert
+            Assert.Contains("myDate: DateTime", code);
+            Assert.Contains("this.myDate = _data[\"myDate\"] ? DateTime.fromISO(_data[\"myDate\"].toString()) : <any>undefined;", code);
+            Assert.Contains("data[\"myDate\"] = this.myDate ? this.myDate.toFormat('yyyy-MM-dd') : <any>undefined;", code);
+        }
+
+        [Fact]
+        public async Task When_date_handling_is_luxon_then_duration_property_is_generated_in_class()
+        {
+            //// Arrange
+            var schema = await JsonSchema.FromJsonAsync(Json);
+
+            //// Act
+            var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings
+            {
+                TypeStyle = TypeScriptTypeStyle.Class,
+                DateTimeType = TypeScriptDateTimeType.Luxon
+            });
+            var code = generator.GenerateFile("MyClass");
+
+            //// Assert
+            Assert.Contains("myTimeSpan: Duration", code);
+            Assert.Contains("this.myTimeSpan = _data[\"myTimeSpan\"] ? Duration.fromISO(_data[\"myTimeSpan\"].toString()) : <any>undefined;", code);
+            Assert.Contains("data[\"myTimeSpan\"] = this.myTimeSpan ? this.myTimeSpan.toString() : <any>undefined;", code);
+        }
+
+        [Fact]
         public async Task When_date_handling_is_dayjs_then_dayjs_property_is_generated_in_class()
         {
             //// Arrange
@@ -147,7 +187,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
             var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings
             {
                 TypeStyle = TypeScriptTypeStyle.Interface,
-                //DateTimeType = TypeScriptDateTimeType.Date 
+                //DateTimeType = TypeScriptDateTimeType.Date
             });
             var code = generator.GenerateFile("MyClass");
 

--- a/src/NJsonSchema.CodeGeneration.TypeScript/DataConversionGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/DataConversionGenerator.cs
@@ -87,6 +87,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                 //StringToDateCode is used for date and date-time formats
                 UseJsDate = parameters.Settings.DateTimeType == TypeScriptDateTimeType.Date,
                 StringToDateCode = GetStringToDateTime(parameters, typeSchema),
+                DateToStringCode = GetDateToString(parameters, typeSchema),
                 DateTimeToStringCode = GetDateTimeToString(parameters, typeSchema),
 
                 HandleReferences = parameters.Settings.HandleReferences
@@ -113,7 +114,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                     }
 
                     return "moment";
-                    
+
                 case TypeScriptDateTimeType.String:
                     return "";
 
@@ -126,6 +127,27 @@ namespace NJsonSchema.CodeGeneration.TypeScript
 
                 case TypeScriptDateTimeType.DayJS:
                     return "dayjs";
+
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        private static string GetDateToString(DataConversionParameters parameters, JsonSchema typeSchema)
+        {
+            switch (parameters.Settings.DateTimeType)
+            {
+                case TypeScriptDateTimeType.Date:
+                case TypeScriptDateTimeType.String:
+                    return "";
+
+                case TypeScriptDateTimeType.MomentJS:
+                case TypeScriptDateTimeType.OffsetMomentJS:
+                case TypeScriptDateTimeType.DayJS:
+                    return "format('YYYY-MM-DD')";
+
+                case TypeScriptDateTimeType.Luxon:
+                    return "toFormat('yyyy-MM-dd')";
 
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -191,7 +213,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                     return false;
                 }
             }
-            else if (type == TypeScriptDateTimeType.DayJS || 
+            else if (type == TypeScriptDateTimeType.DayJS ||
                      type == TypeScriptDateTimeType.MomentJS ||
                      type == TypeScriptDateTimeType.OffsetMomentJS)
             {
@@ -241,7 +263,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                     return true;
                 }
             }
-            else if (type == TypeScriptDateTimeType.DayJS || 
+            else if (type == TypeScriptDateTimeType.DayJS ||
                      type == TypeScriptDateTimeType.MomentJS ||
                      type == TypeScriptDateTimeType.OffsetMomentJS)
             {

--- a/src/NJsonSchema.CodeGeneration.TypeScript/Templates/ConvertToJavaScript.liquid
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Templates/ConvertToJavaScript.liquid
@@ -7,7 +7,7 @@ if (Array.isArray({{ Value }})) {
 {%     if IsArrayItemNewableObject -%}
         {{ Variable }}.push(item.toJSON());
 {%     elseif IsArrayItemDate -%}
-        {{ Variable }}.push({% if UseJsDate %}formatDate(item){% else %}item.format('YYYY-MM-DD'){% endif %});
+        {{ Variable }}.push({% if UseJsDate %}formatDate(item){% else %}item.{{ DateToStringCode }}{% endif %});
 {%     elseif IsArrayItemDateTime -%}
         {{ Variable }}.push(item.{{ DateTimeToStringCode }});
 {%     else -%}
@@ -22,7 +22,7 @@ if ({{ Value }}) {
 {%     if IsDictionaryValueNewableObject -%}
             {{ Variable }}[key] = {{ Value }}[key] ? {{ Value }}[key].toJSON() : <any>{{ NullValue }};
 {%     elseif IsDictionaryValueDate -%}
-            {{ Variable }}[key] = {{ Value }}[key] ? {% if UseJsDate %}formatDate({{ Value }}[key]){% else %}{{ Value }}[key].format('YYYY-MM-DD'){% endif %} : <any>{{ NullValue }};
+            {{ Variable }}[key] = {{ Value }}[key] ? {% if UseJsDate %}formatDate({{ Value }}[key]){% else %}{{ Value }}[key].{{ DateToStringCode }}{% endif %} : <any>{{ NullValue }};
 {%     elseif IsDictionaryValueDateTime -%}
             {{ Variable }}[key] = {{ Value }}[key] ? {{ Value }}[key].{{ DateTimeToStringCode }} : <any>{{ NullValue }};
 {%     else -%}
@@ -35,7 +35,7 @@ if ({{ Value }}) {
     }
 }
 {% elseif IsDate -%}
-{{ Variable }} = {{ Value }} ? {% if UseJsDate %}formatDate({{ Value }}){% else %}{{ Value }}.format('YYYY-MM-DD'){% endif %} : {% if HasDefaultValue -%}{{ DefaultValue }}{% else %}<any>{{ NullValue }}{% endif %};
+{{ Variable }} = {{ Value }} ? {% if UseJsDate %}formatDate({{ Value }}){% else %}{{ Value }}.{{ DateToStringCode }}{% endif %} : {% if HasDefaultValue -%}{{ DefaultValue }}{% else %}<any>{{ NullValue }}{% endif %};
 {% elseif IsDateTime -%}
 {{ Variable }} = {{ Value }} ? {{ Value }}.{{ DateTimeToStringCode }} : {% if HasDefaultValue %}{{ DefaultValue }}{% else %}<any>{{ NullValue }}{% endif %};
 {% elseif NullValue != "undefined" -%}


### PR DESCRIPTION
This (attempts to) fix #1350. I just followed the existing pattern used for converting properties with a `date-time` format, but fixed the function call to use `toFormat('yyyy-MM-dd')`.