### PR TITLE
Replace the zero-length array allocation with the method Array.Empty

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpJsonSerializerGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpJsonSerializerGenerator.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -39,7 +40,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
 
         private static List<string> GetJsonConverters(CSharpGeneratorSettings settings, IEnumerable<string> additionalJsonConverters)
         {
-            return (settings.JsonConverters ?? new string[0]).Concat(additionalJsonConverters ?? new string[0]).ToList();
+            return (settings.JsonConverters ?? Array.Empty<string>()).Concat(additionalJsonConverters ?? Array.Empty<string>()).ToList();
         }
 
         private static string GenerateForJsonLibrary(CSharpGeneratorSettings settings, List<string> jsonConverters, bool hasJsonConverters)

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/ExtensionCodeTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/ExtensionCodeTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace NJsonSchema.CodeGeneration.TypeScript.Tests
@@ -129,7 +130,7 @@ export class UseHttpCookiesForApi {
 }";
 
             //// Act
-            var extensionCode = new TypeScriptExtensionCode(code, new string[0], new[] { "UseHttpCookiesForApi" });
+            var extensionCode = new TypeScriptExtensionCode(code, Array.Empty<string>(), new[] { "UseHttpCookiesForApi" });
 
             //// Assert
             Assert.Empty(extensionCode.ExtensionClasses);

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptGeneratorSettings.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptGeneratorSettings.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Linq;
 using System.Reflection;
 
@@ -38,8 +39,8 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                 typeof(TypeScriptGeneratorSettings).GetTypeInfo().Assembly
             });
 
-            ClassTypes = new string[0];
-            ExtendedClasses = new string[0];
+            ClassTypes = Array.Empty<string>();
+            ExtendedClasses = Array.Empty<string>();
 
             InlineNamedDictionaries = false;
         }

--- a/src/NJsonSchema.CodeGeneration/CodeGeneratorSettingsBase.cs
+++ b/src/NJsonSchema.CodeGeneration/CodeGeneratorSettingsBase.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System;
 using Newtonsoft.Json;
 
 namespace NJsonSchema.CodeGeneration
@@ -17,7 +18,7 @@ namespace NJsonSchema.CodeGeneration
         public CodeGeneratorSettingsBase()
         {
             GenerateDefaultValues = true;
-            ExcludedTypeNames = new string[0];
+            ExcludedTypeNames = Array.Empty<string>();
         }
 
         /// <summary>Gets or sets the schema type (default: JsonSchema).</summary>

--- a/src/NJsonSchema.Tests/Generation/SystemTextJson/JsonInheritanceConverter.cs
+++ b/src/NJsonSchema.Tests/Generation/SystemTextJson/JsonInheritanceConverter.cs
@@ -152,10 +152,10 @@ namespace NJsonSchema.Tests.Generation.SystemTextJson
                     }
                     else if (attribute.MethodName != null)
                     {
-                        var method = type.GetRuntimeMethod((string)attribute.MethodName, new Type[0]);
+                        var method = type.GetRuntimeMethod((string)attribute.MethodName, Type.EmptyTypes);
                         if (method != null)
                         {
-                            var types = (IEnumerable<Type>)method.Invoke(null, new object[0]);
+                            var types = (IEnumerable<Type>)method.Invoke(null, Array.Empty<object>());
                             foreach (var knownType in types)
                             {
                                 if (knownType.Name == discriminatorValue)


### PR DESCRIPTION
Avoid unnecessary memory allocation.