### PR TITLE
TypeScript CodeGeneration checks AllowAdditionalProperties

### DIFF
--- a/src/NJsonSchema.CodeGeneration.TypeScript/Models/ClassTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Models/ClassTemplateModel.cs
@@ -111,7 +111,9 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Models
 
         /// <summary>Gets a value indicating whether the class inherits from dictionary.</summary>
         public bool HasIndexerProperty => _schema.IsDictionary ||
-                                          _schema.InheritedSchema?.IsDictionary == true;
+                                          _schema.InheritedSchema?.IsDictionary == true ||
+                                          _schema.ActualTypeSchema.AllowAdditionalProperties ||
+                                          _schema.ActualTypeSchema.AdditionalPropertiesSchema != null;
 
         /// <summary>Gets the type of the indexer property value.</summary>
         public string IndexerPropertyValueType


### PR DESCRIPTION
Code generation for TypeScript doesn't currently respect the AllowAdditionalProperties or AdditionalPropertiesSchema values. Current template code already has relevant syntax when HasIndexerProperty is set to true. HasIndexerProperty is only referenced by the Liquid template and is only used in ways that allows for additional properties in classes/interfaces, so I simply modified the getter for HasIndexerProperty to check the additional properties