### PR TITLE
Fix TypeScript enum default generation in StringLiteral mode

### DIFF
--- a/src/NJsonSchema.CodeGeneration.Tests/DefaultValueGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/DefaultValueGeneratorTests.cs
@@ -218,7 +218,36 @@ namespace NJsonSchema.CodeGeneration.Tests
             Assert.Equal("Ns.MyEnum.bar", csharpValue);
             Assert.Equal("MyEnum.bar", typescriptValue);
         }
-        
+
+        /// <summary>
+        /// This test asserts the fix for issue #1618
+        /// </summary>
+        [Fact]
+        public void When_schema_has_a_default_value_for_an_enum_and_uses_enumstyle_stringliteral_it_defaults_to_the_stringliteral()
+        {
+            //// Arrange
+            var schema = new JsonSchema()
+            {
+                Type = JsonObjectType.String,
+                Enumeration =
+                {
+                    "Foo",
+                    "Bar"
+                },
+                Default = "Bar"
+            };
+
+            var typescriptSettings = new TypeScriptGeneratorSettings { EnumStyle = TypeScriptEnumStyle.StringLiteral };
+            var typescriptGenerator = new TypeScriptValueGenerator(typescriptSettings);
+            var typescriptTypeResolver = new TypeScriptTypeResolver(typescriptSettings);
+
+            //// Act
+            var typescriptValue = typescriptGenerator.GetDefaultValue(schema, true, "MyEnum", "MyEnum", true, typescriptTypeResolver);
+
+            //// Assert
+            Assert.Equal("\"Bar\"", typescriptValue);
+        }
+
         [Fact]
         public void When_schema_has_required_abstract_class_it_generates_no_default_value_for_in_CSharp_and_TypeScript()
         {

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptGeneratorTests.cs
@@ -140,6 +140,48 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
             Assert.Contains(@"/** EnumDesc. *", output);
         }
 
+        /// <summary>
+        /// This test asserts the fix for issue #1618
+        /// </summary>
+        [Fact]
+        public async Task When_enum_has_default_and_using_enumstyle_stringliteral_it_defaults_to_stringliteral()
+        {
+            //// Arrange
+            var jsonSchema = """
+                {
+                  "$schema": "http://json-schema.org/draft-04/schema#",
+                  "openapi": "3.1.0",
+                  "title": "TShirt",
+                  "type": "object",
+                  "properties": {
+                    "color": {
+                      "type": "string",
+                      "default": "green",
+                      "enum": ["red", "green", "blue", "black"]
+                    }
+                  }
+                }
+                """;
+
+            var schema = await JsonSchema.FromJsonAsync(jsonSchema);
+            var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings
+            {
+                EnumStyle = TypeScriptEnumStyle.StringLiteral,
+                TypeScriptVersion = 5m,
+            });
+
+            //// Act
+            var code = generator.GenerateFile("MyFile");
+
+            //// Assert
+            Assert.Contains("export type MyFileColor = \"red\" | \"green\" | \"blue\" | \"black\";", code);
+            Assert.Contains("this.color = _data[\"color\"] !== undefined ? _data[\"color\"] : \"green\";", code);
+            Assert.Contains("this.color = \"green\";", code);
+
+            // This is the old code gen that used the enum prior to the fix for #1618
+            Assert.DoesNotContain("Color.Green", code);
+        }
+
         [Fact]
         public async Task When_class_has_description_then_typescript_has_comment()
         {

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptGeneratorTests.cs
@@ -147,21 +147,20 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
         public async Task When_enum_has_default_and_using_enumstyle_stringliteral_it_defaults_to_stringliteral()
         {
             //// Arrange
-            var jsonSchema = """
+            var jsonSchema = @"
                 {
-                  "$schema": "http://json-schema.org/draft-04/schema#",
-                  "openapi": "3.1.0",
-                  "title": "TShirt",
-                  "type": "object",
-                  "properties": {
-                    "color": {
-                      "type": "string",
-                      "default": "green",
-                      "enum": ["red", "green", "blue", "black"]
+                    ""$schema"": ""http://json-schema.org/draft-04/schema#"",
+                    ""openapi"": ""3.1.0"",
+                    ""title"": ""TShirt"",
+                    ""type"": ""object"",
+                    ""properties"": {
+                        ""color"": {
+                            ""type"": ""string"",
+                            ""default"": ""green"",
+                            ""enum"": [""red"", ""green"", ""blue"", ""black""]
+                        }
                     }
-                  }
-                }
-                """;
+                }";
 
             var schema = await JsonSchema.FromJsonAsync(jsonSchema);
             var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptValueGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptValueGenerator.cs
@@ -29,6 +29,23 @@ namespace NJsonSchema.CodeGeneration.TypeScript
         {
         }
 
+        /// <summary>Gets the enum default value.</summary>
+        /// <param name="schema">The schema.</param>
+        /// <param name="actualSchema">The actual schema.</param>
+        /// <param name="typeNameHint">The type name hint.</param>
+        /// <param name="typeResolver">The type resolver.</param>
+        /// <returns>The enum default value.</returns>
+        protected override string GetEnumDefaultValue(JsonSchema schema, JsonSchema actualSchema, string typeNameHint, TypeResolverBase typeResolver)
+        {
+            if (schema?.Default is not null &&
+                typeResolver is TypeScriptTypeResolver { Settings.EnumStyle: TypeScriptEnumStyle.StringLiteral })
+            {
+                return GetDefaultAsStringLiteral(schema);
+            }
+
+            return base.GetEnumDefaultValue(schema, actualSchema, typeNameHint, typeResolver);
+        }
+
         /// <summary>Gets the default value code.</summary>
         /// <param name="schema">The schema.</param>
         /// <param name="allowsNull">Specifies whether the default value assignment also allows null.</param>


### PR DESCRIPTION
This fixes https://github.com/RicoSuter/NJsonSchema/issues/1618

I used the newer object pattern-matching syntax.  If this is a concern, I can do the check manually.