### PR TITLE
Fixed validation of JTokens with type Uri

### DIFF
--- a/src/NJsonSchema.Tests/Validation/FormatUriTests.cs
+++ b/src/NJsonSchema.Tests/Validation/FormatUriTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 using NJsonSchema.Validation;
@@ -33,6 +34,23 @@ namespace NJsonSchema.Tests.Validation
             schema.Format = JsonFormatStrings.Uri;
 
             var token = new JValue("http://rsuter.com");
+
+            //// Act
+            var errors = schema.Validate(token);
+
+            //// Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void When_uri_token_is_of_type_uri_then_validation_succeeds()
+        {
+            //// Arrange
+            var schema = new JsonSchema();
+            schema.Type = JsonObjectType.String;
+            schema.Format = JsonFormatStrings.Uri;
+
+            var token = new JValue(new Uri("http://rsuter.com"));
 
             //// Act
             var errors = schema.Validate(token);

--- a/src/NJsonSchema/Validation/JsonSchemaValidator.cs
+++ b/src/NJsonSchema/Validation/JsonSchemaValidator.cs
@@ -222,7 +222,23 @@ namespace NJsonSchema.Validation
 
             if (isString)
             {
-                var value = token.Type == JTokenType.Date ? (token as JValue).ToString("yyyy-MM-ddTHH:mm:ssK") : token.Value<string>();
+                string value;
+
+                switch (token.Type)
+                {
+                    case JTokenType.Date:
+                        value = (token as JValue).ToString("yyyy-MM-ddTHH:mm:ssK");
+                        break;
+
+                    case JTokenType.Uri:
+                        value = (token as JValue).ToString();
+                        break;
+
+                    default:
+                        value = token.Value<string>();
+                        break;
+                }
+
                 if (value != null)
                 {
                     if (!string.IsNullOrEmpty(schema.Pattern))


### PR DESCRIPTION
JsonSchemaValidator was not properly converting JTokens of type Uri to strings. Calling token.Value<string>() would throw exception because Uri does not implement IConvertible. Instead Uri's ToString() should be used to convert to string.

Converted to switch statement to handle multiple different Type scenarios and added unit test to cover Uri case.