### PR TITLE
feat: option to use c# 11 required keyword for required properties

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpGeneratorSettings.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpGeneratorSettings.cs
@@ -46,6 +46,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
             PropertySetterAccessModifier = string.Empty;
             GenerateJsonMethods = false;
             EnforceFlagEnums = false;
+            UseRequiredKeyword = false;
 
             ValueGenerator = new CSharpValueGenerator(this);
             PropertyNameGenerator = new CSharpPropertyNameGenerator();
@@ -146,6 +147,9 @@ namespace NJsonSchema.CodeGeneration.CSharp
 
         /// <summary>Gets or sets a value indicating whether enums should be always generated as bit flags (default: false).</summary>
         public bool EnforceFlagEnums { get; set; }
+
+        /// <summary>Gets or sets a value indicating whether the C# 11 "required" keyword should be used for required properties (default: false). </summary>
+        public bool UseRequiredKeyword { get; set; }
 
         /// <summary>Gets or sets a value indicating whether named/referenced dictionaries should be inlined or generated as class with dictionary inheritance.</summary>
         public bool InlineNamedDictionaries { get; set; }

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/ClassTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/ClassTemplateModel.cs
@@ -151,6 +151,9 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
         /// <summary>Gets or sets the access modifier of generated classes and interfaces.</summary>
         public string TypeAccessModifier => _settings.TypeAccessModifier;
 
+        /// <summary>Gets a value indicating whether to use the C# 11 "required" keyword.</summary>
+        public bool UseRequiredKeyword => _settings.UseRequiredKeyword;
+
         /// <summary>Gets the access modifier of property setters (default: '').</summary>
         public string PropertySetterAccessModifier => !string.IsNullOrEmpty(_settings.PropertySetterAccessModifier) ? _settings.PropertySetterAccessModifier + " " : "";
 

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
@@ -95,7 +95,7 @@
     [System.Obsolete{% if property.HasDeprecatedMessage %}({{ property.DeprecatedMessage | literal }}){% endif %}]
 {%-   endif -%}
     {%- template Class.Property.Annotations -%}
-    public {{ property.Type }} {{ property.PropertyName }}{% if RenderInpc == false and RenderPrism == false %} { get; {% if property.HasSetter and RenderRecord == false %}set; {% elsif RenderRecord and GenerateNativeRecords %}init; {% endif %}}{% if property.HasDefaultValue and RenderRecord == false %} = {{ property.DefaultValue }};{% elsif GenerateNullableReferenceTypes and RenderRecord == false %} = default!;{% endif %}
+    public {% if UseRequiredKeyword and property.IsRequired %}required {% endif %}{{ property.Type }} {{ property.PropertyName }}{% if RenderInpc == false and RenderPrism == false %} { get; {% if property.HasSetter and RenderRecord == false %}set; {% elsif RenderRecord and GenerateNativeRecords %}init; {% endif %}}{% if property.HasDefaultValue and RenderRecord == false %} = {{ property.DefaultValue }};{% elsif GenerateNullableReferenceTypes and RenderRecord == false %} = default!;{% endif %}
 {% else %}
     {
         get { return {{ property.FieldName }}; }


### PR DESCRIPTION
This PR adds a `UseRequiredKeyword` option to the C# code generator. This will use the `required` [modifier](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/required), added in C#11, for any properties that are required in the json schema.