### PR TITLE
Use generated property name for constructor parameters

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/GeneralGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/GeneralGeneratorTests.cs
@@ -155,6 +155,33 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
         }
 
         [Fact]
+        public async Task When_property_name_is_created_by_custom_fun_then_parameter_name_is_correct_for_record()
+        {
+            //// Arrange
+            var schema = NewtonsoftJsonSchemaGenerator.FromType<Address>();
+            var schemaData = schema.ToJson();
+            var settings = new CSharpGeneratorSettings 
+            {
+                ClassStyle = CSharpClassStyle.Record,
+                PropertyNameGenerator = new CustomPropertyNameGenerator(),
+            };
+            var generator = new CSharpGenerator(schema, settings);
+
+            //// Act
+            var output = generator.GenerateFile("Address");
+
+            //// Assert
+            Assert.DoesNotContain(@"public string Street { get; }", output);
+            Assert.Contains(@"public string MyCustomStreet { get; }", output);
+            Assert.Contains(@"this.MyCustomStreet = @myCustomStreet;", output);
+
+            Assert.DoesNotContain(@"public Address(string @city, string @street)", output);
+            Assert.Contains(@"public Address(string @myCustomCity, string @myCustomStreet)", output);
+
+            AssertCompile(output);
+        }
+
+        [Fact]
         public async Task When_schema_contains_ref_to_definition_that_refs_another_definition_then_result_should_contain_correct_target_ref_type()
         {
             //// Arrange
@@ -1821,7 +1848,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             var data = schema.ToJson();
             var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings
             {
-                ClassStyle = CSharpClassStyle.Record
+                ClassStyle = CSharpClassStyle.Record,
             });
 
             //// Act

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.Constructor.Record.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.Constructor.Record.liquid
@@ -13,13 +13,13 @@
 {%- else %}
 [Newtonsoft.Json.JsonConstructor]
 {%- endif %}
-{% if IsAbstract %}protected{% else %}public{% endif %} {{ClassName}}({% for property in sortedProperties %}{%- if skipComma %}{%- assign skipComma = false %}{% else %}, {% endif %}{{ property.Type }} @{{ property.Name | lowercamelcase }}{% endfor %})
+{% if IsAbstract %}protected{% else %}public{% endif %} {{ClassName}}({% for property in sortedProperties %}{%- if skipComma %}{%- assign skipComma = false %}{% else %}, {% endif %}{{ property.Type }} @{{ property.PropertyName | lowercamelcase }}{% endfor %})
 {%- assign skipComma = true %}
 {%- if HasInheritance %}
-    : base({%- for property in sortedParentProperties %}{%- if skipComma %}{%- assign skipComma = false %}{% else %}, {% endif %}{{ property.Name | lowercamelcase }}{%- endfor %})
+    : base({%- for property in sortedParentProperties %}{%- if skipComma %}{%- assign skipComma = false %}{% else %}, {% endif %}{{ property.PropertyName | lowercamelcase }}{%- endfor %})
 {%- endif %}
 {
 {%- for property in Properties %}
-    this.{{property.PropertyName}} = @{{property.Name | lowercamelcase}};
+    this.{{property.PropertyName}} = @{{property.PropertyName | lowercamelcase}};
 {%- endfor %}
 }


### PR DESCRIPTION
Makes the naming of the constructor parameters consistent with the property names of the type when using the ParameterNameGenerator with records.