### PR TITLE
fixes #1728 return null when subType is not found, fixes Stackoverflow exception

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/JsonInheritanceConverter.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/JsonInheritanceConverter.liquid
@@ -100,7 +100,7 @@ public class JsonInheritanceConverter<TBase> : System.Text.Json.Serialization.Js
                 return attribute.Type;
         }
 
-        return objectType;
+        return null;
     }
 
     private string GetSubtypeDiscriminator(System.Type objectType)


### PR DESCRIPTION
Fixes #1728 

I do not know how to test it. The generated code in the liquid file is not the same a the 'real' ```NJsonSchema.Converters.JsonInheritanceConverter<TBase>```, which has tests.

Also the 'real' code of ```GetObjectSubtype``` returns a null value when subType is not found.
so the fix got to be right! ;)

```
private static Type? GetObjectSubtype(Type baseType, string discriminatorValue)
{
    var jsonInheritanceAttributes = baseType
        .GetTypeInfo()
        .GetCustomAttributes(true)
        .OfType<JsonInheritanceAttribute>();

    return jsonInheritanceAttributes.SingleOrDefault(a => a.Key == discriminatorValue)?.Type;
}
```