### PR TITLE
Add support for STJ-native polymorphic `JsonDerivedType` and `JsonPolymorphic` attributes to C# client/schema generator

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100",
+    "version": "7.0.100",
     "rollForward": "latestMinor"
   }
 }

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/InheritanceInterfaceTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/InheritanceInterfaceTests.cs
@@ -74,9 +74,9 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.True(json.Properties["Item"].ActualTypeSchema.AllOf.First().HasReference);
-            Assert.Contains("[JsonInheritanceConverter(typeof(Fruit), \"discriminator\")]", code);
-            Assert.Contains("[JsonInheritanceAttribute(\"Banana\", typeof(Banana))]", code);
-            Assert.Contains("public class JsonInheritanceConverter<TBase> : System.Text.Json.Serialization.JsonConverter<TBase>", code);
+            Assert.Contains("[System.Text.Json.Serialization.JsonPolymorphic(TypeDiscriminatorPropertyName = \"discriminator\")]", code);
+            Assert.Contains("[System.Text.Json.Serialization.JsonDerivedType(typeof(Banana), typeDiscriminator: \"Banana\")]", code);
+            Assert.DoesNotContain("public class JsonInheritanceConverter<TBase> : System.Text.Json.Serialization.JsonConverter<TBase>", code);
         }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/InheritanceTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/InheritanceTests.cs
@@ -135,14 +135,20 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
         }
 
         [Fact]
-        public async Task When_definitions_inherit_from_root_schema()
+        public async Task When_definitions_inherit_from_root_schema_Newtonsoft()
         {
             //// Arrange
             var path = GetTestDirectory() + "/References/Animal.json";
 
             //// Act
             var schema = await JsonSchema.FromFileAsync(path);
-            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings { ClassStyle = CSharpClassStyle.Record });
+            var generator = new CSharpGenerator(
+                schema,
+                new CSharpGeneratorSettings
+                {
+                    ClassStyle = CSharpClassStyle.Record,
+                    JsonLibrary = CSharpJsonLibrary.NewtonsoftJson
+                });
 
             //// Act
             var code = generator.GenerateFile();
@@ -155,6 +161,33 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             Assert.Contains("[JsonInheritanceAttribute(\"PersianCat\", typeof(PersianCat))]", code);
         }
 
+        [Fact]
+        public async Task When_definitions_inherit_from_root_schema_STJ()
+        {
+            //// Arrange
+            var path = GetTestDirectory() + "/References/Animal.json";
+
+            //// Act
+            var schema = await JsonSchema.FromFileAsync(path);
+            var generator = new CSharpGenerator(
+                schema,
+                new CSharpGeneratorSettings
+                {
+                    ClassStyle = CSharpClassStyle.Record,
+                    JsonLibrary = CSharpJsonLibrary.SystemTextJson
+                });
+
+            //// Act
+            var code = generator.GenerateFile();
+
+            //// Assert
+            Assert.Contains("public abstract partial class Animal", code);
+            Assert.Contains("public partial class Cat : Animal", code);
+            Assert.Contains("public partial class PersianCat : Cat", code);
+            Assert.Contains("[System.Text.Json.Serialization.JsonDerivedType(typeof(Cat), typeDiscriminator: \"Cat\")]", code);
+            Assert.Contains("[System.Text.Json.Serialization.JsonDerivedType(typeof(PersianCat), typeDiscriminator: \"PersianCat\")]", code);
+        }
+
         private string GetTestDirectory()
         {
             var codeBase = Assembly.GetExecutingAssembly().CodeBase;
@@ -163,3 +196,4 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
         }
     }
 }
+

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
@@ -5,13 +5,17 @@
 {%- endif -%}
 {%- if HasDiscriminator -%}
 {%- if UseSystemTextJson -%}
-[JsonInheritanceConverter(typeof({{ ClassName }}), "{{ Discriminator }}")]
+[System.Text.Json.Serialization.JsonPolymorphic(TypeDiscriminatorPropertyName = "{{ Discriminator }}")]
 {%- else -%}
 [Newtonsoft.Json.JsonConverter(typeof(JsonInheritanceConverter), "{{ Discriminator }}")]
 {%- endif -%}
 {%- for derivedClass in DerivedClasses -%}
 {%- if derivedClass.IsAbstract != true -%}
+{%- if UseSystemTextJson -%}
+[System.Text.Json.Serialization.JsonDerivedType(typeof({{ derivedClass.ClassName }}), typeDiscriminator: "{{ derivedClass.Discriminator }}")]
+{%- else -%}
 [JsonInheritanceAttribute("{{ derivedClass.Discriminator }}", typeof({{ derivedClass.ClassName }}))]
+{%- endif -%}
 {%- endif -%}
 {%- endfor -%}
 {%- endif -%}

--- a/src/NJsonSchema.Tests/Generation/InheritanceTests.cs
+++ b/src/NJsonSchema.Tests/Generation/InheritanceTests.cs
@@ -439,5 +439,56 @@ namespace NJsonSchema.Tests.Generation
             Assert.Contains(@"""a"": """, data);
             Assert.Contains(@"""o"": """, data);
         }
+
+#if NET7_0_OR_GREATER
+        public class AppleSTJ : FruitSTJ
+        {
+            public string Foo { get; set; }
+        }
+
+        public class OrangeSTJ : FruitSTJ
+        {
+            public string Bar { get; set; }
+        }
+
+        [System.Text.Json.Serialization.JsonDerivedType(typeof(AppleSTJ), typeDiscriminator: "a")]
+        [System.Text.Json.Serialization.JsonDerivedType(typeof(OrangeSTJ), typeDiscriminator: "o")]
+        [System.Text.Json.Serialization.JsonPolymorphic(TypeDiscriminatorPropertyName = "k")]
+        public class FruitSTJ
+        {
+            public string Baz { get; set; }
+        }
+
+        [Fact]
+        public async Task When_using_JsonDerivedType_then_schema_is_correct()
+        {
+            //// Act
+            var schema = JsonSchema.FromType<FruitSTJ>();
+            var data = schema.ToJson();
+
+            //// Assert
+            Assert.NotNull(data);
+            Assert.Contains(@"""a"": """, data);
+            Assert.Contains(@"""o"": """, data);
+        }
+
+        [Fact]
+        public async Task When_using_JsonDerivedType_then_schema_is_equivalent_to_schema_using_JsonDerivedType()
+        {
+            //// Arrange
+            var expectedJson = JsonSchema
+                .FromType<Fruit>()
+                .ToJson();
+
+            //// Act
+            var actualJson = JsonSchema
+                .FromType<FruitSTJ>()
+                .ToJson()
+                .Replace("STJ", string.Empty);
+
+            //// Assert
+            Assert.Equal(expectedJson, actualJson);
+        }
+#endif
     }
 }

--- a/src/NJsonSchema.Tests/NJsonSchema.Tests.csproj
+++ b/src/NJsonSchema.Tests/NJsonSchema.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net461</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;net461</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/src/NJsonSchema/NJsonSchema.csproj
+++ b/src/NJsonSchema/NJsonSchema.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;netstandard2.0;net40;net45</TargetFrameworks>
+    <TargetFrameworks>net7.0;netstandard1.0;netstandard2.0;net40;net45</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net40'">
     <DefineConstants>LEGACY</DefineConstants>


### PR DESCRIPTION
[Beginning with .NET 7, System.Text.Json supports polymorphic type hierarchy serialization and deserialization with attribute annotations.](https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/polymorphism?pivots=dotnet-7-0). This PR adds support for the generation of `JsonPolymorphic` and `JsonDerivedType` attributes to the C# client generator.

This basically deprecates https://github.com/RicoSuter/NJsonSchema/blob/ed250a8b9c4f86a4da40cf0061cf0172cdea0449/src/NJsonSchema.Tests/Generation/SystemTextJson/JsonInheritanceConverter.cs#L14 for .NET 7 and later.

_It Works On My Machine™_, but the addition of unit tests and the changes I've made are pretty naive and the generated STJ code only works for .NET 7 or later. I was looking for something like a ".NET target type" parameter in the Liquid templates, but couldn't find any of the like. @RicoSuter I'd appreciate if you could point me to where else I gotta flesh out the code.

Related issues:

- https://github.com/RicoSuter/NJsonSchema/issues/1013
- https://github.com/RicoSuter/NJsonSchema/issues/1588
- https://github.com/RicoSuter/NSwag/issues/4375
- https://github.com/RicoSuter/NSwag/issues/3887
- https://github.com/RicoSuter/NSwag/issues/2243#issuecomment-780438323