### PR TITLE
Fix: Resolve escaped "/" and "~" in JSON references

### DIFF
--- a/src/NJsonSchema/JsonReferenceResolver.cs
+++ b/src/NJsonSchema/JsonReferenceResolver.cs
@@ -84,6 +84,11 @@ namespace NJsonSchema
             return await ResolveReferenceAsync(rootObject, jsonPath, targetType, contractResolver, false, cancellationToken).ConfigureAwait(false);
         }
 
+        private static string UnescapeReferenceSegment(string segment)
+        {
+            return segment.Replace("~1", "/").Replace("~0", "~");
+        }
+
         /// <summary>Resolves a document reference.</summary>
         /// <param name="rootObject">The root object.</param>
         /// <param name="jsonPath">The JSON path to resolve.</param>
@@ -94,6 +99,11 @@ namespace NJsonSchema
         public virtual IJsonReference ResolveDocumentReference(object rootObject, string jsonPath, Type targetType, IContractResolver contractResolver)
         {
             var allSegments = jsonPath.Split('/').Skip(1).ToList();
+            for (int i = 0; i < allSegments.Count; i++)
+            {
+                allSegments[i] = UnescapeReferenceSegment(allSegments[i]);
+            }
+
             var schema = ResolveDocumentReference(rootObject, allSegments, targetType, contractResolver, new HashSet<object>());
             if (schema == null)
             {


### PR DESCRIPTION
Fixes #1573 and #1703 

In JSON references, the character "~" and "/" should be escaped as "~0" and "~1", respectively [(RFC 6901)](https://www.rfc-editor.org/rfc/rfc6901#section-3). The current version of JsonReferenceResolver would fail on resolving these references.

This fix adds support to ref paths containing these special chars by substituting them with "/"  and "~" for each reference segment. Note that it replaces "~1" first to avoid transforming "~01" to "/" incorrectly (which should be "~1").