### PR TITLE
Fix "Collection contains no matching element" error when no AllOf is of type "Object"

### DIFF
--- a/src/NJsonSchema/JsonSchema.cs
+++ b/src/NJsonSchema/JsonSchema.cs
@@ -290,7 +290,7 @@ namespace NJsonSchema
                     return hasReference.ActualSchema;
                 }
 
-                var objectTyped = _allOf.First(s => s.Type.IsObject());
+                var objectTyped = _allOf.FirstOrDefault(s => s.Type.IsObject());
                 if (objectTyped != null)
                 {
                     return objectTyped.ActualSchema;


### PR DESCRIPTION
This is a simple change to prevent the "Collection contains no matching element" InvalidOperationException that is thrown by `First()` when there is no AllOf of type "Object" (in this case, all are "None").