### PR TITLE
Recursive sample generation

### DIFF
--- a/src/NJsonSchema.Tests/Generation/SampleJsonDataGeneratorTests.cs
+++ b/src/NJsonSchema.Tests/Generation/SampleJsonDataGeneratorTests.cs
@@ -185,6 +185,123 @@ namespace NJsonSchema.Tests.Generation
             Assert.Equal(1, testJson.SelectToken("body.numberContent.value").Value<int>());
         }
 
+        [Fact]
+        public async Task SchemaWithRecursiveDefinition()
+        {
+            //// Arrange
+            var data = @"{
+                ""$schema"": ""http://json-schema.org/draft-04/schema#"",
+                ""title"": ""test schema"",
+                ""type"": ""object"",
+                ""required"": [
+                  ""body"", ""footer""
+                ],
+                ""properties"": {
+                  ""body"": {
+                    ""$ref"": ""#/definitions/body""
+                  },
+                ""footer"": {
+                    ""$ref"": ""#/definitions/numberContent""
+                  }
+                },
+                ""definitions"": {
+                  ""body"": {
+                    ""type"": ""object"",
+                    ""additionalProperties"": false,
+                    ""properties"": {
+                      ""numberContent"": {
+                        ""$ref"": ""#/definitions/numberContent""
+                      }
+                    }
+                  },
+                  ""numberContent"": {
+                    ""type"": ""object"",
+                    ""additionalProperties"": false,
+                    ""properties"": {
+                      ""value"": {
+                        ""type"": ""number"",
+                        ""maximum"": 5.00001,
+                        ""minimum"": 1.000012
+                      },
+                      ""data"": {
+                        ""$ref"": ""#/definitions/body""
+                      }
+                    }
+                  }
+                }
+              }";
+            var generator = new SampleJsonDataGenerator();
+            var schema = await JsonSchema.FromJsonAsync(data);
+            //// Act
+            var testJson = generator.Generate(schema);
+
+            //// Assert
+            var footerToken = testJson.SelectToken("body.numberContent.data.numberContent.value");
+            Assert.NotNull(footerToken);
+
+            var validationResult = schema.Validate(testJson);
+            Assert.NotNull(validationResult);
+            Assert.Equal(1.000012, testJson.SelectToken("footer.value").Value<double>());
+            Assert.True(validationResult.Count > 0); // It is expected to fail validating the recursive properties (because of max recursion level)
+        }
+
+        [Fact]
+        public async Task SchemaWithDefinitionUseMultipleTimes()
+        {
+            //// Arrange
+            var data = @"{
+                ""$schema"": ""http://json-schema.org/draft-04/schema#"",
+                ""title"": ""test schema"",
+                ""type"": ""object"",
+                ""required"": [
+                  ""body"", ""footer""
+                ],
+                ""properties"": {
+                  ""body"": {
+                    ""$ref"": ""#/definitions/body""
+                  },
+                ""footer"": {
+                    ""$ref"": ""#/definitions/numberContent""
+                  }
+                },
+                ""definitions"": {
+                  ""body"": {
+                    ""type"": ""object"",
+                    ""additionalProperties"": false,
+                    ""properties"": {
+                      ""numberContent"": {
+                        ""$ref"": ""#/definitions/numberContent""
+                      }
+                    }
+                  },
+                  ""numberContent"": {
+                    ""type"": ""object"",
+                    ""additionalProperties"": false,
+                    ""properties"": {
+                      ""value"": {
+                        ""type"": ""number"",
+                        ""maximum"": 5.00001,
+                        ""minimum"": 1.000012
+                      }
+                    }
+                  }
+                }
+              }";
+            var generator = new SampleJsonDataGenerator();
+            var schema = await JsonSchema.FromJsonAsync(data);
+
+            //// Act
+            var testJson = generator.Generate(schema);
+
+            //// Assert
+            var footerToken = testJson.SelectToken("footer.value");
+            Assert.NotNull(footerToken);
+
+            var validationResult = schema.Validate(testJson);
+            Assert.NotNull(validationResult);
+            Assert.Equal(0, validationResult.Count);
+            Assert.Equal(1.000012, testJson.SelectToken("body.numberContent.value").Value<double>());
+        }
 
         [Fact]
         public async Task PropertyWithFloatMinimumDefinition()

--- a/src/NJsonSchema/Generation/SampleJsonDataGeneratorSettings.cs
+++ b/src/NJsonSchema/Generation/SampleJsonDataGeneratorSettings.cs
@@ -5,5 +5,8 @@
     {
         /// <summary>Gets or sets a value indicating whether to generate optional properties (default: true).</summary>
         public bool GenerateOptionalProperties { get; set; } = true;
+
+        /// <summary>Gets or sets a value indicating the max level of recursion the generator is allowed to perform (default: 3)</summary>
+        public int MaxRecursionLevel { get; set; } = 3;
     }
 }


### PR DESCRIPTION
Fixes #1560 

This PR modifies SampleJsonDataGenerator to support re-use of definitions, and by extension, recursion.

See issue for the problem before.

### Example 1

Now the following schema:
```json
{
    "definitions": {
        "withNumber": {
            "type": "object",
            "required": ["value"],
            "properties": {
                "value": {
                    "type": "number"
                }
            }
        }
    },
    "type": "object",
    "required": ["number1", "number2"],
    "properties": {
        "number1": { "$ref": "#/definitions/withNumber" },
        "number2": { "$ref": "#/definitions/withNumber" }
    }
}
```

generates 

```json
{
  "number1": {
    "value": 0.0
  },
  "number2": {
    "value": 0.0
  }
}
```

### Example 2

Schema:
```json
{
    "definitions": {
        "data": {
            "type": "object",
            "required": ["body"],
            "properties": {
                "body": { "$ref": "#/definitions/data" }
            }
        }
    },
    "type": "object",
    "required": ["data"],
    "properties": {
        "data": { "$ref": "#/definitions/data" },
    }
}
```

generates:

```json
{
  "data": {
    "body": {
      "body": {
        "body": null
      }
    }
  }
}
```

The level of recursion is controlled by a new setting on `SampleJsonDataGeneratorSettings`