### PR TITLE
Cleanup pre-processor directives

### DIFF
--- a/src/NJsonSchema.CodeGeneration.Tests/InheritanceSerializationTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/InheritanceSerializationTests.cs
@@ -283,7 +283,7 @@ namespace NJsonSchema.CodeGeneration.Tests
             Assert.Contains("this._discriminator = \"Dog\"", code);
         }
 
-#if NETCORE
+#if !NETFRAMEWORK
         [Fact]
 #else
         [Fact(Skip = "Dynamic compilation doesn't work for NET 4.6.1")]

--- a/src/NJsonSchema.Tests/Generation/ArrayGenerationTests.cs
+++ b/src/NJsonSchema.Tests/Generation/ArrayGenerationTests.cs
@@ -82,7 +82,7 @@ namespace NJsonSchema.Tests.Generation
             Assert.NotNull(schema.Definitions["SomeModelCollectionResponse"].Item);
         }
 
-#if NET5_0
+#if !NETFRAMEWORK
 
         public class ClassWithAsyncEnumerable
         {

--- a/src/NJsonSchema.Tests/Generation/SystemTextJson/SystemTextJsonInheritanceTests.cs
+++ b/src/NJsonSchema.Tests/Generation/SystemTextJson/SystemTextJsonInheritanceTests.cs
@@ -45,7 +45,7 @@ namespace NJsonSchema.Tests.Generation.SystemTextJson
   },", data);
         }
 
-#if !NET462
+#if !NETFRAMEWORK
 
         public class Apple2 : Fruit2
         {

--- a/src/NJsonSchema.Tests/Generation/SystemTextJson/SystemTextJsonOptionsConverterTests.cs
+++ b/src/NJsonSchema.Tests/Generation/SystemTextJson/SystemTextJsonOptionsConverterTests.cs
@@ -1,11 +1,11 @@
-﻿#if !net462
+﻿#if !NETFRAMEWORK
 
-using System.Linq;
-using Newtonsoft.Json.Converters;
-using NJsonSchema.Generation;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+
+using NJsonSchema.Generation;
+
 using Xunit;
 
 namespace NJsonSchema.Tests.Generation.SystemTextJson

--- a/src/NJsonSchema/JsonPathUtilities.cs
+++ b/src/NJsonSchema/JsonPathUtilities.cs
@@ -82,10 +82,8 @@ namespace NJsonSchema
 
             var type = obj.GetType();
             if (type == typeof(string)
-#if !NETSTANDARD1_0
                 || type.IsPrimitive
                 || type.IsEnum
-#endif
                 || type == typeof(JValue)
                 || checkedObjects.Contains(obj)
             )

--- a/src/NJsonSchema/JsonSchema.cs
+++ b/src/NJsonSchema/JsonSchema.cs
@@ -106,13 +106,8 @@ namespace NJsonSchema
         /// <exception cref="NotSupportedException">The System.IO.File API is not available on this platform.</exception>
         public static Task<JsonSchema> FromFileAsync(string filePath, Func<JsonSchema, JsonReferenceResolver> referenceResolverFactory, CancellationToken cancellationToken = default)
         {
-#if !NETSTANDARD1_0
             using var stream = File.OpenRead(filePath);
             return FromJsonAsync(stream, filePath, referenceResolverFactory, cancellationToken);
-#else
-            var json = DynamicApis.FileReadAllText(filePath);
-            return FromJsonAsync(json, filePath, referenceResolverFactory, cancellationToken);
-#endif
         }
 
         /// <summary>Loads a JSON Schema from a given URL (only available in .NET 4.x).</summary>


### PR DESCRIPTION
Remove obsolete and use `NETFRAMEWORK` as divider between logic.