### PR TITLE
Don't use DateFormatConverter for DateOnly

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/ClassTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/ClassTemplateModel.cs
@@ -145,7 +145,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                                                _schema?.InheritsSchema(_resolver.ExceptionSchema) == true;
 
         /// <summary>Gets a value indicating whether to use the DateFormatConverter.</summary>
-        public bool UseDateFormatConverter => _settings.DateType.StartsWith("System.Date");
+        public bool UseDateFormatConverter => _settings.DateType.StartsWith("System.DateTime");
 
         /// <summary>Gets or sets the access modifier of generated classes and interfaces.</summary>
         public string TypeAccessModifier => _settings.TypeAccessModifier;


### PR DESCRIPTION
The DateFormatConverter has been causing some problems for use when using DateOnly.  
I don't think it's needed for DateOnly, and removing it will solve these problems