### PR TITLE
Fix: Remove illegal characters before returning to reserved list

### DIFF
--- a/src/NJsonSchema/DefaultTypeNameGenerator.cs
+++ b/src/NJsonSchema/DefaultTypeNameGenerator.cs
@@ -62,12 +62,14 @@ namespace NJsonSchema
             }
 
             var typeName = Generate(schema, typeNameHint);
+            typeName = RemoveIllegalCharacters(typeName);
+
             if (string.IsNullOrEmpty(typeName) || reservedTypeNames.Contains(typeName))
             {
                 typeName = GenerateAnonymousTypeName(typeNameHint, reservedTypeNames);
             }
 
-            return RemoveIllegalCharacters(typeName);
+            return typeName;
         }
 
         /// <summary>Generates the type name for the given schema.</summary>


### PR DESCRIPTION
This fixes a problem, that multiple same-named types was generated and only the first wins. Thats when a illegal character was removed. The reserved list was comparing to the type name WITH the illegal character, but the type name was stored WITHOUT the illegal character - and so couldn't find a match.