### PR TITLE
Upgrade packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,27 +4,25 @@
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="BenchmarkDotNet" Version="0.13.9" />
-    <PackageVersion Include="Fluid.Core" Version="2.9.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageVersion Include="Fluid.Core" Version="2.11.1" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Namotion.Reflection" Version="3.1.1" />
     <PackageVersion Include="NBench" Version="2.0.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="NodaTime" Version="3.1.9" />
-    <PackageVersion Include="NSwag.Core.Yaml" Version="14.0.0-preview011" />
+    <PackageVersion Include="NodaTime" Version="3.1.12" />
+    <PackageVersion Include="NSwag.Core.Yaml" Version="14.0.0" />
     <PackageVersion Include="Pro.NBench.xUnit" Version="2.0.0" />
-    <PackageVersion Include="System.ComponentModel.Annotations" Version="4.4.0" />
-    <PackageVersion Include="System.Text.Json" Version="4.7.2" />
-    <PackageVersion Include="Verify.XUnit" Version="14.7.0" />
-    <PackageVersion Include="xunit" Version="2.8.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.0" />
-    <PackageVersion Include="YamlDotNet" Version="15.1.4" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
+    <PackageVersion Include="Verify.XUnit" Version="26.4.0" />
+    <PackageVersion Include="xunit" Version="2.9.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="YamlDotNet" Version="16.1.0" />
   </ItemGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
-    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <GlobalPackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <GlobalPackageReference Include="PolySharp" Version="1.14.1" />
   </ItemGroup>
 </Project>

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using System.Xml.Linq;
 using Nuke.Common;
 using Nuke.Common.CI;
+using Nuke.Common.CI.GitHubActions;
 using Nuke.Common.Git;
 using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
@@ -83,7 +84,7 @@ partial class Build : NukeBuild
             VersionSuffix = $"dev-{DateTime.UtcNow:yyyyMMdd-HHmm}";
         }
 
-        using var _ = Block("BUILD SETUP");
+        Serilog.Log.Information("BUILD SETUP");
         Serilog.Log.Information("Configuration:\t {Configuration}" , Configuration);
         Serilog.Log.Information("Version prefix:\t {VersionPrefix}" , VersionPrefix);
         Serilog.Log.Information("Version suffix:\t {VersionSuffix}" , VersionSuffix);
@@ -118,11 +119,15 @@ partial class Build : NukeBuild
                 .EnableNoRestore()
                 .SetDeterministic(IsServerBuild)
                 .SetContinuousIntegrationBuild(IsServerBuild)
+                // ensure we don't generate too much output in CI run
+                // 0  Turns off emission of all warning messages
+                // 1  Displays severe warning messages
+                .SetWarningLevel(IsServerBuild ? 0 : 1)
             );
         });
 
     Target Test => _ => _
-        .After(Compile)
+        .DependsOn(Compile)
         .Executes(() =>
         {
             var framework = "";
@@ -135,7 +140,9 @@ partial class Build : NukeBuild
                 .SetProjectFile(Solution)
                 .SetConfiguration(Configuration)
                 .EnableNoRestore()
+                .EnableNoBuild()
                 .SetFramework(framework)
+                .When(GitHubActions.Instance is not null, x => x.SetLoggers("GitHubActions"))
             );
         });
 

--- a/src/NJsonSchema.Benchmark/JsonInheritanceConverterBenchmarks.cs
+++ b/src/NJsonSchema.Benchmark/JsonInheritanceConverterBenchmarks.cs
@@ -1,8 +1,6 @@
-﻿using System.Diagnostics;
-using NBench;
+﻿using NBench;
 using NJsonSchema.Tests.Generation;
 using Pro.NBench.xUnit.XunitExtensions;
-using Xunit.Abstractions;
 
 namespace NJsonSchema.Benchmark
 {
@@ -10,12 +8,6 @@ namespace NJsonSchema.Benchmark
     {
         private Counter _counter;
         private JsonInheritanceConverterTests _tests;
-
-        public JsonInheritanceConverterBenchmarks(ITestOutputHelper output)
-        {
-            Trace.Listeners.Clear();
-            Trace.Listeners.Add(new XunitTraceListener(output));
-        }
 
         [PerfSetup]
         public void Setup(BenchmarkContext context)

--- a/src/NJsonSchema.Benchmark/NJsonSchema.Benchmark.csproj
+++ b/src/NJsonSchema.Benchmark/NJsonSchema.Benchmark.csproj
@@ -23,10 +23,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    </ItemGroup>
-
-    <ItemGroup>
         <ProjectReference Include="..\NJsonSchema.CodeGeneration.CSharp\NJsonSchema.CodeGeneration.CSharp.csproj" />
         <ProjectReference Include="..\NJsonSchema.CodeGeneration.TypeScript\NJsonSchema.CodeGeneration.TypeScript.csproj" />
         <ProjectReference Include="..\NJsonSchema.NewtonsoftJson\NJsonSchema.NewtonsoftJson.csproj" />

--- a/src/NJsonSchema.Benchmark/SchemaGenerationBenchmarks.cs
+++ b/src/NJsonSchema.Benchmark/SchemaGenerationBenchmarks.cs
@@ -1,22 +1,14 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Runtime.Serialization;
 using NBench;
 using NJsonSchema.NewtonsoftJson.Generation;
 using Pro.NBench.xUnit.XunitExtensions;
-using Xunit.Abstractions;
 
 namespace NJsonSchema.Benchmark
 {
     public class SchemaGenerationBenchmarks
     {
         private Counter _counter;
-
-        public SchemaGenerationBenchmarks(ITestOutputHelper output)
-        {
-            Trace.Listeners.Clear();
-            Trace.Listeners.Add(new XunitTraceListener(output));
-        }
 
         [PerfSetup]
         public void Setup(BenchmarkContext context)

--- a/src/NJsonSchema.Benchmark/SerializationBenchmarks.cs
+++ b/src/NJsonSchema.Benchmark/SerializationBenchmarks.cs
@@ -1,10 +1,8 @@
-﻿using System.Diagnostics;
-using System.IO;
+﻿using System.IO;
 using System.Reflection;
 using NBench;
 using Pro.NBench.xUnit.XunitExtensions;
 using Xunit;
-using Xunit.Abstractions;
 
 [assembly: CollectionBehavior(DisableTestParallelization = true)]
 
@@ -15,12 +13,6 @@ namespace NJsonSchema.Benchmark
         private JsonSchema _schema;
         private Counter _counter;
         private string _json;
-
-        public SerializationBenchmarks(ITestOutputHelper output)
-        {
-            Trace.Listeners.Clear();
-            Trace.Listeners.Add(new XunitTraceListener(output));
-        }
 
         [PerfSetup]
         public void Setup(BenchmarkContext context)

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/AdditionalPropertiesTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/AdditionalPropertiesTests.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using NJsonSchema.CodeGeneration.CSharp;
-using NJsonSchema.Generation;
 using NJsonSchema.NewtonsoftJson.Generation;
 using Xunit;
 

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/CSharpJsonSerializerGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/CSharpJsonSerializerGeneratorTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Xunit;
+﻿using Xunit;
 
 namespace NJsonSchema.CodeGeneration.CSharp.Tests
 {

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/EnumTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/EnumTests.cs
@@ -1,7 +1,6 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using NJsonSchema.CodeGeneration.CSharp;
-using NJsonSchema.Generation;
 using NJsonSchema.NewtonsoftJson.Generation;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/GeneralGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/GeneralGeneratorTests.cs
@@ -13,7 +13,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using NJsonSchema.Annotations;
-using NJsonSchema.Generation;
 using NJsonSchema.NewtonsoftJson.Generation;
 using Xunit;
 

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/InheritanceInterfaceTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/InheritanceInterfaceTests.cs
@@ -4,7 +4,6 @@ using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using NJsonSchema.CodeGeneration.CSharp;
-using NJsonSchema.Generation;
 using NJsonSchema.NewtonsoftJson.Converters;
 using NJsonSchema.NewtonsoftJson.Generation;
 using Xunit;

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/InterfaceTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/InterfaceTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Threading.Tasks;
-using NJsonSchema.Generation;
 using NJsonSchema.NewtonsoftJson.Generation;
 using Xunit;
 

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/NJsonSchema.CodeGeneration.CSharp.Tests.csproj
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/NJsonSchema.CodeGeneration.CSharp.Tests.csproj
@@ -18,7 +18,6 @@
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Condition="'$(TargetFramework)' == 'net8.0'" />
-        <PackageReference Condition="'$(TargetFramework)' == 'net8.0'" Include="System.ComponentModel.Annotations" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/NullableReferenceTypesTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/NullableReferenceTypesTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;
 using NJsonSchema.CodeGeneration.CSharp;
-using NJsonSchema.Generation;
 using NJsonSchema.NewtonsoftJson.Generation;
 using Xunit;
 

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/NullableTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/NullableTests.cs
@@ -1,5 +1,4 @@
 ﻿using NJsonSchema.CodeGeneration.CSharp;
-using NJsonSchema.Generation;
 using NJsonSchema.NewtonsoftJson.Generation;
 using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/ObjectPropertyRequiredTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/ObjectPropertyRequiredTests.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;
 using NJsonSchema.CodeGeneration.CSharp;
-using NJsonSchema.Generation;
 using NJsonSchema.NewtonsoftJson.Generation;
 using Xunit;
 

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/StringPropertyRequiredTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/StringPropertyRequiredTests.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;
-using NJsonSchema.Generation;
 using NJsonSchema.NewtonsoftJson.Generation;
 using Xunit;
 

--- a/src/NJsonSchema.CodeGeneration.Tests/DefaultGenerationTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/DefaultGenerationTests.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using System.Threading.Tasks;
 using NJsonSchema.CodeGeneration.CSharp;
-using NJsonSchema.Generation;
 using NJsonSchema.NewtonsoftJson.Generation;
 using Xunit;
 

--- a/src/NJsonSchema.CodeGeneration.Tests/DefaultValueGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/DefaultValueGeneratorTests.cs
@@ -1,5 +1,4 @@
-﻿using NJsonSchema.Annotations;
-using NJsonSchema.CodeGeneration.CSharp;
+﻿using NJsonSchema.CodeGeneration.CSharp;
 using NJsonSchema.CodeGeneration.TypeScript;
 using Xunit;
 

--- a/src/NJsonSchema.CodeGeneration.Tests/EnumGenerationTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/EnumGenerationTests.cs
@@ -6,7 +6,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using NJsonSchema.CodeGeneration.CSharp;
 using NJsonSchema.CodeGeneration.TypeScript;
-using NJsonSchema.Generation;
 using NJsonSchema.NewtonsoftJson.Generation;
 using Xunit;
 

--- a/src/NJsonSchema.CodeGeneration.Tests/NJsonSchema.CodeGeneration.Tests.csproj
+++ b/src/NJsonSchema.CodeGeneration.Tests/NJsonSchema.CodeGeneration.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net462</TargetFrameworks>
+        <TargetFrameworks>net8.0;net472</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <NoWarn>$(NoWarn),1998,1591,618</NoWarn>
         <Nullable>disable</Nullable>
@@ -9,19 +9,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Condition="'$(TargetFramework)' == 'net462'" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Condition="'$(TargetFramework)' == 'net8.0'" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio" />
     </ItemGroup>
 
     <ItemGroup>
-        <Reference Condition="'$(TargetFramework)' == 'net462'" Include="System.ComponentModel.DataAnnotations" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+        <Reference Condition="'$(TargetFramework)' == 'net472'" Include="System.ComponentModel.DataAnnotations" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/ClassGenerationTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/ClassGenerationTests.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using NJsonSchema.Generation;
 using NJsonSchema.NewtonsoftJson.Converters;
 using NJsonSchema.NewtonsoftJson.Generation;
 using System;
@@ -8,14 +7,12 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
-using VerifyXunit;
 using Xunit;
 
 using static NJsonSchema.CodeGeneration.TypeScript.Tests.VerifyHelper;
 
 namespace NJsonSchema.CodeGeneration.TypeScript.Tests
 {
-    [UsesVerify]
     public class ClassGenerationTests
     {
         public class MyClassTest

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/ConstructorInterfaceTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/ConstructorInterfaceTests.cs
@@ -2,7 +2,6 @@
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
-using NJsonSchema.Generation;
 using NJsonSchema.NewtonsoftJson.Converters;
 using NJsonSchema.NewtonsoftJson.Generation;
 using Xunit;

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/DateCodeGenerationTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/DateCodeGenerationTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Threading.Tasks;
-using NJsonSchema.CodeGeneration.TypeScript;
 using Xunit;
 
 namespace NJsonSchema.CodeGeneration.TypeScript.Tests

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/DateTimeCodeGenerationTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/DateTimeCodeGenerationTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Threading.Tasks;
-using NJsonSchema.CodeGeneration.TypeScript;
 using NJsonSchema.NewtonsoftJson.Generation;
 using Xunit;
 

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/InheritanceTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/InheritanceTests.cs
@@ -1,6 +1,5 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
-using NJsonSchema.Generation;
 using NJsonSchema.Infrastructure;
 using NJsonSchema.NewtonsoftJson.Converters;
 using NJsonSchema.NewtonsoftJson.Generation;

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/NJsonSchema.CodeGeneration.TypeScript.Tests.csproj
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/NJsonSchema.CodeGeneration.TypeScript.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net462</TargetFrameworks>
+        <TargetFrameworks>net8.0;net472</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>$(NoWarn),1587,1998,1591,618</NoWarn>
@@ -19,7 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Reference Condition="'$(TargetFramework)' == 'net462'" Include="System.ComponentModel.DataAnnotations" />
+        <Reference Condition="'$(TargetFramework)' == 'net472'" Include="System.ComponentModel.DataAnnotations" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/PropertyNameTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/PropertyNameTests.cs
@@ -1,14 +1,11 @@
 ﻿using System.Threading.Tasks;
-using NJsonSchema.Annotations;
 using NJsonSchema.NewtonsoftJson.Generation;
-using VerifyXunit;
 using Xunit;
 
 using static NJsonSchema.CodeGeneration.TypeScript.Tests.VerifyHelper;
 
 namespace NJsonSchema.CodeGeneration.TypeScript.Tests;
 
-[UsesVerify]
 public class PropertyNameTests
 {
     private class TypeWithRestrictedProperties

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptDiscriminatorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptDiscriminatorTests.cs
@@ -5,12 +5,10 @@ using System.Runtime.Serialization;
 using Xunit;
 using NJsonSchema.NewtonsoftJson.Converters;
 using NJsonSchema.NewtonsoftJson.Generation;
-using VerifyXunit;
 using Newtonsoft.Json.Converters;
 
 namespace NJsonSchema.CodeGeneration.TypeScript.Tests
 {
-    [UsesVerify]
     public class TypeScriptDiscriminatorTests
     {
         [JsonConverter(typeof(JsonInheritanceConverter), nameof(Type))]

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptGeneratorTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using NJsonSchema.CodeGeneration.TypeScript.Tests.Models;
+﻿using NJsonSchema.CodeGeneration.TypeScript.Tests.Models;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;

--- a/src/NJsonSchema.CodeGeneration/DefaultTemplateFactory.cs
+++ b/src/NJsonSchema.CodeGeneration/DefaultTemplateFactory.cs
@@ -308,7 +308,7 @@ namespace NJsonSchema.CodeGeneration
             }
 
             private static ValueTask<Completion> RenderTemplate(
-                List<Expression> arguments,
+                IReadOnlyList<Expression> arguments,
                 TextWriter writer,
                 TextEncoder encoder,
                 TemplateContext context)

--- a/src/NJsonSchema.NewtonsoftJson.Tests/NJsonSchema.NewtonsoftJson.Tests.csproj
+++ b/src/NJsonSchema.NewtonsoftJson.Tests/NJsonSchema.NewtonsoftJson.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net462</TargetFrameworks>
+        <TargetFrameworks>net8.0;net472</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
         <Nullable>disable</Nullable>
@@ -10,6 +10,8 @@
     <PropertyGroup>
         <DocumentationFile>bin\Debug\$(TargetFramework)\NJsonSchema.Tests.xml</DocumentationFile>
         <NoWarn>$(NoWarn),618,1587,1998,1591</NoWarn>
+        <!-- Remove the underscores from member name -->
+        <NoWarn>$(NoWarn),CA1707</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
@@ -21,8 +23,6 @@
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
         <PackageReference Include="NodaTime" />
-        <Reference Condition="'$(TargetFramework)' == 'net462'" Include="System.ComponentModel.DataAnnotations"></Reference>
-        <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NJsonSchema.Tests/Conversion/ArrayTypeToSchemaTests.cs
+++ b/src/NJsonSchema.Tests/Conversion/ArrayTypeToSchemaTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using NJsonSchema.NewtonsoftJson.Generation;

--- a/src/NJsonSchema.Tests/Conversion/TypeToSchemaTests.cs
+++ b/src/NJsonSchema.Tests/Conversion/TypeToSchemaTests.cs
@@ -1,12 +1,10 @@
 ﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
-using NJsonSchema.Generation;
 using NJsonSchema.NewtonsoftJson.Generation;
 using Xunit;
 

--- a/src/NJsonSchema.Tests/Generation/AllowAdditionalPropertiesTests.cs
+++ b/src/NJsonSchema.Tests/Generation/AllowAdditionalPropertiesTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq;
-using NJsonSchema.Generation;
 using System.Collections.Generic;
 using Xunit;
 using NJsonSchema.NewtonsoftJson.Generation;

--- a/src/NJsonSchema.Tests/Generation/ArrayGenerationTests.cs
+++ b/src/NJsonSchema.Tests/Generation/ArrayGenerationTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
-using NJsonSchema.Generation;
 using NJsonSchema.NewtonsoftJson.Generation;
 using Xunit;
 

--- a/src/NJsonSchema.Tests/Generation/ContractResolverTests.cs
+++ b/src/NJsonSchema.Tests/Generation/ContractResolverTests.cs
@@ -1,6 +1,5 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
-using NJsonSchema.Generation;
 using NJsonSchema.NewtonsoftJson.Generation;
 using System;
 using System.Collections;

--- a/src/NJsonSchema.Tests/Generation/DataContractTests.cs
+++ b/src/NJsonSchema.Tests/Generation/DataContractTests.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using NJsonSchema.Generation;
 using NJsonSchema.NewtonsoftJson.Generation;
 using System.Runtime.Serialization;
 using Xunit;

--- a/src/NJsonSchema.Tests/Generation/DictionaryTests.cs
+++ b/src/NJsonSchema.Tests/Generation/DictionaryTests.cs
@@ -1,5 +1,4 @@
-﻿using NJsonSchema.Generation;
-using NJsonSchema.NewtonsoftJson.Generation;
+﻿using NJsonSchema.NewtonsoftJson.Generation;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;

--- a/src/NJsonSchema.Tests/Generation/EnumGenerationTests.cs
+++ b/src/NJsonSchema.Tests/Generation/EnumGenerationTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using NJsonSchema.Generation;
 using NJsonSchema.NewtonsoftJson.Generation;
 using Xunit;
 

--- a/src/NJsonSchema.Tests/Generation/EnumTests.cs
+++ b/src/NJsonSchema.Tests/Generation/EnumTests.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using NJsonSchema.Generation;
 using Xunit;
 using NJsonSchema.NewtonsoftJson.Generation;
 

--- a/src/NJsonSchema.Tests/Generation/ExtensionDataGenerationTests.cs
+++ b/src/NJsonSchema.Tests/Generation/ExtensionDataGenerationTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
-using NJsonSchema.Generation;
 using NJsonSchema.NewtonsoftJson.Generation;
 using Xunit;
 

--- a/src/NJsonSchema.Tests/Generation/FlattenInheritanceHierarchyTests.cs
+++ b/src/NJsonSchema.Tests/Generation/FlattenInheritanceHierarchyTests.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using Newtonsoft.Json.Converters;
 using NJsonSchema.Annotations;
-using NJsonSchema.Generation;
 using NJsonSchema.NewtonsoftJson.Generation;
 using Xunit;
 

--- a/src/NJsonSchema.Tests/Generation/InheritanceTests.cs
+++ b/src/NJsonSchema.Tests/Generation/InheritanceTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
-using NJsonSchema.Generation;
 using NJsonSchema.Generation.SchemaProcessors;
 using NJsonSchema.NewtonsoftJson.Converters;
 using NJsonSchema.NewtonsoftJson.Generation;

--- a/src/NJsonSchema.Tests/Generation/InterfaceTests.cs
+++ b/src/NJsonSchema.Tests/Generation/InterfaceTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using NJsonSchema.Generation;
 using NJsonSchema.NewtonsoftJson.Generation;
 using Xunit;
 

--- a/src/NJsonSchema.Tests/Generation/JsonPropertyAttributeTests.cs
+++ b/src/NJsonSchema.Tests/Generation/JsonPropertyAttributeTests.cs
@@ -1,7 +1,6 @@
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
-using NJsonSchema.Generation;
 using NJsonSchema.NewtonsoftJson.Generation;
 using Xunit;
 

--- a/src/NJsonSchema.Tests/Generation/JsonSchemaExtensionDataAttributeGeneratorTests.cs
+++ b/src/NJsonSchema.Tests/Generation/JsonSchemaExtensionDataAttributeGeneratorTests.cs
@@ -1,5 +1,4 @@
 ﻿using NJsonSchema.Annotations;
-using NJsonSchema.Generation;
 using NJsonSchema.NewtonsoftJson.Generation;
 using System;
 using System.Globalization;

--- a/src/NJsonSchema.Tests/Generation/KnownTypeGenerationTests.cs
+++ b/src/NJsonSchema.Tests/Generation/KnownTypeGenerationTests.cs
@@ -1,6 +1,5 @@
 ﻿using NJsonSchema.NewtonsoftJson.Generation;
 using System;
-using System.Linq;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using Xunit;

--- a/src/NJsonSchema.Tests/Generation/PrimitiveTypeGenerationTests.cs
+++ b/src/NJsonSchema.Tests/Generation/PrimitiveTypeGenerationTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
-using NJsonSchema.Annotations;
 using NJsonSchema.NewtonsoftJson.Generation;
 using NodaTime;
 using Xunit;

--- a/src/NJsonSchema.Tests/Generation/PropertyNamesGenerationTests.cs
+++ b/src/NJsonSchema.Tests/Generation/PropertyNamesGenerationTests.cs
@@ -2,7 +2,6 @@ using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
-using NJsonSchema.Generation;
 using NJsonSchema.NewtonsoftJson.Generation;
 using Xunit;
 

--- a/src/NJsonSchema.Tests/Generation/SampleJsonSchemaGeneratorTests.cs
+++ b/src/NJsonSchema.Tests/Generation/SampleJsonSchemaGeneratorTests.cs
@@ -1,5 +1,4 @@
-﻿using NJsonSchema.Annotations;
-using Xunit;
+﻿using Xunit;
 
 namespace NJsonSchema.Tests.Generation
 {

--- a/src/NJsonSchema.Tests/Generation/SchemaGenerationTests.cs
+++ b/src/NJsonSchema.Tests/Generation/SchemaGenerationTests.cs
@@ -1,5 +1,4 @@
-﻿using NJsonSchema.Annotations;
-using NJsonSchema.NewtonsoftJson.Generation;
+﻿using NJsonSchema.NewtonsoftJson.Generation;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/NJsonSchema.Tests/Generation/SchemaProcessorTests.cs
+++ b/src/NJsonSchema.Tests/Generation/SchemaProcessorTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading.Tasks;
-using NJsonSchema.Annotations;
+﻿using NJsonSchema.Annotations;
 using NJsonSchema.Generation;
 using NJsonSchema.NewtonsoftJson.Generation;
 using Xunit;

--- a/src/NJsonSchema.Tests/Generation/TypeMapperTests.cs
+++ b/src/NJsonSchema.Tests/Generation/TypeMapperTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Threading.Tasks;
-using NJsonSchema.Generation;
 using NJsonSchema.Generation.TypeMappers;
 using NJsonSchema.NewtonsoftJson.Generation;
 using Xunit;

--- a/src/NJsonSchema.Tests/Generation/XmlObjectTests.cs
+++ b/src/NJsonSchema.Tests/Generation/XmlObjectTests.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json.Linq;
-using NJsonSchema.Generation;
 using NJsonSchema.NewtonsoftJson.Generation;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/NJsonSchema.Tests/NJsonSchema.Tests.csproj
+++ b/src/NJsonSchema.Tests/NJsonSchema.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net462</TargetFrameworks>
+        <TargetFrameworks>net8.0;net472</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
         <Nullable>disable</Nullable>
@@ -10,6 +10,8 @@
     <PropertyGroup>
         <DocumentationFile>bin\Debug\$(TargetFramework)\NJsonSchema.Tests.xml</DocumentationFile>
         <NoWarn>$(NoWarn),618,1587,1998,1591</NoWarn>
+        <!-- Remove the underscores from member name -->
+        <NoWarn>$(NoWarn),CA1707</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
@@ -21,8 +23,10 @@
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
         <PackageReference Include="NodaTime" />
-        <Reference Condition="'$(TargetFramework)' == 'net462'" Include="System.ComponentModel.DataAnnotations"></Reference>
-        <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Reference Condition="'$(TargetFramework)' == 'net472'" Include="System.ComponentModel.DataAnnotations"></Reference>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NJsonSchema.Tests/Validation/CustomValidationTests.cs
+++ b/src/NJsonSchema.Tests/Validation/CustomValidationTests.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json.Linq;
-using NJsonSchema.Annotations;
 using NJsonSchema.Validation;
 using NJsonSchema.Validation.FormatValidators;
 using System;

--- a/src/NJsonSchema.Tests/Validation/FormatBase64Tests.cs
+++ b/src/NJsonSchema.Tests/Validation/FormatBase64Tests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using Newtonsoft.Json.Linq;
-using NJsonSchema.Annotations;
 using NJsonSchema.Validation;
 using Xunit;
 

--- a/src/NJsonSchema.Tests/Validation/FormatDateTests.cs
+++ b/src/NJsonSchema.Tests/Validation/FormatDateTests.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using Newtonsoft.Json.Linq;
-using NJsonSchema.Annotations;
 using NJsonSchema.Validation;
 using Xunit;
 

--- a/src/NJsonSchema.Tests/Validation/FormatDateTimeTests.cs
+++ b/src/NJsonSchema.Tests/Validation/FormatDateTimeTests.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using Newtonsoft.Json.Linq;
-using NJsonSchema.Annotations;
 using NJsonSchema.Validation;
 using Xunit;
 

--- a/src/NJsonSchema.Tests/Validation/FormatEmailTests.cs
+++ b/src/NJsonSchema.Tests/Validation/FormatEmailTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Linq;
 using Newtonsoft.Json.Linq;
-using NJsonSchema.Annotations;
 using NJsonSchema.Validation;
 using Xunit;
 

--- a/src/NJsonSchema.Tests/Validation/FormatGuidTests.cs
+++ b/src/NJsonSchema.Tests/Validation/FormatGuidTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using Newtonsoft.Json.Linq;
-using NJsonSchema.Annotations;
 using NJsonSchema.Validation;
 using Xunit;
 

--- a/src/NJsonSchema.Tests/Validation/FormatHostnameTests.cs
+++ b/src/NJsonSchema.Tests/Validation/FormatHostnameTests.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using Newtonsoft.Json.Linq;
-using NJsonSchema.Annotations;
 using NJsonSchema.Validation;
 using Xunit;
 

--- a/src/NJsonSchema.Tests/Validation/FormatIpV4Tests.cs
+++ b/src/NJsonSchema.Tests/Validation/FormatIpV4Tests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Linq;
 using Newtonsoft.Json.Linq;
-using NJsonSchema.Annotations;
 using NJsonSchema.Validation;
 using Xunit;
 

--- a/src/NJsonSchema.Tests/Validation/FormatIpV6Tests.cs
+++ b/src/NJsonSchema.Tests/Validation/FormatIpV6Tests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Linq;
 using Newtonsoft.Json.Linq;
-using NJsonSchema.Annotations;
 using NJsonSchema.Validation;
 using Xunit;
 

--- a/src/NJsonSchema.Tests/Validation/FormatTimeSpanTests.cs
+++ b/src/NJsonSchema.Tests/Validation/FormatTimeSpanTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Linq;
 using Newtonsoft.Json.Linq;
-using NJsonSchema.Annotations;
 using NJsonSchema.Validation;
 using Xunit;
 

--- a/src/NJsonSchema.Tests/Validation/FormatTimeTests.cs
+++ b/src/NJsonSchema.Tests/Validation/FormatTimeTests.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using Newtonsoft.Json.Linq;
-using NJsonSchema.Annotations;
 using NJsonSchema.Validation;
 using Xunit;
 

--- a/src/NJsonSchema.Tests/Validation/FormatUriTests.cs
+++ b/src/NJsonSchema.Tests/Validation/FormatUriTests.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using Newtonsoft.Json.Linq;
-using NJsonSchema.Annotations;
 using NJsonSchema.Validation;
 using Xunit;
 

--- a/src/NJsonSchema.Tests/Validation/FormatUuidTests.cs
+++ b/src/NJsonSchema.Tests/Validation/FormatUuidTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using Newtonsoft.Json.Linq;
-using NJsonSchema.Annotations;
 using NJsonSchema.Validation;
 using Xunit;
 

--- a/src/NJsonSchema.Tests/Validation/NullPropertyTests.cs
+++ b/src/NJsonSchema.Tests/Validation/NullPropertyTests.cs
@@ -1,4 +1,3 @@
-using NJsonSchema.Generation;
 using NJsonSchema.NewtonsoftJson.Generation;
 using System;
 using System.Threading.Tasks;

--- a/src/NJsonSchema.Yaml.Tests/NJsonSchema.Yaml.Tests.csproj
+++ b/src/NJsonSchema.Yaml.Tests/NJsonSchema.Yaml.Tests.csproj
@@ -1,10 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net462</TargetFrameworks>
+        <TargetFrameworks>net8.0;net472</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
         <Nullable>disable</Nullable>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <!-- Remove the underscores from member name -->
+        <NoWarn>$(NoWarn),CA1707</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
@@ -12,7 +17,6 @@
         <PackageReference Include="NSwag.Core.Yaml" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
-        <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
         <PackageReference Include="NodaTime" />
     </ItemGroup>
 

--- a/src/NJsonSchema.sln
+++ b/src/NJsonSchema.sln
@@ -32,6 +32,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "00 Build", "00 Build", "{863B2D88-A0BD-4466-8583-AAD0B8D3F182}"
 	ProjectSection(SolutionItems) = preProject
 		..\Directory.Build.props = ..\Directory.Build.props
+		..\Directory.Packages.props = ..\Directory.Packages.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "_build", "..\build\_build.csproj", "{8E4E5A64-B5B7-4718-A92F-CB6B08512264}"

--- a/src/NJsonSchema/Generation/JsonSchemaGeneratorSettings.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGeneratorSettings.cs
@@ -64,7 +64,7 @@ namespace NJsonSchema.Generation
         /// <summary>Gets or sets a value indicating whether to generate xmlObject representation for definitions (default: false).</summary>
         public bool GenerateXmlObjects { get; set; }
 
-        /// <summary>Gets or sets a value indicating whether to ignore properties with the <see cref="ObsoleteAttribute"/>.</summary>
+        /// <summary>Gets or sets a value indicating whether to ignore properties with the <see cref="T:ObsoleteAttribute"/>.</summary>
         public bool IgnoreObsoleteProperties { get; set; }
 
         /// <summary>Gets or sets a value indicating whether to use $ref references even if additional properties are

--- a/src/NJsonSchema/NJsonSchema.csproj
+++ b/src/NJsonSchema/NJsonSchema.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net6.0' ">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 


### PR DESCRIPTION
* latest dependencies
* target `net472` consistently for test projects
* remove unnecessary `dotnet-xunit` reference
* remove unused `using`s in test projects
* remove problematic constructors for NBench based tests which no longer work properly (BenchmarkDotNet has superseded these anyway I guess)
* ensure GitHubActionsTestLogger is in use