### PR TITLE
Increased Json MaxDepth to 128

### DIFF
--- a/src/NJsonSchema/Infrastructure/JsonSchemaSerialization.cs
+++ b/src/NJsonSchema/Infrastructure/JsonSchemaSerialization.cs
@@ -214,7 +214,8 @@ namespace NJsonSchema.Infrastructure
                 MetadataPropertyHandling = MetadataPropertyHandling.Ignore,
                 ConstructorHandling = ConstructorHandling.Default,
                 ReferenceLoopHandling = ReferenceLoopHandling.Serialize,
-                PreserveReferencesHandling = PreserveReferencesHandling.None
+                PreserveReferencesHandling = PreserveReferencesHandling.None,
+                MaxDepth = 128
             };
         }
     }


### PR DESCRIPTION
Using NSwag on schemas with large depths causes an exception to be thrown due to the MaxDepth default setting of 64. I am not aware of any way of customizing the Json settings for parsing the schema in a project when using NSwag, as it invokes the precompiled DLL directly. More context here: https://github.com/RicoSuter/NSwag/issues/4394. #1565 is also related, but can be solved by modifying the settings in the project.

I'm not sure if it is the best approach to just change the default setting in this project to solve it. There doesn't seem to be a way of passing in a `JsonSerializerSettings` object or func to modify it in `FromJsonAsync` (called from [here](https://github.com/RicoSuter/NSwag/blob/9175311f5427ccc899098971c8a4dd2353a1400a/src/NSwag.Core/OpenApiDocument.cs#L204C73-L204C73) in NSwag). If there was such an option, the default wouldn't have to be modified here but it could be changed in NSwag where the issue is relevant.