### PR TITLE
Pass entire ContextualType to SchemaProcessorContext

### DIFF
--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -798,7 +798,7 @@ namespace NJsonSchema.Generation
 
         private void ApplySchemaProcessors(JsonSchema schema, ContextualType contextualType, JsonSchemaResolver schemaResolver)
         {
-            var context = new SchemaProcessorContext(contextualType.OriginalType, schema, schemaResolver, this, Settings);
+            var context = new SchemaProcessorContext(contextualType, schema, schemaResolver, this, Settings);
             foreach (var processor in Settings.SchemaProcessors)
             {
                 processor.Process(context);

--- a/src/NJsonSchema/Generation/SchemaProcessorContext.cs
+++ b/src/NJsonSchema/Generation/SchemaProcessorContext.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using Namotion.Reflection;
 using System;
 
 namespace NJsonSchema.Generation
@@ -14,14 +15,14 @@ namespace NJsonSchema.Generation
     public class SchemaProcessorContext
     {
         /// <summary>Initializes a new instance of the <see cref="SchemaProcessorContext" /> class.</summary>
-        /// <param name="type">The source type.</param>
+        /// <param name="contextualType">The source contextual type.</param>
         /// <param name="schema">The JSON Schema.</param>
         /// <param name="resolver">The resolver.</param>
         /// <param name="generator">The generator.</param>
         /// <param name="settings">The settings.</param>
-        public SchemaProcessorContext(Type type, JsonSchema schema, JsonSchemaResolver resolver, JsonSchemaGenerator generator, JsonSchemaGeneratorSettings settings)
+        public SchemaProcessorContext(ContextualType contextualType, JsonSchema schema, JsonSchemaResolver resolver, JsonSchemaGenerator generator, JsonSchemaGeneratorSettings settings)
         {
-            Type = type;
+            ContextualType = contextualType;
             Schema = schema;
             Resolver = resolver;
             Generator = generator;
@@ -29,7 +30,11 @@ namespace NJsonSchema.Generation
         }
 
         /// <summary>The source type.</summary>
-        public Type Type { get; }
+        [Obsolete("Use ContextualType to obtain this instead.")]
+        public Type Type { get => ContextualType.OriginalType; }
+
+        /// <summary>The source contextual type.</summary>
+        public ContextualType ContextualType { get; }
 
         /// <summary>The JSON Schema to process.</summary>
         public JsonSchema Schema { get; }

--- a/src/NJsonSchema/Generation/SchemaProcessors/DiscriminatorSchemaProcessor.cs
+++ b/src/NJsonSchema/Generation/SchemaProcessors/DiscriminatorSchemaProcessor.cs
@@ -7,7 +7,6 @@
 //-----------------------------------------------------------------------
 
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 using NJsonSchema.Converters;
 using System;
 
@@ -32,7 +31,7 @@ namespace NJsonSchema.Generation.SchemaProcessors
 
         public void Process(SchemaProcessorContext context)
         {
-            if (context.Type == BaseType)
+            if (context.ContextualType.OriginalType == BaseType)
             {
                 var schema = context.Schema;
                 schema.Discriminator = Discriminator;


### PR DESCRIPTION
Currently there is no (simple) way to access the attributes of the property or type being processed in `ISchemaProcessor.Process`, as the `SchemaProcessorContext` object only contains a reference to the type of the schema processed. However, if, for instance, you need to generate custom schema properties based on attributes set on the properties of the type that the schema is generated for, you would need to know 1. the type of the root schema (not necessarily an issue) and 2. the name of the property form that type so that you can access it's attributes trough reflection. The problem lies with getting the name of the property, because there is no guarantee the name of the property in the .NET type is the same as the one in the JSON schema (eg. camel case naming convention used in generator settings).

But all this is not required if instead of only having a reference to the type, the `SchemaProcessorContext` would have a reference to the ContextualType, which can be used to get the attributes on a property (`ContextualType.ContextAttributes`) as well as the actual type of it (`ContextualType.OriginalType`).

In this PR I still included the `SchemaProcessorContext.Type` property for backwards compatibility but marked it as obsolete.