### PR TITLE
Add support for non-string discriminators using System.Text.Json

### DIFF
--- a/src/NJsonSchema.Tests/Generation/SystemTextJson/SystemTextJsonInheritanceTests.cs
+++ b/src/NJsonSchema.Tests/Generation/SystemTextJson/SystemTextJsonInheritanceTests.cs
@@ -106,6 +106,46 @@ namespace NJsonSchema.Tests.Generation.SystemTextJson
                     """.ReplaceLineEndings(), data);
         }
 
+        public class Dalmation : Dog
+        {
+            public string Foo { get; set; }
+        }
+
+        public class Poodle : Dog
+        {
+            public string Bar { get; set; }
+        }
+
+        [JsonDerivedType(typeof(Dalmation), 1)]
+        [JsonDerivedType(typeof(Poodle), 2)]
+        [JsonPolymorphic(TypeDiscriminatorPropertyName = "breed")]
+        public class Dog
+        {
+            public string Baz { get; set; }
+        }
+
+        [Fact]
+        public async Task When_using_native_attributes_and_integer_discriminator_in_SystemTextJson_then_schema_is_correct()
+        {
+            //// Act
+            var schema = JsonSchema.FromType<Dog>();
+            var data = schema.ToJson().ReplaceLineEndings();
+
+            //// Assert
+            Assert.NotNull(data);
+            Assert.Contains(@"""1"": """, data);
+            Assert.Contains(@"""2"": """, data);
+            Assert.Contains(
+                """
+                      "discriminator": {
+                        "propertyName": "breed",
+                        "mapping": {
+                          "1": "#/definitions/Dalmation",
+                          "2": "#/definitions/Poodle"
+                        }
+                      },
+                    """.ReplaceLineEndings(), data);
+        }
 #endif
     }
 }

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -1141,9 +1141,9 @@ namespace NJsonSchema.Generation
 
             public string DiscriminatorName { get; }
 
-            public string GetDiscriminatorValue(Type type)
+            public string? GetDiscriminatorValue(Type type)
             {
-                return _jsonDerivedTypeAttributes.FirstOrDefault(a => a.DerivedType == type)?.TypeDiscriminator
+                return _jsonDerivedTypeAttributes.FirstOrDefault(a => a.DerivedType == type)?.TypeDiscriminator?.ToString()
                     ?? throw new InvalidOperationException($"Discriminator value for {type.FullName} not found.");
             }
         }


### PR DESCRIPTION
System.Text.Json supports non-string discriminators using JsonDerivedType.  This PR stringifies the discriminator value.

Fixes #1723

From https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/polymorphism?pivots=dotnet-8-0#mix-and-match-type-discriminator-formats
```
[JsonDerivedType(typeof(ThreeDimensionalPoint), typeDiscriminator: 3)]
[JsonDerivedType(typeof(FourDimensionalPoint), typeDiscriminator: "4d")]
public class BasePoint
{
    public int X { get; set; }
    public int Y { get; set; }
}

public class ThreeDimensionalPoint : BasePoint
{
    public int Z { get; set; }
}

public sealed class FourDimensionalPoint : ThreeDimensionalPoint
{
    public int W { get; set; }
}
```