### PR TITLE
For NSwag #3342. Check ExtensionData for nullable property

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/References/F.json
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/References/F.json
@@ -1,0 +1,9 @@
+{
+    "type": "object",
+    "properties": {
+        "name": {
+            "$ref": "./G.json",
+            "description": "This is the type of G"
+        }
+    }
+}

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/References/G.json
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/References/G.json
@@ -1,0 +1,4 @@
+{
+    "type": "string",
+    "nullable": true
+}

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/ReferencesTest.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/ReferencesTest.cs
@@ -47,6 +47,27 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             Assert.DoesNotContain("public enum C2", code);
         }
 
+        [Fact]
+        public async Task When_ref_is_file_and_it_contains_nullable_property_then_generated_property_is_also_nullable()
+        {
+            //// Arrange
+            var path = GetTestDirectory() + "/References/F.json";
+
+            //// Act
+            var schema = await JsonSchema.FromFileAsync(path);
+            var generatorSettings = new CSharpGeneratorSettings
+            {
+                GenerateNullableReferenceTypes = true
+            };
+            var generator = new CSharpGenerator(schema, generatorSettings);
+
+            //// Act
+            var code = generator.GenerateFile("MyClass");
+
+            //// Assert
+            Assert.Contains("public string? Name", code);
+        }
+
         private string GetTestDirectory()
         {
             var codeBase = Assembly.GetExecutingAssembly().CodeBase;

--- a/src/NJsonSchema/JsonSchema.cs
+++ b/src/NJsonSchema/JsonSchema.cs
@@ -894,6 +894,14 @@ namespace NJsonSchema
                 return true;
             }
 
+            if (ExtensionData != null && ExtensionData.TryGetValue("nullable", out var value))
+            {
+                if (bool.TryParse(value.ToString(), out var boolValue))
+                {
+                    return boolValue;
+                }
+            }
+
             return false;
         }
 


### PR DESCRIPTION
For [NSwag #3342](https://github.com/RicoSuter/NSwag/issues/3342). Adds nullable property check from `JsonSchema.ExtensionData`