### PR TITLE
configurable fieldname

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpGeneratorSettings.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpGeneratorSettings.cs
@@ -164,5 +164,11 @@ namespace NJsonSchema.CodeGeneration.CSharp
 
         /// <summary>Generate C# 9.0 record types instead of record-like classes.</summary>
         public bool GenerateNativeRecords { get; set; }
+
+        /// <summary>
+        /// The prefix appended when generating a field based on the property name. Default is "_";
+        /// </summary>
+        public string FieldNamePrefix { get; set; } = "_";
+        
     }
 }

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
@@ -9,6 +9,7 @@
 using NJsonSchema.Annotations;
 using System.Globalization;
 using NJsonSchema.CodeGeneration.Models;
+using System.Runtime;
 
 namespace NJsonSchema.CodeGeneration.CSharp.Models
 {
@@ -49,7 +50,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
         public string? Description => _property.Description;
 
         /// <summary>Gets the name of the field.</summary>
-        public string FieldName => "_" + ConversionUtilities.ConvertToLowerCamelCase(PropertyName, true);
+        public string FieldName => _settings.FieldNamePrefix + ConversionUtilities.ConvertToLowerCamelCase(PropertyName, true);
 
         /// <summary>Gets a value indicating whether the property is nullable.</summary>
         public override bool IsNullable => (_settings.GenerateOptionalPropertiesAsNullable && !_property.IsRequired) || base.IsNullable;


### PR DESCRIPTION
Because the naming convention for properties in JsonSchema is not very standardized, we have property names like "_id".
When the CSharpGeneratorSettings.ClassStyle setting is Inpc, the field name generation logic causes the automatically generated field _id for the property Id to have the same name as the property _id. We hope to be able to customize the prefix.