### PR TITLE
Use pattern variable to avoid several casts

### DIFF
--- a/src/NJsonSchema/JsonReferenceResolver.cs
+++ b/src/NJsonSchema/JsonReferenceResolver.cs
@@ -278,11 +278,11 @@ namespace NJsonSchema
             checkedObjects.Add(obj);
             var firstSegment = segments[0];
 
-            if (obj is IDictionary)
+            if (obj is IDictionary dictionary)
             {
-                if (((IDictionary)obj).Contains(firstSegment))
+                if (dictionary.Contains(firstSegment))
                 {
-                    return ResolveDocumentReference(((IDictionary)obj)[firstSegment], segments.Skip(1).ToList(), targetType, contractResolver, checkedObjects);
+                    return ResolveDocumentReference(dictionary[firstSegment], segments.Skip(1).ToList(), targetType, contractResolver, checkedObjects);
                 }
             }
             else if (obj is IEnumerable)


### PR DESCRIPTION
Use pattern variable for type check to avoid several casts.