### PR TITLE
Add settings UseUriTypeForUriFormattedStrings

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpGeneratorSettings.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpGeneratorSettings.cs
@@ -52,6 +52,8 @@ namespace NJsonSchema.CodeGeneration.CSharp
             InlineNamedArrays = false;
             InlineNamedDictionaries = false;
             InlineNamedTuples = true;
+
+            UseUriTypeForUriFormattedStrings = true;
         }
 
         /// <summary>Gets or sets the .NET namespace of the generated types (default: MyNamespace).</summary>
@@ -147,5 +149,8 @@ namespace NJsonSchema.CodeGeneration.CSharp
 
         /// <summary>Generate C# 9.0 record types instead of record-like classes.</summary>
         public bool GenerateNativeRecords { get; set; }
+
+        /// <summary>Indicate if System.Uri should be used for strings with format uri (default: true)</summary>
+        public bool UseUriTypeForUriFormattedStrings { get; set; }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
@@ -182,7 +182,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
 
             var nullableReferenceType = Settings.GenerateNullableReferenceTypes && isNullable ? "?" : string.Empty;
 
-            if (schema.Format == JsonFormatStrings.Uri)
+            if (schema.Format == JsonFormatStrings.Uri && Settings.UseUriTypeForUriFormattedStrings)
             {
                 return "System.Uri" + nullableReferenceType;
             }


### PR DESCRIPTION
Now all uri formatted strings will translate into System.Uri, and it's not desired in every situation.
This change make it possible for the user to not use the System.Uri and string will be used instead.