### PR TITLE
Bump Fluid.Core

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.9" />
-    <PackageVersion Include="Fluid.Core" Version="2.9.0" />
+    <PackageVersion Include="Fluid.Core" Version="2.11.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />

--- a/src/NJsonSchema.CodeGeneration/DefaultTemplateFactory.cs
+++ b/src/NJsonSchema.CodeGeneration/DefaultTemplateFactory.cs
@@ -308,7 +308,7 @@ namespace NJsonSchema.CodeGeneration
             }
 
             private static ValueTask<Completion> RenderTemplate(
-                List<Expression> arguments,
+                IReadOnlyList<Expression> arguments,
                 TextWriter writer,
                 TextEncoder encoder,
                 TemplateContext context)


### PR DESCRIPTION
[Fluid.Core](https://github.com/sebastienros/fluid/blob/0de3b07a5eeba650d69f19849fa62255fa1b4ca9/Fluid/FluidParser.cs#L522) has a breaking change between 2.9.0 and 2.11.1 because Parlot, the library Fluid.Core depends on, has a [breaking change](https://github.com/sebastienros/parlot/pull/103/files#diff-075f3dea19a91e058660dfe2a77be11a72a2d4fbbcf24441ec6a5f9a46869540L9) which propagated to Fluid.Core between 2.9.0 and 2.11.1.

This change bumps Fluid.Core and transitively upgraded Parlot to bring in the change.