### PR TITLE
Make the GetKey protected & virtual to allow overriding it

### DIFF
--- a/src/NJsonSchema/Generation/JsonSchemaResolver.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaResolver.cs
@@ -68,7 +68,13 @@ namespace NJsonSchema.Generation
         /// <summary>Gets all the schemas.</summary>
         public IEnumerable<JsonSchema> Schemas => _mappings.Values;
 
-        private string GetKey(Type type, bool isIntegerEnum)
+        /// <summary>
+        /// Gets the mapping key for the given type.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <param name="isIntegerEnum">Specifies whether the type is an integer enum.</param>
+        /// <returns>The mapping key.</returns>
+        protected virtual string GetKey(Type type, bool isIntegerEnum)
         {
             return type.FullName + (isIntegerEnum ? ":Integer" : string.Empty);
         }


### PR DESCRIPTION
Hi,

In this change the JsonSchemaResolver's GetKey is made protected & virtual in order to use additional information than just the FullName as the mapping key. In our case we would like to use Assembly version in addition to fullname.

In our scenario controllers are loaded runtime and there might be two classes with the exact same FullName coming from two different assemblies and we need to generate schemas for both of them as the types may be different (different properties etc.).



