### PR TITLE
Update JsonInheritanceConverter.liquid

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/InheritanceInterfaceTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/InheritanceInterfaceTests.cs
@@ -57,7 +57,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             Assert.True(json.Properties["Item"].ActualTypeSchema.AllOf.First().HasReference);
             Assert.Contains("[Newtonsoft.Json.JsonConverter(typeof(JsonInheritanceConverter), \"discriminator\")]", code);
             Assert.Contains("[JsonInheritanceAttribute(\"Banana\", typeof(Banana))]", code);
-            Assert.Contains("internal class JsonInheritanceConverter : Newtonsoft.Json.JsonConverter", code);
+            Assert.Contains("public class JsonInheritanceConverter : Newtonsoft.Json.JsonConverter", code);
         }
 
         [Fact]
@@ -76,7 +76,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             Assert.True(json.Properties["Item"].ActualTypeSchema.AllOf.First().HasReference);
             Assert.Contains("[JsonInheritanceConverter(typeof(Fruit), \"discriminator\")]", code);
             Assert.Contains("[JsonInheritanceAttribute(\"Banana\", typeof(Banana))]", code);
-            Assert.Contains("internal class JsonInheritanceConverter<TBase> : System.Text.Json.Serialization.JsonConverter<TBase>", code);
+            Assert.Contains("public class JsonInheritanceConverter<TBase> : System.Text.Json.Serialization.JsonConverter<TBase>", code);
         }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/DateFormatConverter.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/DateFormatConverter.liquid
@@ -7,7 +7,7 @@ internal class DateFormatConverter : System.Text.Json.Serialization.JsonConverte
         var dateTime = reader.GetString();
         if (dateTime == null)
         {
-            throw new JsonException("Unexpected JsonTokenType.Null");
+            throw new System.Text.Json.JsonException("Unexpected JsonTokenType.Null");
         }
 
         return System.DateTime.Parse(dateTime);

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/JsonInheritanceConverter.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/JsonInheritanceConverter.liquid
@@ -11,7 +11,7 @@ internal class JsonInheritanceConverterAttribute : System.Text.Json.Serializatio
     }
 }
 
-internal class JsonInheritanceConverter<TBase> : System.Text.Json.Serialization.JsonConverter<TBase>
+public class JsonInheritanceConverter<TBase> : System.Text.Json.Serialization.JsonConverter<TBase>
 {
     private readonly string _discriminatorName;
 
@@ -115,7 +115,7 @@ internal class JsonInheritanceConverter<TBase> : System.Text.Json.Serialization.
     }
 }
 {%- else -%}
-internal class JsonInheritanceConverter : Newtonsoft.Json.JsonConverter
+public class JsonInheritanceConverter : Newtonsoft.Json.JsonConverter
 {
     internal static readonly string DefaultDiscriminatorName = "discriminator";
 


### PR DESCRIPTION
The JsonInheritanceConverters need to be made public so downstream NSwag Generator can get the DiscriminatorName (i.e. wrapping Client classes in another generated client class)

Error below:
6> ---> Microsoft.CSharp.RuntimeBinder.RuntimeBinderException: 'System.Text.Json.Serialization.JsonConverter<BaseClass>' does not contain a definition for 'DiscriminatorName'