### PR TITLE
Add handling for parenthesis to CSharpPropertyNameGenerator

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpPropertyNameGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpPropertyNameGenerator.cs
@@ -23,6 +23,8 @@ namespace NJsonSchema.CodeGeneration.CSharp
                     .Replace("$", string.Empty)
                     .Replace("[", string.Empty)
                     .Replace("]", string.Empty)
+                    .Replace("(", "_")
+                    .Replace(")", string.Empty)
                     .Replace(".", "-")
                     .Replace("=", "-")
                     .Replace("+", "plus"), true)


### PR DESCRIPTION
Hi, because life is hard, there are companies that include parenthesis characters in property names in their Swagger/OpenAPI definitions.  As an example, the Vertex [sales tax API](https://developer.vertexcloud.com/wp-content/uploads/openapi-json/VertexRestAPI-JSON-20190806.zip) has a property called `timeElapsed(ms)` in it.  

This patch replaces opening parenthesis with an underscore, and removes closing parenthesis.

I'm attaching the Vertex swagger doc for reference:
[VertexRestApi1.json.zip](https://github.com/RicoSuter/NJsonSchema/files/6810046/VertexRestApi1.json.zip)
