### PR TITLE
Expose failing JToken in ValidationError

### DIFF
--- a/src/NJsonSchema.Tests/Validation/ObjectValidationTests.cs
+++ b/src/NJsonSchema.Tests/Validation/ObjectValidationTests.cs
@@ -24,6 +24,7 @@ namespace NJsonSchema.Tests.Validation
 
             //// Assert
             Assert.Equal(ValidationErrorKind.ObjectExpected, errors.First().Kind);
+            Assert.Equal("10", errors.First().Token?.ToString());
         }
 
         [Fact]
@@ -47,6 +48,7 @@ namespace NJsonSchema.Tests.Validation
             Assert.Equal("Foo", errors.First().Property);
             Assert.Equal("#/Foo", errors.First().Path);
             Assert.Equal(ValidationErrorKind.PropertyRequired, errors.First().Kind);
+            Assert.Equal("{}", errors.First().Token?.ToString());
         }
 
         [Fact]
@@ -134,6 +136,7 @@ namespace NJsonSchema.Tests.Validation
             Assert.Equal(ValidationErrorKind.StringExpected, errors.First().Kind);
             Assert.Equal("Foo", errors.First().Property);
             Assert.Equal("#/Foo", errors.First().Path);
+            Assert.Equal("10", errors.First().Token?.ToString());
         }
 
         [Fact]
@@ -180,6 +183,7 @@ namespace NJsonSchema.Tests.Validation
 
             //// Assert
             Assert.Equal(ValidationErrorKind.NoAdditionalPropertiesAllowed, errors.First().Kind);
+            Assert.Equal("\"foo\": 5", errors.First().Token?.ToString());
         }
 
         [Fact]

--- a/src/NJsonSchema/Validation/ValidationError.cs
+++ b/src/NJsonSchema/Validation/ValidationError.cs
@@ -25,6 +25,7 @@ namespace NJsonSchema.Validation
             Kind = errorKind;
             Property = propertyName;
             Path = propertyPath != null ? "#/" + propertyPath : "#";
+            Token = token;
 
             var lineInfo = token as IJsonLineInfo;
             HasLineInfo = lineInfo != null && lineInfo.HasLineInfo();
@@ -62,6 +63,9 @@ namespace NJsonSchema.Validation
 
         /// <summary>Gets the schema element that contains the validation rule. </summary>
         public JsonSchema Schema { get; private set; }
+
+        /// <summary>Gets the JToken of the element failed the validation. </summary>
+        public JToken? Token { get; private set; }
 
         /// <summary>Returns a string that represents the current object.</summary>
         /// <returns>A string that represents the current object.</returns>


### PR DESCRIPTION
Hi there. A very small PR that would greatly improve how I can post-process validation errors 🙂 

Exposing the JToken that failed the error will allow NJsonSchema users to access various information, including the actual content of the failed token.

For example, when you have a "StringExpected" error, you can quickly access `ValidationError.Token` to see what is the actual value that is not a string. Especially handy for investigating non-nullable field that received a null value.