### PR TITLE
Only generate additional properties at base class level

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/ClassTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/ClassTemplateModel.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="ClassTemplateModel.cs" company="NJsonSchema">
 //     Copyright (c) Rico Suter. All rights reserved.
 // </copyright>
@@ -62,15 +62,21 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
         /// <summary>Gets a value indicating whether the C#8 nullable reference types are enabled for this file.</summary>
         public bool GenerateNullableReferenceTypes => _settings.GenerateNullableReferenceTypes;
 
-        /// <summary>Gets a value indicating whether an additional properties type is available and needed.</summary>
+        /// <summary>Gets a value indicating whether an additional properties type is available.</summary>
         public bool HasAdditionalPropertiesType =>
+            HasAdditionalPropertiesTypeInBaseClass || // if the base class has them, inheritance dictates that this class will have them to
             !_schema.IsDictionary &&
             !_schema.ActualTypeSchema.IsDictionary &&
             !_schema.IsArray &&
             !_schema.ActualTypeSchema.IsArray &&
             (_schema.ActualTypeSchema.AllowAdditionalProperties ||
-             _schema.ActualTypeSchema.AdditionalPropertiesSchema != null)
-            && BaseClass?.HasAdditionalPropertiesType != true; // if base class already has extension data array, we need to avoid it in the subclass
+             _schema.ActualTypeSchema.AdditionalPropertiesSchema != null); 
+        
+        /// <summary>Gets a value indicating whether an additional properties type is available in the base class.</summary>
+        public bool HasAdditionalPropertiesTypeInBaseClass => BaseClass?.HasAdditionalPropertiesType ?? false;
+
+        /// <summary> Gets a value indicating if the "Additional properties" property should be generated. </summary>
+        public bool GenerateAdditionalPropertiesProperty => HasAdditionalPropertiesType && !HasAdditionalPropertiesTypeInBaseClass;
 
         /// <summary>Gets the type of the additional properties.</summary>
         public string AdditionalPropertiesType => HasAdditionalPropertiesType ? "object" : null; // TODO: Find a way to use typed dictionaries

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
@@ -118,7 +118,7 @@
 {%-   endif %}
 {%- endfor -%}
 
-{%- if HasAdditionalPropertiesType -%}
+{%- if GenerateAdditionalPropertiesProperty -%}
 
     private System.Collections.Generic.IDictionary<string, {{ AdditionalPropertiesType }}> _additionalProperties = new System.Collections.Generic.Dictionary<string, {{ AdditionalPropertiesType }}>();
 


### PR DESCRIPTION
Fixes #1488 

The JsonExtensionData attribute is only allowed once on a class.
A previous fix to make sure it's only generated once (#1447) did not cover deep hiarachies of inheritance.
-  Included a unit test to reproduce the multilevel inheritance issue
-  Extended the model so that there is a sepperation of logic
   - Indication if the class has addtional properties
   - Indication if the additional properties actually need to be generated

Related Issues:
 [#2818 on the NSwag repo](https://github.com/RicoSuter/NSwag/issues/2818)