### PR TITLE
Add support for flag enums with more than 32 values

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/EnumTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/EnumTests.cs
@@ -15,7 +15,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
         {
             //// Arrange
             var json =
-            @"{
+                @"{
                 ""type"": ""object"", 
                 ""properties"": {
                     ""category"" : {
@@ -41,7 +41,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
         {
             //// Arrange
             var json =
-            @"{
+                @"{
                 ""type"": ""object"", 
                 ""properties"": {
                     ""category"" : {
@@ -57,7 +57,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             }";
 
             var schema = await JsonSchema.FromJsonAsync(json);
-            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings { EnforceFlagEnums = true });
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings {EnforceFlagEnums = true});
 
             //// Act
             var code = generator.GenerateFile("MyClass");
@@ -139,7 +139,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             //// Arrange
             var schema = JsonSchema.FromType<MyStringEnumListTest>();
             var data = schema.ToJson();
-            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings { ClassStyle = CSharpClassStyle.Poco });
+            var generator =
+                new CSharpGenerator(schema, new CSharpGeneratorSettings {ClassStyle = CSharpClassStyle.Poco});
 
             //// Act
             var code = generator.GenerateFile();
@@ -154,16 +155,22 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             //// Arrange
             var schema = JsonSchema.FromType<MyStringEnumListTest>();
             var data = schema.ToJson();
-            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings { ClassStyle = CSharpClassStyle.Poco });
+            var generator =
+                new CSharpGenerator(schema, new CSharpGeneratorSettings {ClassStyle = CSharpClassStyle.Poco});
 
             //// Act
             var code = generator.GenerateFile();
 
             //// Assert
-            Assert.Contains("[Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]", code);
+            Assert.Contains("[Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]",
+                code);
         }
 
-        public enum SomeEnum { Thing1, Thing2 }
+        public enum SomeEnum
+        {
+            Thing1,
+            Thing2
+        }
 
         public class SomeClass
         {
@@ -179,7 +186,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             var json = schema.ToJson();
 
             //// Act
-            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings { ClassStyle = CSharpClassStyle.Poco });
+            var generator =
+                new CSharpGenerator(schema, new CSharpGeneratorSettings {ClassStyle = CSharpClassStyle.Poco});
             var code = generator.GenerateFile();
 
             //// Assert
@@ -232,7 +240,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
         {
             //// Arrange
             var json =
-            @"{
+                @"{
     ""type"": ""object"",
     ""required"": [
         ""name"",
@@ -251,7 +259,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
     }
 }";
             var schema = await JsonSchema.FromJsonAsync(json);
-            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings { SchemaType = SchemaType.Swagger2 });
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings {SchemaType = SchemaType.Swagger2});
 
             //// Act
             var code = generator.GenerateFile("MyClass");
@@ -523,7 +531,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             //// Act
             var schema = await JsonSchema.FromJsonAsync(json);
 
-            var settings = new CSharpGeneratorSettings { EnforceFlagEnums = true };
+            var settings = new CSharpGeneratorSettings {EnforceFlagEnums = true};
             var generator = new CSharpGenerator(schema, settings);
 
             var code = generator.GenerateFile("Foo");
@@ -539,7 +547,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
         {
             //// Arrange
             var json =
-            @"{
+                @"{
                 ""type"": ""object"", 
                 ""properties"": {
                     ""category"" : {
@@ -565,7 +573,44 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             var code = generator.GenerateFile("MyClass");
 
             //// Assert
-            Assert.Contains("public MyClassCategory? Category { get; set; } = MyNamespace.MyClassCategory.Commercial;", code);
+            Assert.Contains("public MyClassCategory? Category { get; set; } = MyNamespace.MyClassCategory.Commercial;",
+                code);
+        }
+
+        [Fact]
+        public async Task When_enum_has_a_format_then_enum_is_generated_with_correct_basetype()
+        {
+            // Arrange
+            var json = @"
+{
+    ""properties"": {
+        ""foo"": {
+            ""$ref"": ""#/definitions/ManyValuesTestEnum""
+        }
+    },
+    ""definitions"": {
+        ""ManyValuesTestEnum"": {
+            ""type"": ""integer"",
+            ""format"": ""int64"",
+            ""x-enumNames"": [
+                ""None"",
+                ""FirstBit""
+            ],
+            ""enum"": [
+                0,
+                1
+            ]
+        }
+    }
+}";
+            var schema = await JsonSchema.FromJsonAsync(json);
+            var generator = new CSharpGenerator(schema);
+
+            //// Act
+            var code = generator.GenerateFile("MyClass");
+
+            //// Assert
+            Assert.Contains("public enum ManyValuesTestEnum : long", code);
         }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/EnumTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/EnumTests.cs
@@ -156,7 +156,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             var schema = JsonSchema.FromType<MyStringEnumListTest>();
             var data = schema.ToJson();
             var generator =
-                new CSharpGenerator(schema, new CSharpGeneratorSettings {ClassStyle = CSharpClassStyle.Poco});
+                new CSharpGenerator(schema, new CSharpGeneratorSettings { ClassStyle = CSharpClassStyle.Poco });
 
             //// Act
             var code = generator.GenerateFile();
@@ -187,7 +187,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Act
             var generator =
-                new CSharpGenerator(schema, new CSharpGeneratorSettings {ClassStyle = CSharpClassStyle.Poco});
+                new CSharpGenerator(schema, new CSharpGeneratorSettings { ClassStyle = CSharpClassStyle.Poco });
             var code = generator.GenerateFile();
 
             //// Assert
@@ -259,7 +259,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
     }
 }";
             var schema = await JsonSchema.FromJsonAsync(json);
-            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings {SchemaType = SchemaType.Swagger2});
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings { SchemaType = SchemaType.Swagger2 });
 
             //// Act
             var code = generator.GenerateFile("MyClass");

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/EnumTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/EnumTemplateModel.cs
@@ -52,6 +52,9 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
         /// <summary>Gets or sets if we output as Bit Flags.</summary>
         public bool IsEnumAsBitFlags => _settings.EnforceFlagEnums || _schema.IsFlagEnumerable;
 
+        /// <summary>Gets a value indicating whether the enum needs an other base type to representing an extended value range.</summary>
+        public bool HasExtendedValueRange => _schema.Format == JsonFormatStrings.Long;
+
         /// <summary>Gets the enum values.</summary>
         public IEnumerable<EnumerationItemModel> Enums
         {

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Enum.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Enum.liquid
@@ -7,7 +7,7 @@
 {%- if IsEnumAsBitFlags -%}
 [System.Flags]
 {%- endif -%}
-{{ TypeAccessModifier }} enum {{ Name }}
+{{ TypeAccessModifier }} enum {{ Name }}{%- if HasExtendedValueRange %} : long{% endif %}
 {
 {%- for enum in Enums %}
 {%-   if IsStringEnum -%}


### PR DESCRIPTION
The generator has so far only generated enums with the implicit default type int.
Also for enums declared with the base type long in C# and a "Format = int64" was specified in the OpenAPI document.
**Original C#**
~~~csharp
 public enum Foo : long
    {
        _0 = 0L,
        _1 = 1L << 1,
        _2 = 1L << 2,
       ...
        _31 = 1L << 31,
        _32 = 1L << 32,
        _33 = 1L << 33
    }
~~~
**Swagger Definition**
~~~json
      "Foo": {
        "type": "integer",
        "format": "int64",
        "description": "",
        "x-enumNames": [
          "_0",
          "_1",
          "_2",
       ...
          "_31",
          "_32",
          "_33"
        ],
        "enum": [
          0,
          2,
          4,
       ...
          2147483648,
          4294967296,
          8589934592
        ]
      }
~~~
**NSwag Output**
~~~csharp
 public enum Foo
    {
        _0 = 0,
        _1 = 2,
        _2 = 4,
       ...
        _31 = 2147483648,
        _32 = 4294967296,
        _33 = 8589934592
    }
~~~

The nswag output does not compile because "long" is missing as base type.
The values exceed the range of the implicit base type int.