### PR TITLE
Adds custom extension x-enumMetaData

### DIFF
--- a/src/NJsonSchema.Tests/Generation/EnumTests.cs
+++ b/src/NJsonSchema.Tests/Generation/EnumTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -107,9 +109,48 @@ namespace NJsonSchema.Tests.Generation
             Assert.Equal("Value2", schema.EnumerationNames.Last());
         }
 
-        [Flags]
-        public enum EnumWithFlags
+        [Fact]
+        public async Task When_ComponentModel_Attributes_are_not_used_meta_data_has_only_the_names()
         {
+            // Arrange
+
+            // Act
+            var schema = JsonSchema.FromType<MyEnum>();
+            var json = schema.ToJson();
+
+            // Assert
+            Assert.Equal("Value1", schema.EnumerationMetaData.First().Title);
+            Assert.Equal("Value2", schema.EnumerationMetaData.Last().Title);
+
+            Assert.Null(schema.EnumerationMetaData.First().Description);
+            Assert.Null(schema.EnumerationMetaData.Last().Description);
+        }
+
+        public enum MyEnumWithAttributes {
+            [Display(Name = "My name 1", Description = "My description 1")] Value1,
+            [Description("My description 2")]
+            Value2
+        }
+
+        [Fact]
+        public async Task When_ComponentModel_Attributes_are_used_on_enum_values_its_used_in_meta_data()
+        {
+            // Arrange
+
+            // Act
+            var schema = JsonSchema.FromType<MyEnumWithAttributes>();
+            var json = schema.ToJson();
+
+            // Assert
+            Assert.Equal("My name 1", schema.EnumerationMetaData.First().Title);
+            Assert.Equal("Value2", schema.EnumerationMetaData.Last().Title);
+
+            Assert.Equal("My description 1", schema.EnumerationMetaData.First().Description);
+            Assert.Equal("My description 2", schema.EnumerationMetaData.Last().Description);
+        }
+
+        [Flags]
+        public enum EnumWithFlags {
             Foo = 1,
             Bar = 2,
             Baz = 4,

--- a/src/NJsonSchema/Generation/EnumerationMetaData.cs
+++ b/src/NJsonSchema/Generation/EnumerationMetaData.cs
@@ -1,0 +1,23 @@
+using Newtonsoft.Json;
+
+namespace NJsonSchema.Generation {
+    /// <summary>
+    /// Additional meta data for enumerations.
+    /// </summary>
+    /// <remarks>
+    /// An enum value doesn't have a title or description associated with it in the JSON schema specification.
+    /// </remarks>
+    public class EnumerationMetaData {
+        /// <summary>
+        /// Surrogate for the "title" keyword as described in <see href="https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.9.1">the specification</see>.
+        /// </summary>
+        [JsonProperty("title", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate, Order = 0)]
+        public string Title { get; set; }
+        
+        /// <summary>
+        /// Surrogate for the "description" keyword as described in <see href="https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.9.1">the specification</see>.
+        /// </summary>
+        [JsonProperty("description", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate, Order = 0)]
+        public string Description { get; set; }
+    }
+}

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -351,15 +351,10 @@ namespace NJsonSchema.Generation
         {
             var contextualType = typeDescription.ContextualType;
 
-            dynamic displayAttribute = contextualType.ContextAttributes.FirstAssignableToTypeNameOrDefault("System.ComponentModel.DataAnnotations.DisplayAttribute");
-            if (displayAttribute != null)
+            var name = contextualType.GetDisplayName();
+            if (name != null) 
             {
-                // GetName returns null if the Name property on the attribute is not specified.
-                var name = displayAttribute.GetName();
-                if (name != null) 
-                {
-                    schema.Title = name;
-                }
+                schema.Title = name;
             }
 
             dynamic defaultValueAttribute = contextualType.ContextAttributes.FirstAssignableToTypeNameOrDefault("System.ComponentModel.DefaultValueAttribute");
@@ -719,6 +714,13 @@ namespace NJsonSchema.Generation
                         schema.Enumeration.Add(JsonConvert.DeserializeObject<string>(json));
                     }
                 }
+
+                var contextualFieldType = contextualType.GetField(enumName);
+                schema.EnumerationMetaData.Add(new EnumerationMetaData
+                {
+                    Title = contextualFieldType?.GetDisplayName() ?? enumName,
+                    Description = contextualFieldType?.GetDescription()
+                });
 
                 schema.EnumerationNames.Add(enumName);
             }

--- a/src/NJsonSchema/Infrastructure/TypeExtensions.cs
+++ b/src/NJsonSchema/Infrastructure/TypeExtensions.cs
@@ -56,6 +56,15 @@ namespace NJsonSchema.Infrastructure
             return member.Name;
         }
 
+        /// <summary>Gets the name of the given member (based on the DisplayAttribute).</summary>
+        /// <returns>The name or null if no name is available.</returns>
+        public static string GetDisplayName(this ContextualType contextualType)
+        {
+            dynamic displayAttribute = contextualType.ContextAttributes.FirstAssignableToTypeNameOrDefault("System.ComponentModel.DataAnnotations.DisplayAttribute");
+            // GetName returns null if the Name property on the attribute is not specified.
+            return displayAttribute?.GetName();
+        }
+
         /// <summary>Gets the description of the given member (based on the DescriptionAttribute, DisplayAttribute or XML Documentation).</summary>
         /// <param name="type">The member info</param>
         /// <param name="attributeType">The attribute type to check.</param>

--- a/src/NJsonSchema/JsonSchema.Serialization.cs
+++ b/src/NJsonSchema/JsonSchema.Serialization.cs
@@ -16,6 +16,7 @@ using Namotion.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NJsonSchema.Collections;
+using NJsonSchema.Generation;
 using NJsonSchema.Infrastructure;
 
 namespace NJsonSchema
@@ -131,6 +132,10 @@ namespace NJsonSchema
         /// <summary>Gets or sets the enumeration names (optional, draft v5). </summary>
         [JsonIgnore]
         public Collection<string> EnumerationNames { get; set; }
+        
+        /// <summary>Gets or sets the enumeration meta data (custom extension, sets 'x-enumMetaData').</summary>
+        [JsonIgnore]
+        public Collection<EnumerationMetaData> EnumerationMetaData { get; set; }
 
         /// <summary>Gets or sets a value indicating whether the maximum value is excluded. </summary>
         [JsonProperty("exclusiveMaximum", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
@@ -393,6 +398,14 @@ namespace NJsonSchema
         {
             get { return EnumerationNames != null && EnumerationNames.Count > 0 ? EnumerationNames : null; }
             set { EnumerationNames = value != null ? new ObservableCollection<string>(value) : new ObservableCollection<string>(); }
+        }
+
+        /// <summary>Gets or sets the enumeration meta data (custom extension, sets 'x-enumMetaData').</summary>
+        [JsonProperty("x-enumMetaData", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        internal Collection<EnumerationMetaData> EnumerationMetaDataRaw
+        {
+            get { return EnumerationMetaData != null && EnumerationMetaData.Count > 0 ? EnumerationMetaData : null; }
+            set { EnumerationMetaData = value != null ? new ObservableCollection<EnumerationMetaData>(value) : new ObservableCollection<EnumerationMetaData>(); }
         }
 
         [JsonProperty("enum", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]

--- a/src/NJsonSchema/JsonSchema.cs
+++ b/src/NJsonSchema/JsonSchema.cs
@@ -968,6 +968,11 @@ namespace NJsonSchema
             {
                 EnumerationNames = new Collection<string>();
             }
+            
+            if (EnumerationMetaData == null)
+            {
+                EnumerationMetaData = new Collection<EnumerationMetaData>();
+            }
         }
     }
 }


### PR DESCRIPTION
Display or Description attributes from System.ComponentModel(.DataAnnotations) on enum values currently do not result in readable output on the JSON schema.

This change adds the x-enumMetaData array with objects that have `title` and `description` properties.

The two properties behave exactly like they do for normal types that are converted to schema, so this should feel very familiar to developers.


My use case for this is auto generating a basic editor UI using json schema. Currently there is no good way to create a title and description for individual enum members.