### PR TITLE
DateFormatConverter JsonException using full name

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/DateFormatConverter.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/DateFormatConverter.liquid
@@ -7,7 +7,7 @@ internal class DateFormatConverter : System.Text.Json.Serialization.JsonConverte
         var dateTime = reader.GetString();
         if (dateTime == null)
         {
-            throw new JsonException("Unexpected JsonTokenType.Null");
+            throw new System.Text.Json.JsonException("Unexpected JsonTokenType.Null");
         }
 
         return System.DateTime.Parse(dateTime);


### PR DESCRIPTION
DateFormatConverter JsonException replaced with System.Text.Json.JsonException