### PR TITLE
Skip custom JsonConverterAttribute when checking for JsonInheritanceConverter/StringEnumConverter

### DIFF
--- a/src/NJsonSchema/Generation/DefaultReflectionService.cs
+++ b/src/NJsonSchema/Generation/DefaultReflectionService.cs
@@ -384,8 +384,11 @@ namespace NJsonSchema.Generation
             if (jsonConverterAttribute != null && ObjectExtensions.HasProperty(jsonConverterAttribute, "ConverterType"))
             {
                 var converterType = (Type)jsonConverterAttribute.ConverterType;
-                return converterType.IsAssignableToTypeName("StringEnumConverter", TypeNameStyle.Name) ||
-                       converterType.IsAssignableToTypeName("System.Text.Json.Serialization.JsonStringEnumConverter", TypeNameStyle.FullName);
+                if (converterType != null)
+                {
+                    return converterType.IsAssignableToTypeName("StringEnumConverter", TypeNameStyle.Name) ||
+                           converterType.IsAssignableToTypeName("System.Text.Json.Serialization.JsonStringEnumConverter", TypeNameStyle.FullName);
+                }
             }
 
             return false;

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -1165,8 +1165,10 @@ namespace NJsonSchema.Generation
             if (jsonConverterAttribute != null)
             {
                 var converterType = (Type)jsonConverterAttribute.ConverterType;
-                if (converterType.IsAssignableToTypeName(nameof(JsonInheritanceConverter), TypeNameStyle.Name) || // Newtonsoft's converter
-                    converterType.IsAssignableToTypeName(nameof(JsonInheritanceConverter) + "`1", TypeNameStyle.Name)) // System.Text.Json's converter
+                if (converterType != null && (
+                    converterType.IsAssignableToTypeName(nameof(JsonInheritanceConverter), TypeNameStyle.Name) || // Newtonsoft's converter
+                    converterType.IsAssignableToTypeName(nameof(JsonInheritanceConverter) + "`1", TypeNameStyle.Name) // System.Text.Json's converter
+                    ))
                 {
                     return ObjectExtensions.HasProperty(jsonConverterAttribute, "ConverterParameters") && 
                            jsonConverterAttribute.ConverterParameters != null && 


### PR DESCRIPTION
These methods currently throw `NullReferenceException` when tries to match `JsonConverterAttribute.ConverterType` but it's `null` (it's possible in `System.Text.Json`, see https://docs.microsoft.com/en-us/dotnet/api/system.text.json.serialization.jsonconverterattribute.convertertype?view=net-5.0)