### PR TITLE
Add ability to customize which JsonProperties get ignored

### DIFF
--- a/src/NJsonSchema.NewtonsoftJson/Generation/NewtonsoftJsonReflectionService.cs
+++ b/src/NJsonSchema.NewtonsoftJson/Generation/NewtonsoftJsonReflectionService.cs
@@ -158,7 +158,7 @@ namespace NJsonSchema.NewtonsoftJson.Generation
         private void LoadPropertyOrField(JsonProperty jsonProperty, ContextualAccessorInfo accessorInfo, Type parentType, JsonSchema parentSchema, NewtonsoftJsonSchemaGeneratorSettings settings, JsonSchemaGenerator schemaGenerator, JsonSchemaResolver schemaResolver)
         {
             var propertyTypeDescription = ((IReflectionService)this).GetDescription(accessorInfo.AccessorType, settings);
-            if (jsonProperty.Ignored == false && schemaGenerator.IsPropertyIgnoredBySettings(accessorInfo) == false)
+            if (!settings.IgnoreProperty(jsonProperty) && !schemaGenerator.IsPropertyIgnoredBySettings(accessorInfo))
             {
                 var propertyName = GetPropertyName(jsonProperty, accessorInfo, settings);
                 var propertyAlreadyExists = parentSchema.Properties.ContainsKey(propertyName);

--- a/src/NJsonSchema.NewtonsoftJson/Generation/NewtonsoftJsonSchemaGeneratorSettings.cs
+++ b/src/NJsonSchema.NewtonsoftJson/Generation/NewtonsoftJsonSchemaGeneratorSettings.cs
@@ -29,6 +29,9 @@ namespace NJsonSchema.NewtonsoftJson.Generation
             SerializerSettings = new JsonSerializerSettings();
         }
 
+        /// <summary> Returns whether to ignore a <see cref="JsonProperty"/>. By default this is simply the "Ignored" property of JsonProperty</summary>
+        public Func<JsonProperty, bool> IgnoreProperty = prop => prop.Ignored;
+
         /// <summary>Gets or sets the Newtonsoft JSON serializer settings.</summary>
         [JsonIgnore]
         public JsonSerializerSettings SerializerSettings

--- a/src/NJsonSchema.Tests/Generation/IgnoredPropertyTests.cs
+++ b/src/NJsonSchema.Tests/Generation/IgnoredPropertyTests.cs
@@ -18,6 +18,15 @@ namespace NJsonSchema.Tests.Generation
             public string IgnoreMe;
         }
 
+        [Fact]
+        public async Task When_IgnoreJsonIgnore_is_specified_marked_fields_are_included()
+        {
+            var json = NewtonsoftJsonSchemaGenerator.FromType<Mno>(new NewtonsoftJsonSchemaGeneratorSettings
+            {
+                IgnoreProperty = prop => false
+            }).ToJson();
+            Assert.Contains("IgnoreMe", json);
+        }
 
         [Fact]
         public async Task When_field_has_JsonIgnoreAttribute_then_it_is_ignored()


### PR DESCRIPTION
I have a model where when serialized to JSON some properties should be ignored, but they should still be included in the JSON schema - I didn't see a way to do that in the library as-is. I put this version on NuGet here: https://www.nuget.org/packages/NJsonSchema-Ignore/

