### PR TITLE
Fix XML comments on CodeGeneratorSettings

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpGeneratorSettings.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpGeneratorSettings.cs
@@ -124,7 +124,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
         /// <summary>Gets or sets the name of a static method which is called to transform the JsonSerializerSettings (for Newtonsoft.Json) or the JsonSerializerOptions (for System.Text.Json) used in the generated ToJson()/FromJson() methods (default: null).</summary>
         public string JsonSerializerSettingsTransformationMethod { get; set; }
 
-        /// <summary>Gets or sets a value indicating whether to render ToJson() and FromJson() methods (default: true).</summary>
+        /// <summary>Gets or sets a value indicating whether to render ToJson() and FromJson() methods (default: false).</summary>
         public bool GenerateJsonMethods { get; set; }
 
         /// <summary>Gets or sets a value indicating whether enums should be always generated as bit flags (default: false).</summary>

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptGeneratorSettings.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptGeneratorSettings.cs
@@ -44,7 +44,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
             InlineNamedDictionaries = false;
         }
 
-        /// <summary>Gets or sets the target TypeScript version (default: 1.8).</summary>
+        /// <summary>Gets or sets the target TypeScript version (default: 2.7).</summary>
         public decimal TypeScriptVersion { get; set; }
 
         /// <summary>Gets a value indicating whether the target TypeScript version supports strict null checks.</summary>


### PR DESCRIPTION
Fix some inconsistencies in the documented default values in XML comments of `CSharpGeneratorSettings` and `TypeScriptGeneratorSettings`.