### PR TITLE
Improve LeafType generated code

### DIFF
--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptDiscriminatorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptDiscriminatorTests.cs
@@ -110,7 +110,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
             Assert.Contains("export interface OneChild extends Base", code);
             Assert.Contains("export interface SecondChild extends Base", code);
             Assert.Contains("Child: OneChild | SecondChild;", code);
-            Assert.Contains("Children: OneChild[] | SecondChild[];", code);
+            Assert.Contains("Children: (OneChild | SecondChild)[];", code);
         }
         
         [Fact]
@@ -133,7 +133,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
             Assert.Contains("export class OneChild extends Base", code);
             Assert.Contains("export class SecondChild extends Base", code);
             Assert.Contains("child: OneChild | SecondChild;", code);
-            Assert.Contains("children: OneChild[] | SecondChild[];", code);
+            Assert.Contains("children: (OneChild | SecondChild)[];", code);
         }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
@@ -304,10 +304,20 @@ namespace NJsonSchema.CodeGeneration.TypeScript
 
                 if (Settings.UseLeafType)
                 {
-                    return string.Join(UnionPipe,
-                        Resolve(schema.Item, true, typeNameHint) // TODO: Make typeNameHint singular if possible
-                            .Split(new[] { UnionPipe }, StringSplitOptions.RemoveEmptyEntries)
-                            .Select(x => string.Format("{0}[]", GetNullableItemType(schema, prefix + x))));
+                    var itemTypes = Resolve(schema.Item, true, typeNameHint) // TODO: Make typeNameHint singular if possible
+                        .Split(new[] { UnionPipe }, StringSplitOptions.RemoveEmptyEntries)
+                        .Select(x => GetNullableItemType(schema, prefix + x))
+                        .ToList();
+
+                    var itemType = string.Join(UnionPipe, itemTypes);
+
+                    // is TypeUnion
+                    if (itemTypes.Count > 1)
+                    {
+                        itemType = string.Format("({0})", itemType);
+                    }
+
+                    return string.Format("{0}[]", itemType);
                 }
                 else
                 {


### PR DESCRIPTION
The generated code using the `UseLeafType` was not 100% correct for arrays. This PR changes generated code from:
```ts
property: A[] | B[],
```
to:
```ts
property: (A | B)[],
```