### PR TITLE
Give better error message from elseif usage

### DIFF
--- a/src/NJsonSchema.CodeGeneration.Tests/LiquidTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/LiquidTests.cs
@@ -1,6 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Reflection;
 using Fluid;
+using NJsonSchema.CodeGeneration.TypeScript;
 using Xunit;
 
 namespace NJsonSchema.CodeGeneration.Tests
@@ -15,13 +18,13 @@ namespace NJsonSchema.CodeGeneration.Tests
         }
 
         [Fact]
-        public void LiquidModelHasDictionry_KeyAccessShouldWork()
+        public void LiquidModelHasDictionary_KeyAccessShouldWork()
         {
-            /// Arrange
+            // Arrange
             var model = new TestModel();
             model.Bar["Baz"] = "abc";
 
-            /// Act
+            // Act
             var context = new TemplateContext(model)
             {
                 CultureInfo = CultureInfo.InvariantCulture
@@ -30,23 +33,27 @@ namespace NJsonSchema.CodeGeneration.Tests
             var template = parser.Parse("Hi {{ Foo }} {{ Bar[\"Baz\"] }}");
             var text = template.Render(context);
 
-            /// Assert
+            // Assert
             Assert.Equal("Hi Foo. abc", text);
         }
 
         [Fact]
         public void LiquidModelHasNestedDictionaryAndLists_KeyAccessAndListIterationShouldWork()
         {
-            /// Arrange
+            // Arrange
             var model = new TestModel();
-            model.Bar["Baz"] = new[] { new Dictionary<string, object> {
-                { "key1", "value1" },
-                { "key2", "value2" }
-            } };
+            model.Bar["Baz"] = new[]
+            {
+                new Dictionary<string, object>
+                {
+                    { "key1", "value1" },
+                    { "key2", "value2" }
+                }
+            };
 
             var liquid = "{% assign x = Bar[\"Baz\"] -%}{% for i in x -%}key1={{ i[\"key1\"] }},key2={{ i[\"key2\"] }}{% endfor -%}";
 
-            /// Act
+            // Act
             var context = new TemplateContext(model)
             {
                 CultureInfo = CultureInfo.InvariantCulture
@@ -55,8 +62,27 @@ namespace NJsonSchema.CodeGeneration.Tests
             var template = parser.Parse(liquid);
             var text = template.Render(context);
 
-            /// Assert
+            // Assert
             Assert.Equal("key1=value1,key2=value2", text);
+        }
+
+
+        [Fact]
+        public void CanGetFriendlyErrorSuggestingUsingElsif()
+        {
+            // Arrange
+            var settings = new TypeScriptGeneratorSettings
+            {
+                TemplateDirectory = "Templates"
+            };
+            var templateFactory = new DefaultTemplateFactory(settings, Array.Empty<Assembly>());
+            var template1 = templateFactory.CreateTemplate("csharp", "elseif", new object());
+
+            // Act
+            var ex = Assert.Throws<InvalidOperationException>(() => template1.Render());
+
+            // Assert
+            Assert.Contains(", did you use 'elseif' instead of correct 'elsif'?", ex.Message);
         }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.Tests/NJsonSchema.CodeGeneration.Tests.csproj
+++ b/src/NJsonSchema.CodeGeneration.Tests/NJsonSchema.CodeGeneration.Tests.csproj
@@ -23,4 +23,7 @@
         <ProjectReference Include="..\NJsonSchema.CodeGeneration\NJsonSchema.CodeGeneration.csproj" />
         <ProjectReference Include="..\NJsonSchema\NJsonSchema.csproj" />
     </ItemGroup>
+    <ItemGroup>
+      <None Update="Templates\*.liquid" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
 </Project>

--- a/src/NJsonSchema.CodeGeneration.Tests/Templates/elseif.liquid
+++ b/src/NJsonSchema.CodeGeneration.Tests/Templates/elseif.liquid
@@ -1,0 +1,5 @@
+{% if false %}
+Wrong
+{% elseif true %}
+Hello
+{% endif %}

--- a/src/NJsonSchema.CodeGeneration/NJsonSchema.CodeGeneration.csproj
+++ b/src/NJsonSchema.CodeGeneration/NJsonSchema.CodeGeneration.csproj
@@ -6,7 +6,7 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Fluid.Core" Version="2.2.8" />
+    <PackageReference Include="Fluid.Core" Version="2.2.14" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
   </ItemGroup>


### PR DESCRIPTION
Maybe will reduce support burden as people never seem to read the release notes. Now giving a hint what to do when this error occurs, this combined with new Fluid version that reports better errors. Now error message is for invalid usage:

```
System.InvalidOperationException
Error while rendering Liquid template csharp/elseif: 
'{% endif %}' was expected at (4:1)
Source:
{% elseif true %}, did you use 'elseif' instead of correct 'elsif'?
   at NJsonSchema.CodeGeneration.DefaultTemplateFactory.LiquidTemplate.Render() in C:\Work\NJsonSchema\src\NJsonSchema.CodeGeneration\DefaultTemplateFactory.cs:line 251
   at NJsonSchema.CodeGeneration.Tests.LiquidTests.CanGetFriendlyErrorSuggestingUsingElsif() in C:\Work\NJsonSchema\src\NJsonSchema.CodeGeneration.Tests\LiquidTests.cs:line 83
```

* upgrade to latest Fluid
* use static compiled regexes