### PR TITLE
Don't include int64 format string for ulong

### DIFF
--- a/src/NJsonSchema/Generation/DefaultReflectionService.cs
+++ b/src/NJsonSchema/Generation/DefaultReflectionService.cs
@@ -72,8 +72,9 @@ namespace NJsonSchema.Generation
             // Primitive types
 
             if (type == typeof(short) ||
+                type == typeof(ushort) ||
                 type == typeof(uint) ||
-                type == typeof(ushort))
+                type == typeof(ulong))
             {
                 return JsonTypeDescription.Create(contextualType, JsonObjectType.Integer, false, null);
             }
@@ -83,8 +84,7 @@ namespace NJsonSchema.Generation
                 return JsonTypeDescription.Create(contextualType, JsonObjectType.Integer, false, JsonFormatStrings.Integer);
             }
 
-            if (type == typeof(long) ||
-                type == typeof(ulong))
+            if (type == typeof(long))
             {
                 return JsonTypeDescription.Create(contextualType, JsonObjectType.Integer, false, JsonFormatStrings.Long);
             }


### PR DESCRIPTION
Currently `ulong` values generate `format: int64`, however my understanding is that [int64 describes a signed value](https://swagger.io/specification/#dataTypeFormat). The idea of this change is that the generated type description will no longer include a format. In the same way that `uint` doesn't generate `format: int32`.