### PR TITLE
Move source link to GlobalPackageReference

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -25,8 +25,4 @@
       <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
-  </ItemGroup>
-
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,7 +9,6 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Namotion.Reflection" Version="3.1.0" />
     <PackageVersion Include="NBench" Version="2.0.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
@@ -22,5 +21,10 @@
     <PackageVersion Include="xunit" Version="2.5.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3" />
     <PackageVersion Include="YamlDotNet" Version="13.7.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <GlobalPackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
+    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <GlobalPackageReference Include="PolySharp" Version="1.13.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* add shims via Polysharp
* add GitHubActionsTestLogger for better error reporting

`GlobalPackageReference`s are just private assets so they don't reflect to package dependencies on NuGet.
