### PR TITLE
System.Text.Json.Serialization.JsonExtensionDataAttribute allows object & JsonElement values

### DIFF
--- a/src/NJsonSchema.Tests/Generation/SystemTextJson/SystemTextJsonExtensionDataGenerationTests.cs
+++ b/src/NJsonSchema.Tests/Generation/SystemTextJson/SystemTextJsonExtensionDataGenerationTests.cs
@@ -1,6 +1,7 @@
 ﻿#if !NET46 && !NET452
 
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using NJsonSchema.Generation;
 using Xunit;
@@ -9,22 +10,46 @@ namespace NJsonSchema.Tests.Generation.SystemTextJson
 {
     public class SystemTextJsonExtensionDataGenerationTests
     {
-        public class ClassWithExtensionData
+        public class ClassWithObjectExtensionData
         {
             public string Foo { get; set; }
 
             [JsonExtensionData]
             public IDictionary<string, object> ExtensionData { get; set; }
         }
+        
+        public class ClassWithJsonElementExtensionData
+        {
+            public string Foo { get; set; }
+
+            [JsonExtensionData]
+            public IDictionary<string, JsonElement> ExtensionData { get; set; }
+        }
 
         [Fact]
-        public void SystemTextJson_When_class_has_property_with_JsonExtensionDataAttribute_on_property_then_AdditionalProperties_schema_is_set()
+        public void SystemTextJson_When_class_has_object_Dictionary_with_JsonExtensionDataAttribute_on_property_then_AdditionalProperties_schema_is_set()
         {
             //// Act
-            var schema = JsonSchema.FromType<ClassWithExtensionData>(new JsonSchemaGeneratorSettings
+            var schema = JsonSchema.FromType<ClassWithObjectExtensionData>(new JsonSchemaGeneratorSettings
             {
                 SchemaType = SchemaType.OpenApi3,
-                SerializerOptions = new System.Text.Json.JsonSerializerOptions()
+                SerializerOptions = new JsonSerializerOptions()
+            });
+
+            //// Assert
+            Assert.Equal(1, schema.ActualProperties.Count);
+            Assert.True(schema.AllowAdditionalProperties);
+            Assert.True(schema.AdditionalPropertiesSchema.ActualSchema.IsAnyType);
+        }
+        
+        [Fact]
+        public void SystemTextJson_When_class_has_JsonElement_Dictionary_with_JsonExtensionDataAttribute_on_property_then_AdditionalProperties_schema_is_set()
+        {
+            //// Act
+            var schema = JsonSchema.FromType<ClassWithJsonElementExtensionData>(new JsonSchemaGeneratorSettings
+            {
+                SchemaType = SchemaType.OpenApi3,
+                SerializerOptions = new JsonSerializerOptions()
             });
 
             //// Assert

--- a/src/NJsonSchema/Generation/DefaultReflectionService.cs
+++ b/src/NJsonSchema/Generation/DefaultReflectionService.cs
@@ -176,6 +176,7 @@ namespace NJsonSchema.Generation
 
             if (type.IsAssignableToTypeName(nameof(JToken), TypeNameStyle.Name) ||
                 type.FullName == "System.Dynamic.ExpandoObject" ||
+                type.FullName == "System.Text.Json.JsonElement" ||
                 type == typeof(object))
             {
                 return JsonTypeDescription.Create(contextualType, JsonObjectType.None, isNullable, null);

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -767,8 +767,6 @@ namespace NJsonSchema.Generation
             {
                 var genericTypeArguments = extensionDataProperty.GenericArguments;
                 var extensionDataPropertyType = genericTypeArguments.Length == 2 ? genericTypeArguments[1] : typeof(object).ToContextualType();
-                if (extensionDataPropertyType.TypeInfo.FullName.Equals("System.Text.Json.JsonElement"))
-                    extensionDataPropertyType = typeof(object).ToContextualType();
 
                 schema.AdditionalPropertiesSchema = GenerateWithReferenceAndNullability<JsonSchema>(
                     extensionDataPropertyType, schemaResolver);

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -767,6 +767,8 @@ namespace NJsonSchema.Generation
             {
                 var genericTypeArguments = extensionDataProperty.GenericArguments;
                 var extensionDataPropertyType = genericTypeArguments.Length == 2 ? genericTypeArguments[1] : typeof(object).ToContextualType();
+                if (extensionDataPropertyType.TypeInfo.FullName.Equals("System.Text.Json.JsonElement"))
+                    extensionDataPropertyType = typeof(object).ToContextualType();
 
                 schema.AdditionalPropertiesSchema = GenerateWithReferenceAndNullability<JsonSchema>(
                     extensionDataPropertyType, schemaResolver);


### PR DESCRIPTION
According to https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to?pivots=dotnet-5-0#deserialization-of-object-properties System.Text.Json deserializes to JsonElement even if the property is of type IDictionary<string, object>.