### PR TITLE
Add typeName to ArgumentException message in CodeArtifact

### DIFF
--- a/src/NJsonSchema.CodeGeneration/CodeArtifact.cs
+++ b/src/NJsonSchema.CodeGeneration/CodeArtifact.cs
@@ -58,7 +58,7 @@ namespace NJsonSchema.CodeGeneration
         {
             if (typeName == baseTypeName)
             {
-                throw new ArgumentException("The baseTypeName cannot equal typeName.", nameof(typeName));
+                throw new ArgumentException($"The baseTypeName '{baseTypeName}' cannot equal typeName.", nameof(typeName));
             }
 
             TypeName = typeName;


### PR DESCRIPTION
The name of type which leads to ArgumentException in CodeArtifact ctor can help to analyse problems in invalid schema. 

### Background
Observed this ArgumentException in Visual Studio. (CodeGeneration with Unchase plugin). Analyzing reason was very difficult because of missing type name which was invalid in my big schema. This patch helps to find the concerned part in schema.