### PR TITLE
Changed IsNullable for OpenApi3

### DIFF
--- a/src/NJsonSchema/JsonSchemaProperty.cs
+++ b/src/NJsonSchema/JsonSchemaProperty.cs
@@ -95,6 +95,10 @@ namespace NJsonSchema
             {
                 return true;
             }
+            else if (schemaType == SchemaType.OpenApi3 && IsRequired == false)
+            {
+                return true;
+            }
 
             return base.IsNullable(schemaType);
         }


### PR DESCRIPTION
Using NSwag to genereate OpenApi3 with 'openapi2csclient' the default was Mandatory for properties, this is not matching the OpenApi3 schema default, what has as default Optional. This resulted in not validated the jsonrequest-instances correctly.

Please merge this PR so I can use the openapi2csclient from you again instead of using my local one.