### PR TITLE
C# generator: create anoymous types with camel casing

### DIFF
--- a/src/NJsonSchema/DefaultTypeNameGenerator.cs
+++ b/src/NJsonSchema/DefaultTypeNameGenerator.cs
@@ -107,12 +107,14 @@ namespace NJsonSchema
                 }
 
                 var count = 1;
+                string typeName;
                 do
                 {
                     count++;
-                } while (reservedTypeNames.Contains(typeNameHint + count));
+                    typeName = ConversionUtilities.ConvertToUpperCamelCase(typeNameHint + count, true);
+                } while (reservedTypeNames.Contains(typeName));
 
-                return typeNameHint + count;
+                return typeName;
             }
 
             return GenerateAnonymousTypeName("Anonymous", reservedTypeNames);


### PR DESCRIPTION
This is an attempt to fix https://github.com/RicoSuter/NSwag/issues/4849 and https://github.com/RicoSuter/NSwag/issues/4837: since NSwag 14, the resulting C# file generated from a yaml file might contain lower case class names. 
This seems to happen if an array item has as lower case type name hint (e.g. "data"), and a class "Data" was already generated.
In this situation, `DefaultTypeNameGenerator.GenerateAnonymousTypeName` does not call `ConversionUtilities.ConvertToUpperCamelCase` and thus picks the lower case class name "data" as "not used".

I have no idea why this worked with NSwag 13 and what broke it.

With my fix, it would generate a class "Data2" again.

Hope you don't force me to add a test case - for me it happens with a large closed source yaml file, and the open source file from the other bug report is also large. And I am not a yaml specialist...