### PR TITLE
Fix DateFormatConverter System.Text.Json to respect DateType setting

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/GeneralGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/GeneralGeneratorTests.cs
@@ -1614,7 +1614,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             var code = generator.GenerateFile("MyClass");
 
             //// Assert
-            Assert.Contains(@"class DateFormatConverter", code);
+            Assert.Contains(@"class DateFormatConverter : System.Text.Json.Serialization.JsonConverter<System.DateTime>", code);
             Assert.Contains(@"[System.Text.Json.Serialization.JsonConverter(typeof(DateFormatConverter))]", code);
 
             AssertCompile(code);
@@ -1791,7 +1791,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             var code = generator.GenerateFile("MyClass");
 
             //// Assert
-            Assert.Contains(@"class DateFormatConverter", code);
+            Assert.Contains(@"class DateFormatConverter : System.Text.Json.Serialization.JsonConverter<System.DateTimeOffset>", code);
             Assert.Contains(@"[System.Text.Json.Serialization.JsonConverter(typeof(DateFormatConverter))]", code);
 
             AssertCompile(code);

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/DateFormatConverterTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/DateFormatConverterTemplateModel.cs
@@ -26,5 +26,8 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
 
         /// <summary>Gets a value indicating whether to use System.Text.Json</summary>
         public bool UseSystemTextJson => _settings.JsonLibrary == CSharpJsonLibrary.SystemTextJson;
+
+        /// <summary>Gets the date .NET type.</summary>
+        public string DateType => _settings.DateType;
     }
 }

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/DateFormatConverter.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/DateFormatConverter.liquid
@@ -1,8 +1,8 @@
 ﻿[System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "{{ ToolchainVersion }}")]
 {%- if UseSystemTextJson -%}
-internal class DateFormatConverter : System.Text.Json.Serialization.JsonConverter<System.DateTime>
+internal class DateFormatConverter : System.Text.Json.Serialization.JsonConverter<{{ DateType }}>
 {
-    public override System.DateTime Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options)
+    public override {{ DateType }} Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options)
     {
         var dateTime = reader.GetString();
         if (dateTime == null)
@@ -10,10 +10,10 @@ internal class DateFormatConverter : System.Text.Json.Serialization.JsonConverte
             throw new System.Text.Json.JsonException("Unexpected JsonTokenType.Null");
         }
 
-        return System.DateTime.Parse(dateTime);
+        return {{ DateType }}.Parse(dateTime);
     }
 
-    public override void Write(System.Text.Json.Utf8JsonWriter writer, System.DateTime value, System.Text.Json.JsonSerializerOptions options)
+    public override void Write(System.Text.Json.Utf8JsonWriter writer, {{ DateType }} value, System.Text.Json.JsonSerializerOptions options)
     {
         writer.WriteStringValue(value.ToString("yyyy-MM-dd"));
     }


### PR DESCRIPTION
Have `DateFormatConverterTemplateModel` pass on the `CSharpGeneratorSettings.DateType` setting, and use it in the liquid file. Fixes #1526 

