### PR TITLE
Optimize type resolving

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,20 +33,21 @@ jobs:
     name: windows-latest
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: Cache .nuke/temp, ~/.nuget/packages
-        uses: actions/cache@v2
+      - uses: actions/checkout@v3
+      - name: 'Cache: .nuke/temp, ~/.nuget/packages'
+        uses: actions/cache@v3
         with:
           path: |
             .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('global.json', 'src/**/*.csproj', 'src/**/package.json') }}
-      - name: Run './build.cmd Compile Test Pack Publish'
+      - name: 'Run: Compile, Test, Pack, Publish'
         run: ./build.cmd Compile Test Pack Publish
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
           MYGET_API_KEY: ${{ secrets.MYGET_API_KEY }}
-      - uses: actions/upload-artifact@v1
+      - name: 'Publish: artifacts'
+        uses: actions/upload-artifact@v3
         with:
           name: artifacts
           path: artifacts

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,13 +30,13 @@ jobs:
     name: windows-latest
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: Cache .nuke/temp, ~/.nuget/packages
-        uses: actions/cache@v2
+      - uses: actions/checkout@v3
+      - name: 'Cache: .nuke/temp, ~/.nuget/packages'
+        uses: actions/cache@v3
         with:
           path: |
             .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('global.json', 'src/**/*.csproj', 'src/**/package.json') }}
-      - name: Run './build.cmd Compile Test Pack'
+      - name: 'Run: Compile, Test, Pack'
         run: ./build.cmd Compile Test Pack

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Build Schema",
   "$ref": "#/definitions/build",
+  "title": "Build Schema",
   "definitions": {
     "build": {
       "type": "object",
@@ -29,6 +29,7 @@
             "AppVeyor",
             "AzurePipelines",
             "Bamboo",
+            "Bitbucket",
             "Bitrise",
             "GitHubActions",
             "GitLab",
@@ -44,7 +45,7 @@
         },
         "MyGetApiKey": {
           "type": "string",
-          "default": "Secrets must be entered via 'nuke :secret [profile]'"
+          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
         },
         "NoLogo": {
           "type": "boolean",
@@ -52,7 +53,7 @@
         },
         "NuGetApiKey": {
           "type": "string",
-          "default": "Secrets must be entered via 'nuke :secret [profile]'"
+          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
         },
         "Partition": {
           "type": "string",

--- a/build.ps1
+++ b/build.ps1
@@ -18,7 +18,7 @@ $TempDirectory = "$PSScriptRoot\\.nuke\temp"
 
 $DotNetGlobalFile = "$PSScriptRoot\\global.json"
 $DotNetInstallUrl = "https://dot.net/v1/dotnet-install.ps1"
-$DotNetChannel = "Current"
+$DotNetChannel = "STS"
 
 $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1
 $env:DOTNET_CLI_TELEMETRY_OPTOUT = 1
@@ -63,7 +63,12 @@ else {
     $env:DOTNET_EXE = "$DotNetDirectory\dotnet.exe"
 }
 
-Write-Output "Microsoft (R) .NET Core SDK version $(& $env:DOTNET_EXE --version)"
+Write-Output "Microsoft (R) .NET SDK version $(& $env:DOTNET_EXE --version)"
+
+if (Test-Path env:NUKE_ENTERPRISE_TOKEN) {
+    & $env:DOTNET_EXE nuget remove source "nuke-enterprise" > $null
+    & $env:DOTNET_EXE nuget add source "https://f.feedz.io/nuke/enterprise/nuget" --name "nuke-enterprise" --username "PAT" --password $env:NUKE_ENTERPRISE_TOKEN > $null
+}
 
 ExecSafe { & $env:DOTNET_EXE build $BuildProjectFile /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet }
 ExecSafe { & $env:DOTNET_EXE run --project $BuildProjectFile --no-build -- $BuildArguments }

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ TEMP_DIRECTORY="$SCRIPT_DIR//.nuke/temp"
 
 DOTNET_GLOBAL_FILE="$SCRIPT_DIR//global.json"
 DOTNET_INSTALL_URL="https://dot.net/v1/dotnet-install.sh"
-DOTNET_CHANNEL="Current"
+DOTNET_CHANNEL="STS"
 
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
@@ -56,7 +56,12 @@ else
     export DOTNET_EXE="$DOTNET_DIRECTORY/dotnet"
 fi
 
-echo "Microsoft (R) .NET Core SDK version $("$DOTNET_EXE" --version)"
+echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"
+
+if [[ ! -z ${NUKE_ENTERPRISE_TOKEN+x} && "NUKE_ENTERPRISE_TOKEN" != "" ]]; then
+    "$DOTNET_EXE" nuget remove source "nuke-enterprise" &>/dev/null || true
+    "$DOTNET_EXE" nuget add source "https://f.feedz.io/nuke/enterprise/nuget" --name "nuke-enterprise" --username "PAT" --password "$NUKE_ENTERPRISE_TOKEN" --store-password-in-clear-text &>/dev/null || true
+fi
 
 "$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
 "$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="7.0.2" />
+    <PackageReference Include="Nuke.Common" Version="7.0.6" />
     <PackageDownload Include="NuGet.CommandLine" Version="[5.11.0]" />
   </ItemGroup>
 

--- a/src/NJsonSchema.Benchmark/CSharpTypeResolverBenchmark.cs
+++ b/src/NJsonSchema.Benchmark/CSharpTypeResolverBenchmark.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using NJsonSchema.CodeGeneration.CSharp;
+
+namespace NJsonSchema.Benchmark;
+
+[MemoryDiagnoser]
+public class CSharpTypeResolverBenchmark
+{
+    private Dictionary<string, JsonSchema> _definitions;
+    private CSharpGeneratorSettings _settings;
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        var json = await JsonSchemaBenchmark.ReadJson();
+        var schema = await JsonSchema.FromJsonAsync(json);
+        _definitions = schema.Definitions.ToDictionary(p => p.Key, p => p.Value);
+        _settings = new CSharpGeneratorSettings();
+    }
+
+    [Benchmark]
+    public void RegisterSchemaDefinitions()
+    {
+        var resolver = new CSharpTypeResolver(_settings, exceptionSchema: null);
+        resolver.RegisterSchemaDefinitions(_definitions);
+    }
+}

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/NJsonSchema.CodeGeneration.CSharp.Tests.csproj
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/NJsonSchema.CodeGeneration.CSharp.Tests.csproj
@@ -1,29 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  
+
   <PropertyGroup>
-  <TargetFramework>net6.0</TargetFramework>
-  <IsPackable>false</IsPackable>
-  <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  <NoWarn>$(NoWarn),1587,1998,1591,618,SYSLIB0012</NoWarn>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn),1587,1998,1591,618,SYSLIB0012</NoWarn>
   </PropertyGroup>
-  
+
   <ItemGroup>
-  <Content Include="References\*.json" CopyToOutputDirectory="Always" />
+    <Content Include="References\*.json" CopyToOutputDirectory="Always" />
   </ItemGroup>
-  
+
   <ItemGroup>
-  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-  <PackageReference Include="xunit" Version="2.4.1" />
-  <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" PrivateAssets="all" />
-  <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" Condition="'$(TargetFramework)' == 'net6.0'" />
-  <PackageReference Condition="'$(TargetFramework)' == 'net6.0'" Include="System.ComponentModel.Annotations" Version="4.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Condition="'$(TargetFramework)' == 'net6.0'" Include="System.ComponentModel.Annotations" Version="4.4.0" />
   </ItemGroup>
-  
+
   <ItemGroup>
-  <ProjectReference Include="..\NJsonSchema.CodeGeneration.CSharp\NJsonSchema.CodeGeneration.CSharp.csproj" />
-  <ProjectReference Include="..\NJsonSchema.CodeGeneration\NJsonSchema.CodeGeneration.csproj" />
-  <ProjectReference Include="..\NJsonSchema.NewtonsoftJson\NJsonSchema.NewtonsoftJson.csproj" />
-  <ProjectReference Include="..\NJsonSchema\NJsonSchema.csproj" />
+    <ProjectReference Include="..\NJsonSchema.CodeGeneration.CSharp\NJsonSchema.CodeGeneration.CSharp.csproj" />
+    <ProjectReference Include="..\NJsonSchema.NewtonsoftJson\NJsonSchema.NewtonsoftJson.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
@@ -270,7 +270,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
             {
                 var itemTypeNameHint = (schema as JsonSchemaProperty)?.Name;
                 var itemType = Resolve(schema.Item, schema.Item.IsNullable(Settings.SchemaType), itemTypeNameHint);
-                return string.Format(Settings.ArrayType + "<{0}>", itemType);
+                return $"{Settings.ArrayType}<{itemType}>";
             }
 
             if (schema.Items != null && schema.Items.Count > 0)
@@ -279,7 +279,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
                     .Select(i => Resolve(i, i.IsNullable(Settings.SchemaType), null))
                     .ToArray();
 
-                return string.Format("System.Tuple<" + string.Join(", ", tupleTypes) + ">");
+                return $"System.Tuple<{string.Join(", ", tupleTypes)}>";
             }
 
             return Settings.ArrayType + "<object>";
@@ -289,7 +289,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
         {
             var valueType = ResolveDictionaryValueType(schema, "object");
             var keyType = ResolveDictionaryKeyType(schema, "string");
-            return string.Format(Settings.DictionaryType + "<{0}, {1}>", keyType, valueType);
+            return $"{Settings.DictionaryType}<{keyType}, {valueType}>";
         }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.CSharp/NJsonSchema.CodeGeneration.CSharp.csproj
+++ b/src/NJsonSchema.CodeGeneration.CSharp/NJsonSchema.CodeGeneration.CSharp.csproj
@@ -17,12 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\NJsonSchema.CodeGeneration\NJsonSchema.CodeGeneration.csproj" />
-    <ProjectReference Include="..\NJsonSchema\NJsonSchema.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NJsonSchema.CodeGeneration.Tests/NJsonSchema.CodeGeneration.Tests.csproj
+++ b/src/NJsonSchema.CodeGeneration.Tests/NJsonSchema.CodeGeneration.Tests.csproj
@@ -25,9 +25,7 @@
   <ItemGroup>
     <ProjectReference Include="..\NJsonSchema.CodeGeneration.CSharp\NJsonSchema.CodeGeneration.CSharp.csproj" />
     <ProjectReference Include="..\NJsonSchema.CodeGeneration.TypeScript\NJsonSchema.CodeGeneration.TypeScript.csproj" />
-    <ProjectReference Include="..\NJsonSchema.CodeGeneration\NJsonSchema.CodeGeneration.csproj" />
     <ProjectReference Include="..\NJsonSchema.NewtonsoftJson\NJsonSchema.NewtonsoftJson.csproj" />
-    <ProjectReference Include="..\NJsonSchema\NJsonSchema.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/NJsonSchema.CodeGeneration.TypeScript.Tests.csproj
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/NJsonSchema.CodeGeneration.TypeScript.Tests.csproj
@@ -22,9 +22,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\NJsonSchema.CodeGeneration.TypeScript\NJsonSchema.CodeGeneration.TypeScript.csproj" />
-    <ProjectReference Include="..\NJsonSchema.CodeGeneration\NJsonSchema.CodeGeneration.csproj" />
     <ProjectReference Include="..\NJsonSchema.NewtonsoftJson\NJsonSchema.NewtonsoftJson.csproj" />
-    <ProjectReference Include="..\NJsonSchema\NJsonSchema.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/NJsonSchema.CodeGeneration.TypeScript/NJsonSchema.CodeGeneration.TypeScript.csproj
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/NJsonSchema.CodeGeneration.TypeScript.csproj
@@ -23,12 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\NJsonSchema.CodeGeneration\NJsonSchema.CodeGeneration.csproj" />
-    <ProjectReference Include="..\NJsonSchema\NJsonSchema.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
@@ -314,15 +314,15 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                     // is TypeUnion
                     if (itemTypes.Count > 1)
                     {
-                        itemType = string.Format("({0})", itemType);
+                        itemType = $"({itemType})";
                     }
 
-                    return string.Format("{0}[]", itemType);
+                    return $"{itemType}[]";
                 }
                 else
                 {
                     var itemType = prefix + Resolve(schema.Item, true, typeNameHint);
-                    return string.Format("{0}[]", GetNullableItemType(schema, itemType)); // TODO: Make typeNameHint singular if possible
+                    return $"{GetNullableItemType(schema, itemType)}[]"; // TODO: Make typeNameHint singular if possible
                 }
             }
 
@@ -332,7 +332,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                     .Select(s => GetNullableItemType(s, Resolve(s, false, null)))
                     .ToArray();
 
-                return string.Format("[" + string.Join(", ", tupleTypes) + "]");
+                return $"[{string.Join(", ", tupleTypes)}]";
             }
 
             return "any[]";
@@ -342,7 +342,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
         {
             if (Settings.SupportsStrictNullChecks && schema.Item.IsNullable(Settings.SchemaType))
             {
-                return string.Format("({0} | {1})", itemType, Settings.NullValue.ToString().ToLowerInvariant());
+                return $"({itemType} | {Settings.NullValue.ToString().ToLowerInvariant()})";
             }
 
             return itemType;

--- a/src/NJsonSchema.CodeGeneration/NJsonSchema.CodeGeneration.csproj
+++ b/src/NJsonSchema.CodeGeneration/NJsonSchema.CodeGeneration.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="Fluid.Core" Version="2.4.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NJsonSchema.NewtonsoftJson.Tests/NJsonSchema.NewtonsoftJson.Tests.csproj
+++ b/src/NJsonSchema.NewtonsoftJson.Tests/NJsonSchema.NewtonsoftJson.Tests.csproj
@@ -26,7 +26,6 @@
 
     <ItemGroup>
         <ProjectReference Include="..\NJsonSchema.NewtonsoftJson\NJsonSchema.NewtonsoftJson.csproj" />
-        <ProjectReference Include="..\NJsonSchema\NJsonSchema.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/NJsonSchema.NewtonsoftJson/NJsonSchema.NewtonsoftJson.csproj
+++ b/src/NJsonSchema.NewtonsoftJson/NJsonSchema.NewtonsoftJson.csproj
@@ -9,21 +9,6 @@
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-        <PackageReference Include="Microsoft.Bcl.Async">
-            <Version>1.0.168</Version>
-        </PackageReference>
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-        <Reference Include="Microsoft.CSharp" />
-        <Reference Include="System" />
-        <Reference Include="System.Net" />
-        <Reference Include="System.Runtime.Serialization" />
-        <Reference Include="System.Xml" />
-        <Reference Include="System.Xml.Linq" />
-    </ItemGroup>
-
     <ItemGroup>
         <ProjectReference Include="..\NJsonSchema\NJsonSchema.csproj" />
     </ItemGroup>

--- a/src/NJsonSchema.Yaml.Tests/NJsonSchema.Yaml.Tests.csproj
+++ b/src/NJsonSchema.Yaml.Tests/NJsonSchema.Yaml.Tests.csproj
@@ -16,7 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\NJsonSchema\NJsonSchema.csproj" />
     <ProjectReference Include="..\NJsonSchema.Yaml\NJsonSchema.Yaml.csproj" />
   </ItemGroup>
 

--- a/src/NJsonSchema.Yaml/NJsonSchema.Yaml.csproj
+++ b/src/NJsonSchema.Yaml/NJsonSchema.Yaml.csproj
@@ -9,7 +9,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.4.1" />
     <PackageReference Include="YamlDotNet" Version="13.2.0" />
   </ItemGroup>
 

--- a/src/NJsonSchema.sln
+++ b/src/NJsonSchema.sln
@@ -32,7 +32,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "00 Build", "00 Build", "{863B2D88-A0BD-4466-8583-AAD0B8D3F182}"
 	ProjectSection(SolutionItems) = preProject
 		Directory.Build.props = Directory.Build.props
-		..\global.json = ..\global.json
 		..\README.md = ..\README.md
 	EndProjectSection
 EndProject
@@ -242,22 +241,6 @@ Global
 		{990EF464-C967-4E08-8C3D-0568A47B6D2A}.Release|x64.Build.0 = Release|Any CPU
 		{990EF464-C967-4E08-8C3D-0568A47B6D2A}.Release|x86.ActiveCfg = Release|Any CPU
 		{990EF464-C967-4E08-8C3D-0568A47B6D2A}.Release|x86.Build.0 = Release|Any CPU
-		{8E4E5A64-B5B7-4718-A92F-CB6B08512264}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{8E4E5A64-B5B7-4718-A92F-CB6B08512264}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{8E4E5A64-B5B7-4718-A92F-CB6B08512264}.Debug|ARM.ActiveCfg = Debug|Any CPU
-		{8E4E5A64-B5B7-4718-A92F-CB6B08512264}.Debug|ARM.Build.0 = Debug|Any CPU
-		{8E4E5A64-B5B7-4718-A92F-CB6B08512264}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{8E4E5A64-B5B7-4718-A92F-CB6B08512264}.Debug|x64.Build.0 = Debug|Any CPU
-		{8E4E5A64-B5B7-4718-A92F-CB6B08512264}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{8E4E5A64-B5B7-4718-A92F-CB6B08512264}.Debug|x86.Build.0 = Debug|Any CPU
-		{8E4E5A64-B5B7-4718-A92F-CB6B08512264}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{8E4E5A64-B5B7-4718-A92F-CB6B08512264}.Release|Any CPU.Build.0 = Release|Any CPU
-		{8E4E5A64-B5B7-4718-A92F-CB6B08512264}.Release|ARM.ActiveCfg = Release|Any CPU
-		{8E4E5A64-B5B7-4718-A92F-CB6B08512264}.Release|ARM.Build.0 = Release|Any CPU
-		{8E4E5A64-B5B7-4718-A92F-CB6B08512264}.Release|x64.ActiveCfg = Release|Any CPU
-		{8E4E5A64-B5B7-4718-A92F-CB6B08512264}.Release|x64.Build.0 = Release|Any CPU
-		{8E4E5A64-B5B7-4718-A92F-CB6B08512264}.Release|x86.ActiveCfg = Release|Any CPU
-		{8E4E5A64-B5B7-4718-A92F-CB6B08512264}.Release|x86.Build.0 = Release|Any CPU
 		{A9C2A9CD-44F6-4A21-9D72-00CF5BE0A36F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A9C2A9CD-44F6-4A21-9D72-00CF5BE0A36F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A9C2A9CD-44F6-4A21-9D72-00CF5BE0A36F}.Debug|ARM.ActiveCfg = Debug|Any CPU

--- a/src/NJsonSchema/DefaultTypeNameGenerator.cs
+++ b/src/NJsonSchema/DefaultTypeNameGenerator.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -16,19 +17,24 @@ namespace NJsonSchema
     /// <summary>Converts the last part of the full type name to upper case.</summary>
     public class DefaultTypeNameGenerator : ITypeNameGenerator
     {
+        private static readonly char[] TypeNameHintCleanupChars = { '[', ']', '<', '>', ',', ' ' };
+
+        private readonly Dictionary<string, string> _typeNameMappings = new();
+        private string[] _reservedTypeNames = { "object" };
+
         // TODO: Expose as options to UI and cmd line?
 
         /// <summary>Gets or sets the reserved names.</summary>
-        public IEnumerable<string> ReservedTypeNames { get; set; } = new List<string> { "object" };
+        public IEnumerable<string> ReservedTypeNames
+        {
+            get => _reservedTypeNames;
+            set => _reservedTypeNames = value.ToArray();
+        }
 
         /// <summary>Gets the name mappings.</summary>
-        public IDictionary<string, string> TypeNameMappings { get; } = new Dictionary<string, string>();
+        public IDictionary<string, string> TypeNameMappings => _typeNameMappings;
 
-        /// <summary>Generates the type name for the given schema respecting the reserved type names.</summary>
-        /// <param name="schema">The schema.</param>
-        /// <param name="typeNameHint">The type name hint.</param>
-        /// <param name="reservedTypeNames">The reserved type names.</param>
-        /// <returns>The type name.</returns>
+        /// <inheritdoc />
         public virtual string Generate(JsonSchema schema, string typeNameHint, IEnumerable<string> reservedTypeNames)
         {
             if (string.IsNullOrEmpty(typeNameHint) && !string.IsNullOrEmpty(schema.DocumentPath))
@@ -36,16 +42,24 @@ namespace NJsonSchema
                 typeNameHint = schema.DocumentPath.Replace("\\", "/").Split('/').Last();
             }
 
-            typeNameHint = (typeNameHint ?? "")
-                .Replace("[", " Of ")
-                .Replace("]", " ")
-                .Replace("<", " Of ")
-                .Replace(">", " ")
-                .Replace(",", " And ")
-                .Replace("  ", " ");
+            typeNameHint ??= "";
 
-            var parts = typeNameHint.Split(' ');
-            typeNameHint = string.Join(string.Empty, parts.Select(p => Generate(schema, p)));
+            // check with one pass before doing iterations
+            var requiresCleanup = !string.IsNullOrEmpty(typeNameHint) && typeNameHint.IndexOfAny(TypeNameHintCleanupChars) != -1;
+
+            if (requiresCleanup)
+            {
+                typeNameHint = typeNameHint
+                    .Replace("[", " Of ")
+                    .Replace("]", " ")
+                    .Replace("<", " Of ")
+                    .Replace(">", " ")
+                    .Replace(",", " And ")
+                    .Replace("  ", " ");
+
+                var parts = typeNameHint.Split(' ');
+                typeNameHint = string.Join(string.Empty, parts.Select(p => Generate(schema, p)));
+            }
 
             var typeName = Generate(schema, typeNameHint);
             if (string.IsNullOrEmpty(typeName) || reservedTypeNames.Contains(typeName))
@@ -67,12 +81,8 @@ namespace NJsonSchema
                 typeNameHint = schema.Title;
             }
 
-            var lastSegment = typeNameHint;
-            var lastDotIndex = typeNameHint?.LastIndexOf('.') ?? -1;
-            if (lastDotIndex > -1)
-            {
-                lastSegment = typeNameHint.Substring(lastDotIndex + 1);
-            }
+            var lastSegment = GetLastSegment(typeNameHint);
+
             return ConversionUtilities.ConvertToUpperCamelCase(lastSegment ?? "Anonymous", true);
         }
 
@@ -80,14 +90,14 @@ namespace NJsonSchema
         {
             if (!string.IsNullOrEmpty(typeNameHint))
             {
-                if (TypeNameMappings.ContainsKey(typeNameHint))
+                if (_typeNameMappings.TryGetValue(typeNameHint, out var mapping))
                 {
-                    typeNameHint = TypeNameMappings[typeNameHint];
+                    typeNameHint = mapping;
                 }
 
-                typeNameHint = typeNameHint.Split('.').Last();
+                typeNameHint = GetLastSegment(typeNameHint);
 
-                if (!reservedTypeNames.Contains(typeNameHint) && !ReservedTypeNames.Contains(typeNameHint))
+                if (!reservedTypeNames.Contains(typeNameHint) && Array.IndexOf(_reservedTypeNames, typeNameHint) == -1)
                 {
                     return typeNameHint;
                 }
@@ -104,6 +114,21 @@ namespace NJsonSchema
             return GenerateAnonymousTypeName("Anonymous", reservedTypeNames);
         }
 
+        private static string GetLastSegment(string input)
+        {
+            var lastSegment = input;
+            if (input != null)
+            {
+                var index = input.LastIndexOf('.');
+                if (index != -1)
+                {
+                    lastSegment = input.Substring(index + 1);
+                }
+            }
+
+            return lastSegment;
+        }
+
         /// <summary>
         /// Replaces all characters that are not normals letters, numbers or underscore, with an underscore.
         /// Will prepend an underscore if the first characters is a number.
@@ -113,7 +138,7 @@ namespace NJsonSchema
         private static string RemoveIllegalCharacters(string typeName)
         {
             // TODO: Find a way to support unicode characters up to 3.0
-           
+
             // first check if all are valid and we skip altogether
             var invalid = false;
             for (var i = 0; i < typeName.Length; i++)
@@ -136,7 +161,7 @@ namespace NJsonSchema
             {
                 return typeName;
             }
-            
+
             return DoRemoveIllegalCharacters(typeName);
         }
 
@@ -171,10 +196,10 @@ namespace NJsonSchema
             var legalTypeNameString = regexMoreThanOneUnderscore.Replace(legalTypeName.ToString(), "_");
             return legalTypeNameString.TrimEnd('_');
         }
-        
+
         private static bool IsEnglishLetterOrUnderScore(char c)
         {
-            return (c>='A' && c<='Z') || (c>='a' && c<='z') || c == '_';
+            return c is >= 'A' and <= 'Z' or >= 'a' and <= 'z' or '_';
         }
     }
 }

--- a/src/NJsonSchema/NJsonSchema.csproj
+++ b/src/NJsonSchema/NJsonSchema.csproj
@@ -17,15 +17,6 @@
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System" />
-    <Reference Include="System.Net" />
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
-  </ItemGroup>
-
   <ItemGroup>
     <None Include="NuGetIcon.png" Pack="true" PackagePath="\" />
   </ItemGroup>


### PR DESCRIPTION
* reuse same `HashSet` for `reservedTypeNames` instead re-creating on every cache miss
* cleanup csprojs
* let NUKE regenerate GH actions definitions
* remove build configurations for `_build` project in solution file (prevents local command line usage)
* use string interpolation for better optimizations (NET 6+ has optimizations)

The test case has only 3 types and shows the difference quite nicely, real world usage can have hundreds of items, if not thousands.

## NJsonSchema.Benchmark.CSharpTypeResolverBenchmark

| **Diff**|Method|Mean|Error|Allocated|
|------- |-------|-------:|-------|-------:|
| Old |RegisterSchemaDefinitions|1.119 μs|0.0162 μs|1.66 KB|
| **New** |	| **645.8 ns (-44%)** | **5.40 ns** | **888 B (-48%)** |
