### PR TITLE
Remove dictionary allocation from TypeResolverBase.Types

### DIFF
--- a/src/NJsonSchema.CodeGeneration/DefaultTemplateFactory.cs
+++ b/src/NJsonSchema.CodeGeneration/DefaultTemplateFactory.cs
@@ -171,7 +171,6 @@ namespace NJsonSchema.CodeGeneration
             {
                 var childScope = false;
                 TemplateContext templateContext = null;
-                var templateContent = _templateContentLoader(_language, _template);
 
                 try
                 {
@@ -180,6 +179,7 @@ namespace NJsonSchema.CodeGeneration
                     var template = Templates.GetOrAdd(key, _ =>
                     {
                         // our matching expects unix new lines
+                        var templateContent = _templateContentLoader(_language, _template);
                         var data = templateContent.Replace("\r", "");
                         data = "\n" + data;
 
@@ -243,8 +243,7 @@ namespace NJsonSchema.CodeGeneration
                 catch (Exception exception)
                 {
                     var message = $"Error while rendering Liquid template {_language}/{_template}: \n{exception.Message}";
-                    if (exception.Message.Contains("'{% endif %}' was expected ")
-                        && templateContent.IndexOf("elseif", StringComparison.Ordinal) != -1)
+                    if (exception.Message.Contains("'{% endif %}' was expected ") && exception.Message.Contains("elseif"))
                     {
                         message += ", did you use 'elseif' instead of correct 'elsif'?";
                     }

--- a/src/NJsonSchema.CodeGeneration/GeneratorBase.cs
+++ b/src/NJsonSchema.CodeGeneration/GeneratorBase.cs
@@ -72,9 +72,12 @@ namespace NJsonSchema.CodeGeneration
         {
             var processedTypes = new List<string>();
             var types = new Dictionary<string, CodeArtifact>();
+
             while (_resolver.Types.Any(t => !processedTypes.Contains(t.Value)))
             {
-                foreach (var pair in _resolver.Types)
+                // we need to keep clone to allow updates
+                var resolverTypes = new Dictionary<JsonSchema, string>(_resolver._generatedTypeNames);
+                foreach (var pair in resolverTypes)
                 {
                     processedTypes.Add(pair.Value);
                     var result = GenerateType(pair.Key, pair.Value);

--- a/src/NJsonSchema.CodeGeneration/TypeResolverBase.cs
+++ b/src/NJsonSchema.CodeGeneration/TypeResolverBase.cs
@@ -15,7 +15,7 @@ namespace NJsonSchema.CodeGeneration
     public abstract class TypeResolverBase
     {
         private readonly CodeGeneratorSettingsBase _settings;
-        private readonly Dictionary<JsonSchema, string> _generatedTypeNames = new Dictionary<JsonSchema, string>();
+        internal readonly Dictionary<JsonSchema, string> _generatedTypeNames = new();
 
         /// <summary>Initializes a new instance of the <see cref="TypeResolverBase" /> class.</summary>
         /// <param name="settings">The settings.</param>
@@ -25,7 +25,7 @@ namespace NJsonSchema.CodeGeneration
         }
 
         /// <summary>Gets the registered schemas and with their type names.</summary>
-        public IDictionary<JsonSchema, string> Types => _generatedTypeNames.ToDictionary(p => p.Key, p => p.Value);
+        public IReadOnlyDictionary<JsonSchema, string> Types => _generatedTypeNames;
 
         /// <summary>Tries to resolve the schema and returns null if there was a problem.</summary>
         /// <param name="schema">The schema.</param>


### PR DESCRIPTION
Poor chaps like `CSharpTypeResolver` and `TypeScriptTypeResolver` are using `!Types.ContainsKey(schema)` which always allocates a new dictionary (and even uses LINQ to do it). Now offering `IReadOnlyDictionary` access to limit the price to virtual dispatch and creating new dictionary for update enumeration where it's actually needed.

![image](https://user-images.githubusercontent.com/171892/149822587-6ac2dab3-036c-442a-b940-e728ac1602b7.png)
