### PR TITLE
Update CSharpGenerator.cs

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpGenerator.cs
@@ -72,7 +72,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
             {
                 if (Settings.ExcludedTypeNames?.Contains("DateFormatConverter") != true)
                 {
-                    var template = Settings.TemplateFactory.CreateTemplate("CSharp", "DateFormatConverter", new TemplateModelBase());
+                    var template = Settings.TemplateFactory.CreateTemplate("CSharp", "DateFormatConverter", new DateFormatConverterTemplateModel(Settings));
                     artifacts.Add(new CodeArtifact("DateFormatConverter", CodeArtifactType.Class, CodeArtifactLanguage.CSharp, CodeArtifactCategory.Utility, template));
                 }
             }


### PR DESCRIPTION
Make DateFormatConverter use System.Text.Json, if desired.

The liquid template was already adapted for this, but `UseSystemTextJson` was always false. 

NB: I'm not quite sure how to test that my change does what I think it does. Also, if my attempt here actually works, I think this bug might also be hiding for other templates that are instantiated using `TemplateModelBase`