### PR TITLE
Fix "Collection contains no matching element" error when 'type' specifier is ommited in "allOf".

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/AllOfTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/AllOfTests.cs
@@ -240,5 +240,38 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             Assert.Contains("public string Prop1 { get; set; }", code);
             Assert.Contains("public string Prop2 { get; set; }", code);
         }
+
+        [Fact]
+        public async Task When_allOf_schema_contains_two_anonymous_nodes_without_type_specifier_an_anonymous_class_is_generated()
+        {
+            //// Arrange
+            // The issue here is that the 'type' specifier has been (legally) omitted.
+            var json = @"
+                {
+                '$schema': 'http://json-schema.org/draft-04/schema#',
+                'type': 'object',
+                'allOf': [
+                    {
+                        'properties': {
+                            'prop1' : { 'type' : 'string' }
+                        }
+                    },
+                    {
+                        'properties': {
+                            'prop2' : { 'type' : 'number' }
+                        }
+                    }                    
+                ]
+            }";
+
+            //// Act
+            var schema = await JsonSchema.FromJsonAsync(json);
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings { ClassStyle = CSharpClassStyle.Poco });
+            var code = generator.GenerateFile("Foo");
+
+            //// Assert
+            Assert.Contains("class Foo", code);
+            Assert.Contains("class Anonymous", code);
+        }
     }
 }

--- a/src/NJsonSchema/JsonSchema.cs
+++ b/src/NJsonSchema/JsonSchema.cs
@@ -290,7 +290,7 @@ namespace NJsonSchema
                     return hasReference.ActualSchema;
                 }
 
-                var objectTyped = _allOf.First(s => s.Type.IsObject());
+                var objectTyped = _allOf.FirstOrDefault(s => s.Type.IsObject());
                 if (objectTyped != null)
                 {
                     return objectTyped.ActualSchema;


### PR DESCRIPTION
Bug happens when an allOf node contains two or more elements without a type specified. (apparently that's legal json schema)

Added a test to fix this issue from reoccurring. Given existing tests, this does not introduce a regression itself.