### PR TITLE
Handle single quote in properties names

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpPropertyNameGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpPropertyNameGenerator.cs
@@ -18,6 +18,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
         {
             return ConversionUtilities.ConvertToUpperCamelCase(property.Name
                     .Replace("\"", string.Empty)
+                    .Replace("'", string.Empty)
                     .Replace("@", string.Empty)
                     .Replace("?", string.Empty)
                     .Replace("$", string.Empty)


### PR DESCRIPTION
Remove single quotes which cause invalid property names.