### PR TITLE
Update PropertyNameGenerator - escape "|" character in property names

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpPropertyNameGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpPropertyNameGenerator.cs
@@ -11,7 +11,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
     /// <summary>Generates the property name for a given CSharp <see cref="JsonSchemaProperty"/>.</summary>
     public sealed class CSharpPropertyNameGenerator : IPropertyNameGenerator
     {
-        private static readonly char[] _reservedFirstPassChars = { '"', '\'', '@', '?', '!', '$', '[', ']', '(', ')', '.', '=', '+' };
+        private static readonly char[] _reservedFirstPassChars = { '"', '\'', '@', '?', '!', '$', '[', ']', '(', ')', '.', '=', '+', '|' };
         private static readonly char[] _reservedSecondPassChars = { '*', ':', '-', '#', '&' };
 
         /// <summary>Generates the property name.</summary>
@@ -35,7 +35,8 @@ namespace NJsonSchema.CodeGeneration.CSharp
                     .Replace(")", string.Empty)
                     .Replace(".", "-")
                     .Replace("=", "-")
-                    .Replace("+", "plus");
+                    .Replace("+", "plus")
+                    .Replace("|", "_");
             }
 
             name = ConversionUtilities.ConvertToUpperCamelCase(name, true);


### PR DESCRIPTION
Some swagger documents contain | character in property names which is a reserved character in C# and is not valid for use in property names. This code change replaces the vertical line character | with an underscore character _ to generate a valid (according to C#) property name