### PR TITLE
Fix ConvertCSharpDocs multi-line regression

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/GeneralGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/GeneralGeneratorTests.cs
@@ -293,7 +293,11 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             var output = generator.GenerateFile("MyClass");
 
             //// Assert
-            Assert.Contains(@"/// <summary>EnumDesc.</summary>", output);
+            var summary = @"
+        /// <summary>
+        /// EnumDesc.
+        /// </summary>".Replace("\r", "").Trim();
+            Assert.Contains(summary, output);
 
             AssertCompile(output);
         }
@@ -310,7 +314,11 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             var output = generator.GenerateFile("MyClass");
 
             //// Assert
-            Assert.Contains(@"/// <summary>ClassDesc.</summary>", output);
+            var summary = @"
+    /// <summary>
+    /// ClassDesc.
+    /// </summary>".Replace("\r", "");
+            Assert.Contains(summary, output);
 
             AssertCompile(output);
         }
@@ -327,7 +335,11 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             var output = generator.GenerateFile("MyClass");
 
             //// Assert
-            Assert.Contains(@"/// <summary>PropertyDesc.</summary>", output);
+            var summary = @"
+        /// <summary>
+        /// PropertyDesc.
+        /// </summary>".Replace("\r", "").Trim();
+            Assert.Contains(summary, output);
 
             AssertCompile(output);
         }
@@ -1979,6 +1991,49 @@ public static Person FromJson(string data)
             Assert.Contains(normalizedExpectedFromJsonMethodMethod, normalizedOutput);
 
             AssertCompile(output);
+        }
+
+        public class DocumentationTest
+        {
+            /// <summary>
+            /// Summary is here
+            ///
+            /// spanning multiple lines
+            ///
+            /// like this.
+            ///
+            /// </summary>
+            public string HelloMessage { get; set; }
+        }
+
+        [Fact]
+        public async Task When_documentation_present_produces_valid_xml_documentation_syntax()
+        {
+            // Arrange
+            var schema = JsonSchema.FromType<DocumentationTest>();
+
+            // Act
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings
+            {
+                ClassStyle = CSharpClassStyle.Poco
+            });
+
+            var code = generator.GenerateFile("MyClass");
+
+            // Assert
+            var expected = @"
+        /// <summary>
+        /// Summary is here
+        /// <br/>            
+        /// <br/>spanning multiple lines
+        /// <br/>            
+        /// <br/>like this.
+        /// <br/>            
+        /// </summary>".Replace("\r","");
+
+            Assert.Contains(expected, code);
+
+            AssertCompile(code);
         }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
@@ -1,5 +1,7 @@
 ﻿{%- if HasDescription -%}
-/// <summary>{{ Description | csharpdocs }}</summary>
+/// <summary>
+/// {{ Description | csharpdocs }}
+/// </summary>
 {%- endif -%}
 {%- if HasDiscriminator -%}
 {%- if UseSystemTextJson -%}
@@ -45,7 +47,9 @@
 {%- endif -%}
 {%- for property in Properties -%}
 {%-   if property.HasDescription -%}
-    /// <summary>{{ property.Description | csharpdocs }}</summary>
+    /// <summary>
+    /// {{ property.Description | csharpdocs }}
+    /// </summary>
 {%-   endif -%}
 {%- if UseSystemTextJson %}
     [System.Text.Json.Serialization.JsonPropertyName("{{ property.Name }}")]

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Enum.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Enum.liquid
@@ -1,5 +1,7 @@
 ﻿{%- if HasDescription -%}
-/// <summary>{{ Description | csharpdocs }}</summary>
+/// <summary>
+/// {{ Description | csharpdocs }}
+/// </summary>
 {%- endif -%}
 [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "{{ ToolchainVersion }}")]
 {%- if IsEnumAsBitFlags -%}

--- a/src/NJsonSchema/ConversionUtilities.cs
+++ b/src/NJsonSchema/ConversionUtilities.cs
@@ -270,19 +270,13 @@ namespace NJsonSchema
         /// <returns>The output.</returns>
         public static string ConvertCSharpDocs(string input, int tabCount)
         {
-            if (input is null)
-            {
-                return "";
-            }
-            var tabString = CreateTabString(tabCount);
-            input = input
-                .Replace("\r", string.Empty);
-
-            var stringWriter = new StringWriter(new StringBuilder(input.Length), CultureInfo.CurrentCulture);
-            AddPrefixToBeginningOfNonEmptyLines(input, tabString + "/// ", stringWriter);
+            input = input?
+                        .Replace("\r", string.Empty)
+                        .Replace("\n", "\n" + string.Join("", Enumerable.Repeat("    ", tabCount)) + "/// ")
+                    ?? string.Empty;
 
             // TODO: Support more markdown features here
-            var xml = new XText(stringWriter.ToString()).ToString();
+            var xml = new XText(input).ToString();
             return Regex.Replace(xml, @"^( *)/// ", m => m.Groups[1] + "/// <br/>", RegexOptions.Multiline);
         }
 


### PR DESCRIPTION
Reverted back to old logic, added unit test, changed summary format to span multiple lines so multi-line ones don't look weird.

fixes #1462
fixes [#3793](https://github.com/RicoSuter/NSwag/issues/3793)
