### PR TITLE
Resolves #1547: Make RemoveNullability virtual for extendability

### DIFF
--- a/src/NJsonSchema.CodeGeneration.Tests/ApiSurfaceGuard.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/ApiSurfaceGuard.cs
@@ -1,0 +1,23 @@
+﻿namespace NJsonSchema.CodeGeneration.Tests;
+
+public class ApiSurfaceGuard
+{
+    private abstract class TypeResolverBaseApiGuard : TypeResolverBase
+    {
+        protected TypeResolverBaseApiGuard(CodeGeneratorSettingsBase settings) : base(settings)
+        {
+        }
+
+        // dummy implementation making sure this method stays overridable
+        public override string GetOrGenerateTypeName(JsonSchema schema, string typeNameHint)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        // dummy implementation making sure this method stays overridable
+        public override JsonSchema RemoveNullability(JsonSchema schema)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/src/NJsonSchema.CodeGeneration/TypeResolverBase.cs
+++ b/src/NJsonSchema.CodeGeneration/TypeResolverBase.cs
@@ -84,7 +84,7 @@ namespace NJsonSchema.CodeGeneration
         /// <summary>Removes a nullable oneOf reference if available.</summary>
         /// <param name="schema">The schema.</param>
         /// <returns>The actually resolvable schema</returns>
-        public JsonSchema RemoveNullability(JsonSchema schema)
+        public virtual JsonSchema RemoveNullability(JsonSchema schema)
         {
             // TODO: Method on JsonSchema4?
             return schema.OneOf.FirstOrDefault(o => !o.IsNullable(SchemaType.JsonSchema)) ?? schema;


### PR DESCRIPTION
This allows to implement different logic e.g. treat JsonSchema.OneOf
to have multiple (non nullable) items instead of zero or one.