### PR TITLE
Full JsonException type name in DateFormatConverter

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/DateFormatConverter.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/DateFormatConverter.liquid
@@ -7,7 +7,7 @@ internal class DateFormatConverter : System.Text.Json.Serialization.JsonConverte
         var dateTime = reader.GetString();
         if (dateTime == null)
         {
-            throw new JsonException("Unexpected JsonTokenType.Null");
+            throw new System.Text.Json.JsonException("Unexpected JsonTokenType.Null");
         }
 
         return System.DateTime.Parse(dateTime);


### PR DESCRIPTION
When I was using this to generate C# definitions for the Transifex v3 API (using the JSON from their [Download OpenAPI specification](https://transifex.github.io/openapi/index.html) link, the generated code was not building because the type `JsonException` could not be found in the case that it appears within the `DateFormatConverter` (when SystemTextJson is used).

I changed it to use the full type name (`System.Text.Json.JsonException`), as seems to be the common use pattern elsewhere, and that seems to have fixed it.

In case it's useful, the settings that I was using were:

```
var settings = new CSharpClientGeneratorSettings
{
    ClassName = "Transifex{controller}Client",
    CSharpGeneratorSettings =
    {
        Namespace = "TransifexV3.ApiClient",
        GenerateJsonMethods = true,
        GenerateNullableReferenceTypes = true,
        GenerateNativeRecords = true,
        GenerateOptionalPropertiesAsNullable = true,
        ClassStyle = CSharpClassStyle.Record,
        JsonLibrary = CSharpJsonLibrary.SystemTextJson
    },
    GenerateClientInterfaces = true,
    OperationNameGenerator = new MultipleClientsFromPathSegmentsOperationNameGenerator()
};
```

(Note: There is still an error generating code for the Transifex API when the content type `application/vnd.api+json;profile="bulk"` is specified because the quotes don't get escaped - but I've raised that as [a separate issue](https://github.com/RicoSuter/NJsonSchema/issues/1506))