### PR TITLE
Allign JsonPropertyRequiredCode with IsNullable

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
@@ -83,7 +83,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
             {
                 if (_settings.RequiredPropertiesMustBeDefined && _property.IsRequired)
                 {
-                    if (!_property.IsNullable(_settings.SchemaType))
+                    if (!IsNullable)
                     {
                         return "Newtonsoft.Json.Required.Always";
                     }
@@ -94,7 +94,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                 }
                 else
                 {
-                    if (!_property.IsNullable(_settings.SchemaType))
+                    if (!IsNullable)
                     {
                         return "Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore";
                     }


### PR DESCRIPTION
 IsNullable implemented in 87bd7a4e3a552c5fab62564de598cb3ae6053d44

Currently the JsonPropertyRequiredCode does not reflect the previous fix, resulting in generating nullable properties with Required.DisallowNull and NullValueHandling.Ingore for optional properties.