### PR TITLE
Add settings to generate only required fields with SampleJsonDataGenerator

### DIFF
--- a/src/NJsonSchema.Tests/Generation/SampleJsonDataGeneratorTests.cs
+++ b/src/NJsonSchema.Tests/Generation/SampleJsonDataGeneratorTests.cs
@@ -134,7 +134,6 @@ namespace NJsonSchema.Tests.Generation
             Assert.Null(obj.Property("isoptional"));
         }
 
-
         [Fact]
         public async Task PropertyWithIntegerMinimumDefiniton()
         {

--- a/src/NJsonSchema.Tests/Generation/SampleJsonDataGeneratorTests.cs
+++ b/src/NJsonSchema.Tests/Generation/SampleJsonDataGeneratorTests.cs
@@ -89,6 +89,53 @@ namespace NJsonSchema.Tests.Generation
         }
 
         [Fact]
+        public async Task When_generateOptionalProperties_is_false_then_optional_properties_are_not_set()
+        {
+            //// Arrange
+            var data = @"{
+                ""$schema"": ""http://json-schema.org/draft-04/schema#"",
+                ""title"": ""test schema"",
+                ""type"": ""object"",
+                ""required"": [
+                  ""isrequired""
+                ],
+                ""properties"": {
+                  ""isrequired"": {
+                    ""type"": ""object"",
+                    ""properties"": {
+                      ""value"": {
+                        ""type"": ""integer""
+                      }
+                    }
+                  },
+                  ""isoptional"": {
+                    ""type"": ""object"",
+                    ""properties"": {
+                      ""value"": {
+                        ""type"": ""integer""
+                      }
+                    }
+                  }
+                }
+              }";
+
+            var schema = await JsonSchema.FromJsonAsync(data);
+            var generator = new SampleJsonDataGenerator(new SampleJsonDataGeneratorSettings
+            {
+                GenerateOptionalProperties = false
+            });
+
+            //// Act
+            var token = generator.Generate(schema);
+            var obj = token as JObject;
+
+            //// Assert
+            Assert.NotNull(obj.Property("isrequired"));
+            Assert.Null(obj.Property("isoptional"));
+        }
+
+
+        [Fact]
         public async Task PropertyWithIntegerMinimumDefiniton()
         {
             //// Arrange

--- a/src/NJsonSchema/Generation/SampleJsonDataGeneratorSettings.cs
+++ b/src/NJsonSchema/Generation/SampleJsonDataGeneratorSettings.cs
@@ -3,7 +3,7 @@
     /// <summary> Settings for generating sample json data.</summary>
     public class SampleJsonDataGeneratorSettings
     {
-        /// <summary>Gets or sets a value indicating whether to generate to generate optional properties. (default: true).</summary>
+        /// <summary>Gets or sets a value indicating whether to generate optional properties(default: true).</summary>
         public bool GenerateOptionalProperties { get; set; } = true;
     }
 }

--- a/src/NJsonSchema/Generation/SampleJsonDataGeneratorSettings.cs
+++ b/src/NJsonSchema/Generation/SampleJsonDataGeneratorSettings.cs
@@ -3,7 +3,7 @@
     /// <summary> Settings for generating sample json data.</summary>
     public class SampleJsonDataGeneratorSettings
     {
-        /// <summary>Gets or sets a value indicating whether to generate optional properties(default: true).</summary>
+        /// <summary>Gets or sets a value indicating whether to generate optional properties (default: true).</summary>
         public bool GenerateOptionalProperties { get; set; } = true;
     }
 }

--- a/src/NJsonSchema/Generation/SampleJsonDataGeneratorSettings.cs
+++ b/src/NJsonSchema/Generation/SampleJsonDataGeneratorSettings.cs
@@ -1,0 +1,9 @@
+﻿namespace NJsonSchema.Generation
+{
+    /// <summary> Settings for generating sample json data.</summary>
+    public class SampleJsonDataGeneratorSettings
+    {
+        /// <summary>Gets or sets a value indicating whether to generate to generate optional properties. (default: true).</summary>
+        public bool GenerateOptionalProperties { get; set; } = true;
+    }
+}


### PR DESCRIPTION
Currently, SampleJsonDataGenerator will generate all properties, regardless of whether they are required by the schema. Sometimes it can be useful to generate only the required fields, for example to generate minimum viable examples.

This PR adds settings that control the generation of required fields without changing the default behavior.