### PR TITLE
#250 Allow case insensitive property validation

### DIFF
--- a/src/NJsonSchema.Tests/Validation/ObjectValidationTests.cs
+++ b/src/NJsonSchema.Tests/Validation/ObjectValidationTests.cs
@@ -199,7 +199,7 @@ namespace NJsonSchema.Tests.Validation
 
             var validator = new JsonSchemaValidator(new JsonSchemaValidatorSettings()
             {
-                IgnorePropertyNameCase = true,
+                PropertyStringComparer = StringComparer.OrdinalIgnoreCase,
             });
 
             //// Act

--- a/src/NJsonSchema.Tests/Validation/ObjectValidationTests.cs
+++ b/src/NJsonSchema.Tests/Validation/ObjectValidationTests.cs
@@ -135,7 +135,7 @@ namespace NJsonSchema.Tests.Validation
             Assert.Equal("Foo", errors.First().Property);
             Assert.Equal("#/Foo", errors.First().Path);
         }
-        
+
         [Fact]
         public async Task When_type_property_has_integer_type_then_it_is_validated_correctly()
         {
@@ -197,7 +197,7 @@ namespace NJsonSchema.Tests.Validation
             var token = new JObject();
             token["foo"] = new JValue(5);
 
-            var validator = new JsonSchemaValidator(new JsonSchemaValidatorOptions()
+            var validator = new JsonSchemaValidator(new JsonSchemaValidatorSettings()
             {
                 IgnorePropertyNameCase = true,
             });

--- a/src/NJsonSchema.Tests/Validation/ObjectValidationTests.cs
+++ b/src/NJsonSchema.Tests/Validation/ObjectValidationTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using NJsonSchema.Validation;
@@ -157,6 +158,55 @@ namespace NJsonSchema.Tests.Validation
 
             //// Assert
             Assert.Equal(0, errors.Count);
+        }
+
+        [Fact]
+        public void When_case_sensitive_and_property_has_different_casing_then_it_should_fail()
+        {
+            //// Arrange
+            var schema = new JsonSchema();
+            schema.Type = JsonObjectType.Object;
+            schema.AllowAdditionalProperties = false;
+            schema.Properties["Foo"] = new JsonSchemaProperty
+            {
+                Type = JsonObjectType.Number | JsonObjectType.Null
+            };
+
+            var token = new JObject();
+            token["foo"] = new JValue(5);
+
+            //// Act
+            var errors = schema.Validate(token);
+
+            //// Assert
+            Assert.Equal(ValidationErrorKind.NoAdditionalPropertiesAllowed, errors.First().Kind);
+        }
+
+        [Fact]
+        public void When_case_insensitive_and_property_has_different_casing_then_it_should_succeed()
+        {
+            //// Arrange
+            var schema = new JsonSchema();
+            schema.Type = JsonObjectType.Object;
+            schema.AllowAdditionalProperties = false;
+            schema.Properties["Foo"] = new JsonSchemaProperty
+            {
+                Type = JsonObjectType.Number | JsonObjectType.Null
+            };
+
+            var token = new JObject();
+            token["foo"] = new JValue(5);
+
+            var validator = new JsonSchemaValidator(new JsonSchemaValidatorOptions()
+            {
+                IgnorePropertyNameCase = true,
+            });
+
+            //// Act
+            var errors = validator.Validate(token, schema);
+
+            //// Assert
+            Assert.Empty(errors);
         }
     }
 }

--- a/src/NJsonSchema/Validation/JsonSchemaValidator.cs
+++ b/src/NJsonSchema/Validation/JsonSchemaValidator.cs
@@ -404,9 +404,9 @@ namespace NJsonSchema.Validation
                     continue;
                 }
 
-                var newPropertyPath = GetPropertyPath(propertyPath, requiredProperty);
-                if (obj?.Property(requiredProperty) == null)
+                if (obj?.TryGetValue(requiredProperty, stringComparison, out _) != true)
                 {
+                    var newPropertyPath = GetPropertyPath(propertyPath, requiredProperty);
                     errors.Add(new ValidationError(ValidationErrorKind.PropertyRequired, requiredProperty, newPropertyPath, token, schema));
                 }
             }

--- a/src/NJsonSchema/Validation/JsonSchemaValidator.cs
+++ b/src/NJsonSchema/Validation/JsonSchemaValidator.cs
@@ -38,7 +38,7 @@ namespace NJsonSchema.Validation
         };
 
         private readonly IDictionary<string, IFormatValidator[]> _formatValidatorsMap;
-        private readonly JsonSchemaValidatorOptions _options;
+        private readonly JsonSchemaValidatorSettings _options;
 
         /// <summary>
         /// Initializes JsonSchemaValidator
@@ -46,13 +46,13 @@ namespace NJsonSchema.Validation
         public JsonSchemaValidator(params IFormatValidator[] customValidators)
         {
             _formatValidatorsMap = _formatValidators.Union(customValidators).GroupBy(x => x.Format).ToDictionary(v => v.Key, v => v.ToArray());
-            _options = new JsonSchemaValidatorOptions();
+            _options = new JsonSchemaValidatorSettings();
         }
 
         /// <summary>
         /// Initializes JsonSchemaValidator
         /// </summary>
-        public JsonSchemaValidator(JsonSchemaValidatorOptions options, params IFormatValidator[] customValidators)
+        public JsonSchemaValidator(JsonSchemaValidatorSettings options, params IFormatValidator[] customValidators)
         {
             _formatValidatorsMap = _formatValidators.Union(customValidators).GroupBy(x => x.Format).ToDictionary(v => v.Key, v => v.ToArray());
             _options = options;

--- a/src/NJsonSchema/Validation/JsonSchemaValidator.cs
+++ b/src/NJsonSchema/Validation/JsonSchemaValidator.cs
@@ -38,6 +38,7 @@ namespace NJsonSchema.Validation
         };
 
         private readonly IDictionary<string, IFormatValidator[]> _formatValidatorsMap;
+        private readonly JsonSchemaValidatorOptions _options;
 
         /// <summary>
         /// Initializes JsonSchemaValidator
@@ -45,6 +46,16 @@ namespace NJsonSchema.Validation
         public JsonSchemaValidator(params IFormatValidator[] customValidators)
         {
             _formatValidatorsMap = _formatValidators.Union(customValidators).GroupBy(x => x.Format).ToDictionary(v => v.Key, v => v.ToArray());
+            _options = new JsonSchemaValidatorOptions();
+        }
+
+        /// <summary>
+        /// Initializes JsonSchemaValidator
+        /// </summary>
+        public JsonSchemaValidator(JsonSchemaValidatorOptions options, params IFormatValidator[] customValidators)
+        {
+            _formatValidatorsMap = _formatValidators.Union(customValidators).GroupBy(x => x.Format).ToDictionary(v => v.Key, v => v.ToArray());
+            _options = options;
         }
 
         /// <summary>Validates the given JSON data.</summary>
@@ -359,11 +370,16 @@ namespace NJsonSchema.Validation
                 return;
             }
 
+            var stringComparer = _options.IgnorePropertyNameCase ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+            var stringComparison = _options.IgnorePropertyNameCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+            var schemaPropertyKeys = new HashSet<string>(schema.Properties.Keys, stringComparer);
+
             foreach (var propertyInfo in schema.Properties)
             {
                 var newPropertyPath = GetPropertyPath(propertyPath, propertyInfo.Key);
 
-                if (obj != null && obj.TryGetValue(propertyInfo.Key, out var value))
+                if (obj != null && obj.TryGetValue(propertyInfo.Key, stringComparison, out var value))
                 {
                     if (value.Type == JTokenType.Null && propertyInfo.Value.IsNullable(schemaType))
                     {
@@ -382,7 +398,7 @@ namespace NJsonSchema.Validation
             // Properties may be required in a schema without being specified as a property.
             foreach (var requiredProperty in schema.RequiredProperties)
             {
-                if (schema.Properties.ContainsKey(requiredProperty))
+                if (schemaPropertyKeys.Contains(requiredProperty))
                 {
                     // The property has already been checked.
                     continue;
@@ -402,7 +418,7 @@ namespace NJsonSchema.Validation
                 ValidateMaxProperties(token, properties, schema, propertyName, propertyPath, errors);
                 ValidateMinProperties(token, properties, schema, propertyName, propertyPath, errors);
 
-                var additionalProperties = properties.Where(p => !schema.Properties.ContainsKey(p.Name)).ToList();
+                var additionalProperties = properties.Where(p => !schemaPropertyKeys.Contains(p.Name)).ToList();
 
                 ValidatePatternProperties(additionalProperties, schema, schemaType, errors);
                 ValidateAdditionalProperties(token, additionalProperties, schema, schemaType, propertyName, propertyPath, errors);
@@ -542,7 +558,7 @@ namespace NJsonSchema.Validation
                 else if (schema.AdditionalItemsSchema != null)
                 {
                     var error = TryCreateChildSchemaError(item,
-                        schema.AdditionalItemsSchema, 
+                        schema.AdditionalItemsSchema,
                         schemaType,
                         ValidationErrorKind.AdditionalItemNotValid, propertyIndex, propertyPath + propertyIndex);
                     if (error != null)

--- a/src/NJsonSchema/Validation/JsonSchemaValidatorOptions.cs
+++ b/src/NJsonSchema/Validation/JsonSchemaValidatorOptions.cs
@@ -3,7 +3,7 @@
 namespace NJsonSchema.Validation
 {
     /// <summary>Class to configure the behavior of <see cref="JsonSchemaValidator"/>. </summary>
-    public class JsonSchemaValidatorOptions
+    public class JsonSchemaValidatorSettings
     {
         /// <summary>Whether to ignore casing for object properties.</summary>
         public bool IgnorePropertyNameCase { get; set; }

--- a/src/NJsonSchema/Validation/JsonSchemaValidatorOptions.cs
+++ b/src/NJsonSchema/Validation/JsonSchemaValidatorOptions.cs
@@ -5,7 +5,13 @@ namespace NJsonSchema.Validation
     /// <summary>Class to configure the behavior of <see cref="JsonSchemaValidator"/>. </summary>
     public class JsonSchemaValidatorSettings
     {
-        /// <summary>Whether to ignore casing for object properties.</summary>
-        public bool IgnorePropertyNameCase { get; set; }
+        private StringComparer _propertyStringComparer;
+
+        /// <summary>The <see cref="StringComparer"/> used to compare object properties.</summary>
+        public StringComparer PropertyStringComparer
+        {
+            get => _propertyStringComparer ?? StringComparer.Ordinal;
+            set => _propertyStringComparer = value;
+        }
     }
 }

--- a/src/NJsonSchema/Validation/JsonSchemaValidatorOptions.cs
+++ b/src/NJsonSchema/Validation/JsonSchemaValidatorOptions.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace NJsonSchema.Validation
+{
+    /// <summary>Class to configure the behavior of <see cref="JsonSchemaValidator"/>. </summary>
+    public class JsonSchemaValidatorOptions
+    {
+        /// <summary>Whether to ignore casing for object properties.</summary>
+        public bool IgnorePropertyNameCase { get; set; }
+    }
+}


### PR DESCRIPTION
Added a `JsonSchemaValidatorOptions` class with a `IgnorePropertyNameCase` property as per your suggestion in #250