### PR TITLE
Adds configuration settings to influence required annotation

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpGeneratorSettings.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpGeneratorSettings.cs
@@ -61,6 +61,12 @@ namespace NJsonSchema.CodeGeneration.CSharp
         /// (sets Required.Always when the property is required) (default: true).</summary>
         public bool RequiredPropertiesMustBeDefined { get; set; }
 
+        /// <summary>Gets or sets a value indicating whether a required property should be treated as nullable by 
+        /// default (if the property is not explicitly market as nullable: false)
+        /// (sets Required.Default when the property is not required and not explicitly marked as nullable: false).
+        /// </summary>
+        public bool DefaultNonRequiredToNullable { get; set; }
+
         /// <summary>Gets or sets a value indicating whether to generated data annotation attributes (default: true).</summary>
         public bool GenerateDataAnnotations { get; set; }
 

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
@@ -81,6 +81,17 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
         {
             get
             {
+                if (_settings.DefaultNonRequiredToNullable && !_property.IsRequired)
+                {
+                    if (_property.IsNullableRaw == false)
+                    {
+                        return "Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore";
+                    }
+                    else
+                    {
+                        return "Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore";
+                    }
+                }
                 if (_settings.RequiredPropertiesMustBeDefined && _property.IsRequired)
                 {
                     if (!_property.IsNullable(_settings.SchemaType))


### PR DESCRIPTION
Sometimes it would be useful, also with an OpenApi3 schema to generate non-required fields as Required.Default.
Do you think it makes sense to follow such a toggle and elaborate it more?