### PR TITLE
Fix for constructor inherited classes properties initialization when …

### DIFF
--- a/src/NJsonSchema.CodeGeneration.TypeScript/Templates/Class.liquid
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Templates/Class.liquid
@@ -23,14 +23,12 @@
 {%     if HasInheritance -%}
         super({% if GenerateConstructorInterface %}data{% endif %});
 {%     endif -%}
-{%     if GenerateConstructorInterface and condition_temp -%}
         if (data) {
-{%         if HasInheritance == false -%}
             for (var property in data) {
-                if (data.hasOwnProperty(property))
+                if (data.hasOwnProperty(property) && this.hasOwnProperty(property))
                     (<any>this)[property] = (<any>data)[property];
             }
-{%         endif -%}
+{%     if GenerateConstructorInterface and condition_temp -%}
 {%         if ConvertConstructorInterfaceData -%}
 {%             for property in Properties -%}
 {%                 if property.SupportsConstructorConversion -%}
@@ -58,8 +56,9 @@
 {%                 endif -%}
 {%             endfor -%}
 {%         endif -%}
-        }
 {%     endif -%}
+        }
+
 {%     if HasDefaultValues -%}
         {% if GenerateConstructorInterface %}if (!data) {% endif %}{
 {%         for property in Properties -%}


### PR DESCRIPTION
…GenerateConstructorInterface & ConvertConstructorInterfaceData are true.

Simple template fix resolves problem reported in many places eg:
- https://github.com/RicoSuter/NJsonSchema/issues/1128
- https://github.com/RicoSuter/NSwag/issues/3580
- https://github.com/RicoSuter/NSwag/issues/2895
and probably few more.

The problem was when we tried to create instance of class which derives from another one.
After calling `super()` of the parent class, all of the descendant-specific properties are `undefined` and wont be initialized.
Problem example:

![image](https://user-images.githubusercontent.com/4325788/149835709-742da16d-fcb9-476f-a35d-6643dfc67e38.png)

I changed Class template to include such initialization also in derived classes. 