### PR TITLE
Support duration as of JSON Schema 2019-09

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
@@ -175,7 +175,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
                 return isNullable && Settings.TimeType?.ToLowerInvariant() != "string" ? Settings.TimeType + "?" : Settings.TimeType;
             }
 
-            if (schema.Format == JsonFormatStrings.TimeSpan)
+            if (schema.Format is JsonFormatStrings.Duration or JsonFormatStrings.TimeSpan)
             {
                 return isNullable && Settings.TimeSpanType?.ToLowerInvariant() != "string" ? Settings.TimeSpanType + "?" : Settings.TimeSpanType;
             }

--- a/src/NJsonSchema.CodeGeneration.TypeScript/DataConversionGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/DataConversionGenerator.cs
@@ -103,7 +103,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
 
                 case TypeScriptDateTimeType.MomentJS:
                 case TypeScriptDateTimeType.OffsetMomentJS:
-                    if (typeSchema.Format == JsonFormatStrings.TimeSpan)
+                    if (typeSchema.Format is JsonFormatStrings.Duration or JsonFormatStrings.TimeSpan)
                     {
                         return "moment.duration";
                     }
@@ -119,7 +119,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                     return "";
 
                 case TypeScriptDateTimeType.Luxon:
-                    if (typeSchema.Format == JsonFormatStrings.TimeSpan)
+                    if (typeSchema.Format is JsonFormatStrings.Duration or JsonFormatStrings.TimeSpan)
                     {
                         return "Duration.fromISO";
                     }
@@ -163,7 +163,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
 
                 case TypeScriptDateTimeType.MomentJS:
                 case TypeScriptDateTimeType.OffsetMomentJS:
-                    if (typeSchema.Format == JsonFormatStrings.TimeSpan)
+                    if (typeSchema.Format is JsonFormatStrings.Duration or JsonFormatStrings.TimeSpan)
                     {
                         return "format('d.hh:mm:ss.SS', { trim: false })";
                     }
@@ -181,7 +181,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                     return "toString()";
 
                 case TypeScriptDateTimeType.DayJS:
-                    if (typeSchema.Format == JsonFormatStrings.TimeSpan)
+                    if (typeSchema.Format is JsonFormatStrings.Duration or JsonFormatStrings.TimeSpan)
                     {
                         return "format('d.hh:mm:ss.SSS')";
                     }
@@ -208,7 +208,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                     return false;
                 }
 
-                if (format == JsonFormatStrings.TimeSpan)
+                if (format is JsonFormatStrings.Duration or JsonFormatStrings.TimeSpan)
                 {
                     return false;
                 }
@@ -227,7 +227,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                     return true;
                 }
 
-                if (format == JsonFormatStrings.TimeSpan)
+                if (format is JsonFormatStrings.Duration or JsonFormatStrings.TimeSpan)
                 {
                     return true;
                 }
@@ -244,7 +244,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                     return true;
                 }
 
-                if (format == JsonFormatStrings.TimeSpan)
+                if (format is JsonFormatStrings.Duration or JsonFormatStrings.TimeSpan)
                 {
                     return true;
                 }

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
@@ -213,7 +213,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                     return "string";
                 }
 
-                if (schema.Format == JsonFormatStrings.TimeSpan)
+                if (schema.Format is JsonFormatStrings.Duration or JsonFormatStrings.TimeSpan)
                 {
                     return "string";
                 }
@@ -236,7 +236,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                     return "moment.Moment";
                 }
 
-                if (schema.Format == JsonFormatStrings.TimeSpan)
+                if (schema.Format is JsonFormatStrings.Duration or JsonFormatStrings.TimeSpan)
                 {
                     return "moment.Duration";
                 }
@@ -258,7 +258,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                     return "DateTime";
                 }
 
-                if (schema.Format == JsonFormatStrings.TimeSpan)
+                if (schema.Format is JsonFormatStrings.Duration or JsonFormatStrings.TimeSpan)
                 {
                     return "Duration";
                 }
@@ -280,7 +280,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                     return "dayjs.Dayjs";
                 }
 
-                if (schema.Format == JsonFormatStrings.TimeSpan)
+                if (schema.Format is JsonFormatStrings.Duration or JsonFormatStrings.TimeSpan)
                 {
                     return "dayjs.Dayjs";
                 }

--- a/src/NJsonSchema.CodeGeneration/ValueGeneratorBase.cs
+++ b/src/NJsonSchema.CodeGeneration/ValueGeneratorBase.cs
@@ -22,6 +22,7 @@ namespace NJsonSchema.CodeGeneration
             JsonFormatStrings.Date,
             JsonFormatStrings.DateTime,
             JsonFormatStrings.Time,
+            JsonFormatStrings.Duration,
             JsonFormatStrings.TimeSpan,
             JsonFormatStrings.Uri,
             JsonFormatStrings.Guid,

--- a/src/NJsonSchema.Tests/Generation/PrimitiveTypeGenerationTests.cs
+++ b/src/NJsonSchema.Tests/Generation/PrimitiveTypeGenerationTests.cs
@@ -71,7 +71,7 @@ namespace NJsonSchema.Tests.Generation
 
             //// Assert
             Assert.Equal(JsonObjectType.String, schema.Properties["TimeSpan"].Type);
-            Assert.Equal(JsonFormatStrings.TimeSpan, schema.Properties["TimeSpan"].Format);
+            Assert.Equal(JsonFormatStrings.Duration, schema.Properties["TimeSpan"].Format);
         }
 
         [Fact]
@@ -155,7 +155,7 @@ namespace NJsonSchema.Tests.Generation
 
             //// Assert
             Assert.Equal(JsonObjectType.String, schema.Properties["Duration"].Type);
-            Assert.Equal(JsonFormatStrings.TimeSpan, schema.Properties["Duration"].Format);
+            Assert.Equal(JsonFormatStrings.Duration, schema.Properties["Duration"].Format);
         }
     }
 }

--- a/src/NJsonSchema.Tests/Generation/SampleJsonSchemaGeneratorTests.cs
+++ b/src/NJsonSchema.Tests/Generation/SampleJsonSchemaGeneratorTests.cs
@@ -35,7 +35,7 @@ namespace NJsonSchema.Tests.Generation
             Assert.Equal(JsonFormatStrings.DateTime, schema.Properties["datetime"].Format);
 
             Assert.Equal(JsonObjectType.String, schema.Properties["timespan"].Type);
-            Assert.Equal(JsonFormatStrings.TimeSpan, schema.Properties["timespan"].Format);
+            Assert.Equal(JsonFormatStrings.Duration, schema.Properties["timespan"].Format);
         }
 
         [Fact]

--- a/src/NJsonSchema/Generation/DefaultReflectionService.cs
+++ b/src/NJsonSchema/Generation/DefaultReflectionService.cs
@@ -139,7 +139,7 @@ namespace NJsonSchema.Generation
             if (type == typeof(TimeSpan) ||
                 type.FullName == "NodaTime.Duration")
             {
-                return JsonTypeDescription.Create(contextualType, JsonObjectType.String, false, JsonFormatStrings.TimeSpan);
+                return JsonTypeDescription.Create(contextualType, JsonObjectType.String, false, JsonFormatStrings.Duration);
             }
 
             if (type.FullName == "NodaTime.LocalDate" ||

--- a/src/NJsonSchema/Generation/SampleJsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/SampleJsonSchemaGenerator.cs
@@ -131,7 +131,7 @@ namespace NJsonSchema.Generation
 
                 case JTokenType.TimeSpan:
                     schema.Type = JsonObjectType.String;
-                    schema.Format = JsonFormatStrings.TimeSpan;
+                    schema.Format = JsonFormatStrings.Duration;
                     break;
 
                 case JTokenType.Guid:
@@ -157,7 +157,7 @@ namespace NJsonSchema.Generation
 
             if (schema.Type == JsonObjectType.String && Regex.IsMatch(token.Value<string>(), "^[0-9][0-9]:[0-9][0-9](:[0-9][0-9])?$"))
             {
-                schema.Format = JsonFormatStrings.TimeSpan;
+                schema.Format = JsonFormatStrings.Duration;
             }
         }
 

--- a/src/NJsonSchema/JsonFormatStrings.cs
+++ b/src/NJsonSchema/JsonFormatStrings.cs
@@ -16,9 +16,12 @@ namespace NJsonSchema
         /// <summary>Format for a <see cref="System.DateTime"/>. </summary>
         public const string DateTime = "date-time";
 
-        /// <summary>Format for a <see cref="TimeSpan"/>. </summary>
+        /// <summary>Non-standard Format for a duration (time span)<see cref="TimeSpan"/>. </summary>
         public const string TimeSpan = "time-span";
 
+        /// <summary>Format for a duration (time span) as of 2019-09 <see cref="TimeSpan"/>. </summary>
+        public const string Duration = "duration";
+        
         /// <summary>Format for an email. </summary>
         public const string Email = "email";
 


### PR DESCRIPTION
This introduces the "duration" format specifier as of JSON Schema 2019-09 as the preferred alternative to time-span. Following Postel's law, the change is intended to be compatible except for "duration" replacing time-span in schema output.