### PR TITLE
Fixed SystemTextJson indexed properties handling.

### DIFF
--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -1089,7 +1089,7 @@ namespace NJsonSchema.Generation
             }
         }
 
-        private object? TryGetInheritanceDiscriminatorConverter(Type type)
+        private SystemTextJsonInheritanceWrapper? TryGetInheritanceDiscriminatorConverter(Type type)
         {
             var typeAttributes = type.GetTypeInfo().GetCustomAttributes(false).OfType<Attribute>();
 

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -1089,6 +1089,7 @@ namespace NJsonSchema.Generation
             }
         }
 
+#pragma warning disable CA1859
         private object? TryGetInheritanceDiscriminatorConverter(Type type)
         {
             var typeAttributes = type.GetTypeInfo().GetCustomAttributes(false).OfType<Attribute>();
@@ -1099,8 +1100,8 @@ namespace NJsonSchema.Generation
             {
                 var converterType = (Type)jsonConverterAttribute.ConverterType;
                 if (converterType != null && (
-                    converterType.IsAssignableToTypeName("JsonInheritanceConverter", TypeNameStyle.Name) || // Newtonsoft's converter
-                    converterType.IsAssignableToTypeName("JsonInheritanceConverter`1", TypeNameStyle.Name) // System.Text.Json's converter
+                        converterType.IsAssignableToTypeName("JsonInheritanceConverter", TypeNameStyle.Name) || // Newtonsoft's converter
+                        converterType.IsAssignableToTypeName("JsonInheritanceConverter`1", TypeNameStyle.Name) // System.Text.Json's converter
                     ))
                 {
                     return ObjectExtensions.HasProperty(jsonConverterAttribute, "ConverterParameters") &&
@@ -1125,6 +1126,8 @@ namespace NJsonSchema.Generation
 
             return null;
         }
+#pragma warning restore CA1859
+
 
         private sealed class SystemTextJsonInheritanceWrapper
         {

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -1089,7 +1089,7 @@ namespace NJsonSchema.Generation
             }
         }
 
-        private SystemTextJsonInheritanceWrapper? TryGetInheritanceDiscriminatorConverter(Type type)
+        private object? TryGetInheritanceDiscriminatorConverter(Type type)
         {
             var typeAttributes = type.GetTypeInfo().GetCustomAttributes(false).OfType<Attribute>();
 

--- a/src/NJsonSchema/Generation/SystemTextJsonReflectionService.cs
+++ b/src/NJsonSchema/Generation/SystemTextJsonReflectionService.cs
@@ -45,6 +45,12 @@ namespace NJsonSchema.Generation
                     continue;
                 }
 
+                if (accessorInfo.MemberInfo is PropertyInfo propInfo &&
+                    propInfo.GetIndexParameters().Length > 0)
+                {
+                    continue;
+                }
+
                 var propertyIgnored = false;
                 var jsonIgnoreAttribute = accessorInfo
                     .GetAttributes(true)


### PR DESCRIPTION
The `SystemTextJsonReflectionService` did not handle properly types with indexed properties. Exception "The JSON property 'item' is defined multiple times on type" was thrown if schema had been generated for type with multiple indexed properties.

In the applied fix indexed properties are detected and not added to the generated schema. 
Result schema matches schemas generated with `NewtonsoftJsonReflectionService` and previous versions of NJsonSchema library. 

Fixes https://github.com/RicoSuter/NSwag/issues/4874