### PR TITLE
Fix bug that C# property not nullable when specified via reference

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/NullableReferenceTypesTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/NullableReferenceTypesTests.cs
@@ -245,5 +245,48 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             Assert.Contains("public string Required { get; set; } = default!;", code);
             Assert.Contains("public string? Optional { get; set; } = default!;", code);
         }
+
+        [Fact]
+        public async Task
+            When_generating_from_json_schema_string_property_with_reference_is_optional_and_GenerateNullableOptionalProperties_is_set_then_CSharp_property()
+        {
+            //// Arrange
+            var schemaJson = @"
+            {
+                ""type"": ""object"",
+                ""required"": [
+                    ""required""
+                ],
+                ""properties"": {
+                    ""required"": { ""$ref"": ""#/$defs/requiredString"" },
+                    ""optional"": { ""$ref"": ""#/$defs/optionalString"" }
+                },
+                ""$defs"": {
+                    ""requiredString"": { ""type"": ""string"" },
+                    ""optionalString"": { ""type"": ""string"" }
+                }
+            }
+            ";
+
+            var schema = await JsonSchema.FromJsonAsync(schemaJson);
+
+            //// Act
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings
+            {
+                ClassStyle = CSharpClassStyle.Poco,
+                SchemaType = SchemaType.OpenApi3,
+                DateType = "string",
+                DateTimeType = "string",
+                TimeType = "string",
+                TimeSpanType = "string",
+                GenerateNullableReferenceTypes = true,
+                GenerateOptionalPropertiesAsNullable = true
+            });
+            var code = generator.GenerateFile("MyClass");
+
+            //// Assert
+            Assert.Contains("public string Required { get; set; } = default!;", code);
+            Assert.Contains("public string? Optional { get; set; } = default!;", code);
+        }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
@@ -60,19 +60,19 @@ namespace NJsonSchema.CodeGeneration.CSharp
                 throw new ArgumentNullException(nameof(schema));
             }
 
-            schema = GetResolvableSchema(schema);
-
-            if (schema == ExceptionSchema)
-            {
-                return "System.Exception";
-            }
-
             // Primitive schemas (no new type)
             if (Settings.GenerateOptionalPropertiesAsNullable &&
                 schema is JsonSchemaProperty property &&
                 !property.IsRequired)
             {
                 isNullable = true;
+            }
+
+            schema = GetResolvableSchema(schema);
+
+            if (schema == ExceptionSchema)
+            {
+                return "System.Exception";
             }
 
             var markAsNullableType = Settings.GenerateNullableReferenceTypes && isNullable;


### PR DESCRIPTION
This fixes a bug that has been found using both NSwag and NJsonSchema. Essentially when `GenerateNullableReferenceTypes` and `GenerateOptionalPropertiesAsNullable` are both true, these settings are not respected for an optional object property provided via a reference (`$ref`) and the resulting C# property is not optional.

I believe this may solve multiple issues raised in both NSwag and NJsonSchema repos, for example:
https://github.com/RicoSuter/NJsonSchema/issues/1305
https://github.com/RicoSuter/NSwag/issues/4280 (maybe?)

I've added a test that reproduces the problem and passes with the fix.
