### PR TITLE
#1709 Generate C# TimeSpan as a DayJs duration

### DIFF
--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/DateCodeGenerationTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/DateCodeGenerationTests.cs
@@ -15,7 +15,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
 		'myTimeSpan': { 'type': 'string', 'format': 'time-span' }
 	}
 }";
-        
+
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
@@ -149,6 +149,26 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
         }
 
         [Fact]
+        public async Task When_date_handling_is_dayjs_then_duration_property_is_generated_in_class()
+        {
+            //// Arrange
+            var schema = await JsonSchema.FromJsonAsync(Json);
+
+            //// Act
+            var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings
+            {
+                TypeStyle = TypeScriptTypeStyle.Class,
+                DateTimeType = TypeScriptDateTimeType.DayJS
+            });
+            var code = generator.GenerateFile("MyClass");
+
+            //// Assert
+            Assert.Contains("myTimeSpan: dayjs.Duration", code);
+            Assert.Contains("this.myTimeSpan = _data[\"myTimeSpan\"] ? dayjs.duration(((val: string) => {  const [days, rest] = val.split('.');  const [hours, minutes, seconds, milliseconds] = rest.split(/[:.]/);    return dayjs.duration({    days: parseInt(days),    hours: parseInt(hours),    minutes: parseInt(minutes),    seconds: parseInt(seconds),    milliseconds: parseInt(milliseconds),  });  })(_data[\"myTimeSpan\"].toString())) : <any>undefined;", code);
+            Assert.Contains("data[\"myTimeSpan\"] = this.myTimeSpan ? this.myTimeSpan.format('D.HH:mm:ss.SSS') : <any>undefined;", code);
+        }
+
+        [Fact]
         public async Task When_date_handling_is_date_then_date_property_is_generated_in_class()
         {
             //// Arrange
@@ -168,7 +188,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
             Assert.Contains("data[\"myDate\"] = this.myDate ? formatDate(this.myDate) : <any>undefined;", code);
             Assert.Contains("function formatDate(", code);
         }
-        
+
         [Fact]
         public async Task When_date_handling_is_date_then_date_property_is_generated_in_class_with_local_timezone_conversion()
         {

--- a/src/NJsonSchema.CodeGeneration.TypeScript/Templates/ConvertToClass.liquid
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Templates/ConvertToClass.liquid
@@ -54,7 +54,7 @@ if ({{ Value }}) {
     {% if IsDate -%}
 {{ Variable }} = {{ Value }} ? {{ StringToDateOnlyCode }}({{ Value }}.toString()) : {% if HasDefaultValue %}{{ StringToDateOnlyCode }}({{ DefaultValue }}){% else %}<any>{{ NullValue }}{% endif %};
     {% elsif IsDateTime -%}
-{{ Variable }} = {{ Value }} ? {{ StringToDateCode }}({{ Value }}.toString()) : {% if HasDefaultValue %}{{ StringToDateCode }}({{ DefaultValue }}){% else %}<any>{{ NullValue }}{% endif %};
+{{ Variable }} = {{ Value }} ? {{ StringToDateCode }}({{ ConstructDateTimeWith }}) : {% if HasDefaultValue %}{{ StringToDateCode }}({{ DefaultValue }}){% else %}<any>{{ NullValue }}{% endif %};
     {% else -%}
 {%       if HasDefaultValue or NullValue != "undefined" -%}
 {{ Variable }} = {{ Value }} !== undefined ? {{ Value }} : {% if HasDefaultValue %}{{ DefaultValue }}{% else %}<any>{{ NullValue }}{% endif %};

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
@@ -287,7 +287,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
 
                 if (schema.Format is JsonFormatStrings.Duration or JsonFormatStrings.TimeSpan)
                 {
-                    return "dayjs.Dayjs";
+                    return "dayjs.Duration";
                 }
             }
 


### PR DESCRIPTION
Attempt to generate a Dayjs duration for a C# TimeSpan. 

See #1709

Im not familiar with the code however I wanted to attempt to help out. 

DayJS duration takes a ISO 8601 string or an object as a constructor. 

I chose to use a function to convert the 'D.HH:mm:ss.SSS' string to the object.

Im not sure if that is a good idea or if converting it to a ISO 8601 and passing that to the constructor would be more reusable.

Copilot suggests the following conversion function:
```
function convertToISO8601(input: string): string {
  const [days, rest] = input.split('.');
  const [hours, minutes, seconds, milliseconds] = rest.split(/[:.]/);

  // Constructing the ISO 8601 duration string
  let isoDuration = 'P';
  if (parseInt(days) > 0) isoDuration += `${parseInt(days)}D`;
  if (hours !== '00' || minutes !== '00' || seconds !== '00' || milliseconds !== '000') {
    isoDuration += 'T';
    if (parseInt(hours) > 0) isoDuration += `${parseInt(hours)}H`;
    if (parseInt(minutes) > 0) isoDuration += `${parseInt(minutes)}M`;
    if (parseInt(seconds) > 0 || parseInt(milliseconds) > 0) {
      let totalSeconds = parseInt(seconds);
      if (parseInt(milliseconds) > 0) {
        totalSeconds += parseInt(milliseconds) / 1000;
      }
      isoDuration += `${totalSeconds}S`;
    }
  }

  return isoDuration;
}
```
 
It would be best if the conversion function would be added as a function to the file as a utility which can then be called in the generated classes instead of inlined like i did here.

But im not sure how to do this and i hope someone can pick this up and polish it up. 