### PR TITLE
C# Generator: Generate range for different formats

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/ValidationAttributesTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/ValidationAttributesTests.cs
@@ -189,7 +189,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             Assert.Null(schema.Properties["value"].Minimum);
             Assert.Equal(10, schema.Properties["value"].ActualSchema.Minimum);
 
-            Assert.Contains("[System.ComponentModel.DataAnnotations.Range(10D, double.MaxValue)]\n" +
+            Assert.Contains("[System.ComponentModel.DataAnnotations.Range(10L, long.MaxValue)]\n" +
                             "        public long Value { get; set; }\n", code);
         }
 
@@ -229,7 +229,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             Assert.Equal(10000000000m, schema.Properties["value"].ActualSchema.Maximum);
 
             // expect the integer to be converted to an int64
-            Assert.Contains("[System.ComponentModel.DataAnnotations.Range(-10000000000D, 10000000000D)]\n" +
+            Assert.Contains("[System.ComponentModel.DataAnnotations.Range(-10000000000L, 10000000000L)]\n" +
                             "        public long Value { get; set; }\n", code);
         }
 

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/ValueGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/ValueGeneratorTests.cs
@@ -33,6 +33,43 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             Assert.Contains("[System.ComponentModel.DataAnnotations.Range(2, int.MaxValue)]", code);
         }
 
+        [Theory]
+        [InlineData("integer", JsonFormatStrings.Integer, "1, int.MaxValue")]
+        [InlineData("integer", JsonFormatStrings.Long, "1L, long.MaxValue")]
+        [InlineData("integer", JsonFormatStrings.ULong, "1UL, ulong.MaxValue")]
+        [InlineData("number", JsonFormatStrings.Float, "1F, float.MaxValue")]
+        [InlineData("number", JsonFormatStrings.Double, "1D, double.MaxValue")]
+        [InlineData("number", JsonFormatStrings.Decimal, "1M, decimal.MaxValue")]
+        public async Task When_schema_contains_range_and_format_then_code_is_correctly_generated(string propertyType,
+            string propertyFormat, string expectedRange)
+        {
+            /// Arrange
+            var json = $$"""
+                         {
+                             "type": "object",
+                             "properties": {
+                                "pageSize": {
+                                 	"type": "{{propertyType}}",
+                                 	"format": "{{propertyFormat}}",
+                                 	"minimum": 1
+                                },
+                                 }
+                             }
+                         """;
+            var schema = await JsonSchema.FromJsonAsync(json);
+
+            //// Act
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings
+            {
+                ClassStyle = CSharpClassStyle.Poco,
+                SchemaType = SchemaType.Swagger2
+            });
+            var code = generator.GenerateFile("MyClass");
+
+            //// Assert
+            Assert.Contains($"[System.ComponentModel.DataAnnotations.Range({expectedRange})]", code);
+        }
+
         [Fact]
         public async Task When_property_is_integer_and_no_format_is_available_then_default_value_is_int32()
         {

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpValueGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpValueGenerator.cs
@@ -98,6 +98,8 @@ namespace NJsonSchema.CodeGeneration.CSharp
                     return Convert.ToInt32(value, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture);
                 case JsonFormatStrings.Long:
                     return Convert.ToInt64(value, CultureInfo.InvariantCulture) + "L";
+                case JsonFormatStrings.ULong:
+                    return Convert.ToUInt64(value, CultureInfo.InvariantCulture) + "UL";
                 case JsonFormatStrings.Double:
                     return ConvertNumberToString(value) + "D";
                 case JsonFormatStrings.Float:

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
@@ -8,6 +8,7 @@
 
 using NJsonSchema.Annotations;
 using System.Globalization;
+using System.Linq;
 using NJsonSchema.CodeGeneration.Models;
 
 namespace NJsonSchema.CodeGeneration.CSharp.Models
@@ -18,6 +19,16 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
         private readonly JsonSchemaProperty _property;
         private readonly CSharpGeneratorSettings _settings;
         private readonly CSharpTypeResolver _resolver;
+        private static readonly string[] RangeFormats =
+        [
+            JsonFormatStrings.Integer,
+            JsonFormatStrings.Float,
+            JsonFormatStrings.Double,
+            JsonFormatStrings.Long,
+            JsonFormatStrings.ULong,
+            JsonFormatStrings.Decimal
+        ];
+
 
         /// <summary>Initializes a new instance of the <see cref="PropertyModel"/> class.</summary>
         /// <param name="classTemplateModel">The class template model.</param>
@@ -139,8 +150,8 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
             {
                 var schema = _property.ActualSchema;
                 var propertyFormat = GetSchemaFormat(schema);
-                var format = propertyFormat == JsonFormatStrings.Integer ? JsonFormatStrings.Integer : JsonFormatStrings.Double;
-                var type = propertyFormat == JsonFormatStrings.Integer ? "int" : "double";
+                var format = GetRangeFormat(propertyFormat);
+                var type = GetRangeType(propertyFormat);
 
                 var minimum = schema.Minimum;
                 if (minimum.HasValue && schema.IsExclusiveMinimum)
@@ -171,8 +182,8 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
             {
                 var schema = _property.ActualSchema;
                 var propertyFormat = GetSchemaFormat(schema);
-                var format = propertyFormat == JsonFormatStrings.Integer ? JsonFormatStrings.Integer : JsonFormatStrings.Double;
-                var type = propertyFormat == JsonFormatStrings.Integer ? "int" : "double";
+                var format = GetRangeFormat(propertyFormat);
+                var type = GetRangeType(propertyFormat);
 
                 var maximum = schema.Maximum;
                 if (maximum.HasValue && schema.IsExclusiveMaximum)
@@ -311,5 +322,20 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
 
             return schema.Format;
         }
+
+        private static string GetRangeFormat(string? propertyFormat) =>
+            RangeFormats.Contains(propertyFormat) ? propertyFormat! : JsonFormatStrings.Double;
+        
+        private static string GetRangeType(string? propertyFormat) =>
+            propertyFormat switch
+            {
+                JsonFormatStrings.Integer => "int",
+                JsonFormatStrings.Float => "float",
+                JsonFormatStrings.Double => "double",
+                JsonFormatStrings.Long => "long",
+                JsonFormatStrings.ULong => "ulong",
+                JsonFormatStrings.Decimal => "decimal",
+                _ => "double",
+            };
     }
 }


### PR DESCRIPTION
This is an attempt at generating C# Range annotations that supports more formats. My problem was that this property:
```
myProperty:
  type: integer
  format: int64
  minimum: 0
```
Generated this C# code:
```
[Newtonsoft.Json.JsonProperty("myProperty", Required = Newtonsoft.Json.Required.Always)]
[System.ComponentModel.DataAnnotations.Range(0D, double.MaxValue)]
public long MyProperty { get; set; }
```
The code was defaulting to using double values if the format was not int32. In my example it should use `0L, long.MaxValue`. Now it should use the correct suffixes and the correct max values.