### PR TITLE
Fix SystemTextJson read only properties handling

### DIFF
--- a/src/NJsonSchema.Tests/Generation/SystemTextJson/SystemTextJsonTests.cs
+++ b/src/NJsonSchema.Tests/Generation/SystemTextJson/SystemTextJsonTests.cs
@@ -12,6 +12,14 @@ namespace NJsonSchema.Tests.Generation.SystemTextJson
             public string Name { get; }
 
             public string Description { get; }
+
+            private string PrivateReadOnlyProperty1 { get; }
+
+            private string PrivateReadOnlyProperty2 => "TEST";
+
+            public static string PublicReadOnlyStaticProperty { get; }
+
+            private static string PrivateReadOnlyStaticProperty { get; }
         }
 
         [Fact]
@@ -25,6 +33,32 @@ namespace NJsonSchema.Tests.Generation.SystemTextJson
             Assert.NotNull(data);
             Assert.Contains(@"Name", data);
             Assert.Contains(@"Description", data);
+        }
+
+        [Fact]
+        public async Task When_property_is_private_and_readonly_then_its_not_in_the_schema()
+        {
+            //// Act
+            var schema = JsonSchema.FromType<HealthCheckResult>();
+            var data = schema.ToJson();
+
+            //// Assert
+            Assert.NotNull(data);
+            Assert.False(data.Contains("PrivateReadOnlyProperty1"), data);
+            Assert.False(data.Contains("PrivateReadOnlyProperty2"), data);
+        }
+
+        [Fact]
+        public async Task When_property_is_static_readonly_then_its_not_in_the_schema()
+        {
+            //// Act
+            var schema = JsonSchema.FromType<HealthCheckResult>();
+            var data = schema.ToJson();
+
+            //// Assert
+            Assert.NotNull(data);
+            Assert.False(data.Contains("PublicReadOnlyStaticProperty"), data);
+            Assert.False(data.Contains("PrivateReadOnlyStaticProperty"), data);
         }
     }
 }

--- a/src/NJsonSchema/Generation/SystemTextJsonReflectionService.cs
+++ b/src/NJsonSchema/Generation/SystemTextJsonReflectionService.cs
@@ -32,8 +32,8 @@ namespace NJsonSchema.Generation
                 }
 
                 if (accessorInfo.MemberInfo is PropertyInfo propertyInfo &&
-                    (propertyInfo.GetMethod?.IsPrivate == true || propertyInfo.GetMethod?.IsStatic == true) &&
-                    (propertyInfo.SetMethod?.IsPrivate == true || propertyInfo.SetMethod?.IsStatic == true) &&
+                    (propertyInfo.GetMethod == null || propertyInfo.GetMethod.IsPrivate == true || propertyInfo.GetMethod.IsStatic == true) &&
+                    (propertyInfo.SetMethod == null || propertyInfo.SetMethod.IsPrivate == true || propertyInfo.SetMethod.IsStatic == true) &&
                     !propertyInfo.IsDefined(typeof(DataMemberAttribute)))
                 {
                     continue;


### PR DESCRIPTION
The `SystemTextJsonReflectionService` didn't properly handle when a setter (or getter) was missing. As a result read-only private properties and read-only static properties were not ignored when building type schema via reflection.

Fixes #1694