### PR TITLE
Prepare for NET 9 SDK analysis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,7 @@ jobs:
           MYGET_API_KEY: ${{ secrets.MYGET_API_KEY }}
       - name: 'Publish: artifacts'
         uses: actions/upload-artifact@v4
+        if: runner.os == 'Windows'
         with:
           name: artifacts
           path: artifacts
@@ -70,6 +71,7 @@ jobs:
           MYGET_API_KEY: ${{ secrets.MYGET_API_KEY }}
       - name: 'Publish: artifacts'
         uses: actions/upload-artifact@v4
+        if: runner.os == 'Windows'
         with:
           name: artifacts
           path: artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@
 #
 #     - To turn off auto-generation set:
 #
-#         [GitHubActions (AutoGenerate = false)]
+#         [CustomGitHubActions (AutoGenerate = false)]
 #
 #     - To trigger manual generation invoke:
 #
@@ -33,6 +33,10 @@ jobs:
     name: windows-latest
     runs-on: windows-latest
     steps:
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0
       - uses: actions/checkout@v4
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v4
@@ -56,6 +60,10 @@ jobs:
     name: ubuntu-latest
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0
       - uses: actions/checkout@v4
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,7 @@
 #
 #     - To turn off auto-generation set:
 #
-#         [GitHubActions (AutoGenerate = false)]
+#         [CustomGitHubActions (AutoGenerate = false)]
 #
 #     - To trigger manual generation invoke:
 #
@@ -34,6 +34,10 @@ jobs:
     name: windows-latest
     runs-on: windows-latest
     steps:
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0
       - uses: actions/checkout@v4
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v4
@@ -48,6 +52,10 @@ jobs:
     name: ubuntu-latest
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0
       - uses: actions/checkout@v4
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v4

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,12 +33,43 @@
         <AnalysisLevel>latest-Recommended</AnalysisLevel>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         <!--
+          [IDE0005] Using directive is unnecessary
+          [IDE0008] Use explicit type instead of 'var'
+          [IDE0019] Use pattern matching
+          [IDE0021] Use block body for constructor
+          [IDE0022] Use block body for method
+          [IDE0025] Use expression body for property
+          [IDE0027] Use expression body for accessor
+          [IDE0028] Collection initialization can be simplified
+          [IDE0029] Null check can be simplified
+          [IDE0032] Use auto property
+          [IDE0039] Use local function]
+          [IDE0045] 'if' statement can be simplified]
+          [IDE0046] 'if' statement can be simplified
+          [IDE0055] Fix formatting
+          [IDE0057] Substring can be simplified
+          [IDE0059] Unnecessary assignment of a value
+          [IDE0060] Remove unused parameter
+          [IDE0074] Use compound assignment
+          [IDE0078] Use pattern matching
+          [IDE0083] Use pattern matching
+          [IDE0090] 'new' expression can be simplified
+          [IDE0100] Remove redundant equality
+          [IDE0130] Namespace does not match folder structure
+          [IDE0160] Convert to block scoped namespace
+          [IDE0260] Use pattern matching
+          [IDE0290] Use primary constructor
+          [IDE0300] Collection initialization can be simplified
+          [IDE0301] Collection initialization can be simplified
+          [IDE0305] Collection initialization can be simplified
+          [IDE1005] Delegate invocation can be simplified
           [CA1200] Avoid using cref tags with a prefix
           [CA1510] Use 'ArgumentNullException.ThrowIfNull' instead of explicitly throwing a new exception instance
           [CA1716] rename parameter property so that it no longer conflicts with the reserved language keyword
           [CA1720] Identifier 'xxx' contains type name
+          [CA2263] Prefer the generic overload 'System.Enum.GetValues<TEnum>()'
         -->
-        <NoWarn>$(NoWarn);CA1200;CA1510;CA1716;CA1720</NoWarn>
+        <NoWarn>$(NoWarn);IDE0005;IDE0008;IDE0019;IDE0021;IDE0022;IDE0025;IDE0027;IDE0028;IDE0029;IDE0032;IDE0039;IDE0045;IDE0046;IDE0055;IDE0057;IDE0059;IDE0060;IDE0074;IDE0078;IDE0083;IDE0090;IDE0100;IDE0130;IDE0160;IDE0260;IDE0290;IDE0300;IDE0301;IDE0305;IDE1005;CA1200;CA1510;CA1716;CA1720;CA2263</NoWarn>
     </PropertyGroup>
 
 </Project>

--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -21,6 +21,7 @@ using Nuke.Common.CI.GitHubActions;
     OnPushIncludePaths = ["**/*.*"],
     OnPushExcludePaths = ["**/*.md"],
     PublishArtifacts = true,
+    PublishCondition = "runner.os == 'Windows'",
     InvokedTargets = [nameof(Compile), nameof(Test), nameof(Pack), nameof(Publish)],
     ImportSecrets = ["NUGET_API_KEY", "MYGET_API_KEY"],
     CacheKeyFiles = ["global.json", "src/**/*.csproj", "src/**/package.json"])

--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -1,6 +1,10 @@
+using System.Collections.Generic;
 using Nuke.Common.CI.GitHubActions;
+using Nuke.Common.CI.GitHubActions.Configuration;
+using Nuke.Common.Execution;
+using Nuke.Common.Utilities;
 
-[GitHubActions(
+[CustomGitHubActions(
     "pr",
     GitHubActionsImage.WindowsLatest,
     GitHubActionsImage.UbuntuLatest,
@@ -12,7 +16,7 @@ using Nuke.Common.CI.GitHubActions;
     CacheKeyFiles = ["global.json", "src/**/*.csproj", "src/**/package.json"],
     ConcurrencyCancelInProgress = true)
 ]
-[GitHubActions(
+[CustomGitHubActions(
     "build",
     GitHubActionsImage.WindowsLatest,
     GitHubActionsImage.UbuntuLatest,
@@ -27,3 +31,54 @@ using Nuke.Common.CI.GitHubActions;
     CacheKeyFiles = ["global.json", "src/**/*.csproj", "src/**/package.json"])
 ]
 public partial class Build;
+
+class CustomGitHubActionsAttribute : GitHubActionsAttribute
+{
+    public CustomGitHubActionsAttribute(string name, GitHubActionsImage image, params GitHubActionsImage[] images) : base(name, image, images)
+    {
+    }
+
+    protected override GitHubActionsJob GetJobs(GitHubActionsImage image, IReadOnlyCollection<ExecutableTarget> relevantTargets)
+    {
+        var job = base.GetJobs(image, relevantTargets);
+
+        var newSteps = new List<GitHubActionsStep>(job.Steps);
+
+        // only need to list the ones that are missing from default image
+        newSteps.Insert(0, new GitHubActionsSetupDotNetStep(["9.0"]));
+
+        job.Steps = newSteps.ToArray();
+        return job;
+    }
+}
+
+class GitHubActionsSetupDotNetStep : GitHubActionsStep
+{
+    public GitHubActionsSetupDotNetStep(string[] versions)
+    {
+        Versions = versions;
+    }
+
+    string[] Versions { get; }
+
+    public override void Write(CustomFileWriter writer)
+    {
+        writer.WriteLine("- uses: actions/setup-dotnet@v4");
+
+        using (writer.Indent())
+        {
+            writer.WriteLine("with:");
+            using (writer.Indent())
+            {
+                writer.WriteLine("dotnet-version: |");
+                using (writer.Indent())
+                {
+                    foreach (var version in Versions)
+                    {
+                        writer.WriteLine(version);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="8.1.4" />
+    <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
   </ItemGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.100",
     "rollForward": "latestMinor"
   }
 }

--- a/src/NJsonSchema.Benchmark/Program.cs
+++ b/src/NJsonSchema.Benchmark/Program.cs
@@ -10,7 +10,9 @@ namespace NJsonSchema.Benchmark
             BenchmarkDotNet.Running.BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).RunAllJoined();
         }
 
+#pragma warning disable IDE0051
         private static void RunCsharpBenchmark()
+#pragma warning restore IDE0051
         {
             var benchmark = new CsharpGeneratorBenchmark();
             benchmark.Setup().GetAwaiter().GetResult();

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/DefaultPropertyTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/DefaultPropertyTests.cs
@@ -91,8 +91,10 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             }");
 
             //// Act
-            var settings = new CSharpGeneratorSettings();
-            settings.GenerateDefaultValues = true;
+            var settings = new CSharpGeneratorSettings
+            {
+                GenerateDefaultValues = true
+            };
 
             var generator = new CSharpGenerator(document, settings);
             var code = generator.GenerateFile();
@@ -117,8 +119,10 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             }");
 
             //// Act
-            var settings = new CSharpGeneratorSettings();
-            settings.GenerateDefaultValues = true;
+            var settings = new CSharpGeneratorSettings
+            {
+                GenerateDefaultValues = true
+            };
 
             var generator = new CSharpGenerator(document, settings);
             var code = generator.GenerateFile();
@@ -149,8 +153,10 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             }");
 
             // Act
-            var settings = new CSharpGeneratorSettings();
-            settings.GenerateDefaultValues = true;
+            var settings = new CSharpGeneratorSettings
+            {
+                GenerateDefaultValues = true
+            };
 
             var generator = new CSharpGenerator(document, settings);
             var code = generator.GenerateFile();
@@ -181,8 +187,10 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             }");
 
             // Act
-            var settings = new CSharpGeneratorSettings();
-            settings.GenerateDefaultValues = true;
+            var settings = new CSharpGeneratorSettings
+            {
+                GenerateDefaultValues = true
+            };
 
             var generator = new CSharpGenerator(document, settings);
             var code = generator.GenerateFile();

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/GeneralGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/GeneralGeneratorTests.cs
@@ -66,14 +66,15 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             AssertCompile(output);
         }
 
-        class CustomPropertyNameGenerator : IPropertyNameGenerator
+        private class CustomPropertyNameGenerator : IPropertyNameGenerator
         {
             public string Generate(JsonSchemaProperty property)
             {
                 return "MyCustom" + ConversionUtilities.ConvertToUpperCamelCase(property.Name, true);
             }
         }
-        class CustomTypeNameGenerator : ITypeNameGenerator
+
+        private class CustomTypeNameGenerator : ITypeNameGenerator
         {
             public string Generate(JsonSchema schema, string typeNameHint, IEnumerable<string> reservedTypeNames)
             {
@@ -134,10 +135,12 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             //// Arrange
             var schema = NewtonsoftJsonSchemaGenerator.FromType<Teacher>();
             var schemaData = schema.ToJson();
-            var settings = new CSharpGeneratorSettings();
+            var settings = new CSharpGeneratorSettings
+            {
+                TypeNameGenerator = new CustomTypeNameGenerator(),
+                PropertyNameGenerator = new CustomPropertyNameGenerator()
+            };
 
-            settings.TypeNameGenerator = new CustomTypeNameGenerator();
-            settings.PropertyNameGenerator = new CustomPropertyNameGenerator();
             var generator = new CSharpGenerator(schema, settings);
 
             //// Act
@@ -454,8 +457,10 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
         {
             var schema = NewtonsoftJsonSchemaGenerator.FromType<Teacher>();
             var schemaData = schema.ToJson();
-            var settings = new CSharpGeneratorSettings();
-            settings.Namespace = "MyNamespace";
+            var settings = new CSharpGeneratorSettings
+            {
+                Namespace = "MyNamespace"
+            };
             var generator = new CSharpGenerator(schema, settings);
             return generator;
         }
@@ -664,11 +669,16 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
         public void When_object_has_generic_name_then_it_is_transformed()
         {
             //// Arrange
-            var schema = new JsonSchema();
-            schema.Type = JsonObjectType.Object;
-            schema.Properties["foo"] = new JsonSchemaProperty
+            var schema = new JsonSchema
             {
-                Type = JsonObjectType.Number
+                Type = JsonObjectType.Object,
+                Properties =
+                {
+                    ["foo"] = new JsonSchemaProperty
+                    {
+                        Type = JsonObjectType.Number
+                    }
+                }
             };
 
             //// Act

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpGenerator.cs
@@ -144,7 +144,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
                     number++;
                 }
 
-                propertyWithSameNameAsClass.PropertyName = propertyWithSameNameAsClass.PropertyName + number;
+                propertyWithSameNameAsClass.PropertyName += number;
             }
         }
 

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
@@ -268,7 +268,9 @@ namespace NJsonSchema.CodeGeneration.CSharp
             };
 
             if (string.IsNullOrWhiteSpace(numberType))
+            {
                 numberType = "double";
+            }
 
             return isNullable ? numberType + "?" : numberType;
         }

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/EnumTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/EnumTemplateModel.cs
@@ -168,7 +168,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
             }
             else
             {
-                valueInt64 = default(long);
+                valueInt64 = default;
                 return false;
             }
         }

--- a/src/NJsonSchema.CodeGeneration.Tests/InheritanceSerializationTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/InheritanceSerializationTests.cs
@@ -189,10 +189,7 @@ namespace NJsonSchema.CodeGeneration.Tests
             var tasks = new List<Task>();
             for (int i = 0; i < 100; i++)
             {
-                tasks.Add(Task.Run(async () =>
-                {
-                    await When_JsonInheritanceConverter_is_used_then_inheritance_is_correctly_serialized_and_deserialized();
-                }));
+                tasks.Add(Task.Run(When_JsonInheritanceConverter_is_used_then_inheritance_is_correctly_serialized_and_deserialized));
             }
 
             //// Act
@@ -300,12 +297,7 @@ namespace NJsonSchema.CodeGeneration.Tests
             var code = generator.GenerateFile();
 
             var assembly = Compile(code);
-            var type = assembly.GetType("foo.Foo");
-            if (type == null)
-            {
-                throw new Exception("Foo not found in " + String.Join(", ", assembly.GetTypes().Select(t => t.Name)));
-            }
-
+            var type = assembly.GetType("foo.Foo") ?? throw new Exception("Foo not found in " + String.Join(", ", assembly.GetTypes().Select(t => t.Name)));
             var bar = JsonConvert.DeserializeObject(@"{""discriminator"":""bar""}", type);
 
             //// Assert
@@ -331,19 +323,17 @@ namespace NJsonSchema.CodeGeneration.Tests
                 MetadataReference.CreateFromFile(coreDir.FullName + Path.DirectorySeparatorChar + "System.Linq.Expressions.dll"),
                 MetadataReference.CreateFromFile(coreDir.FullName + Path.DirectorySeparatorChar + "System.Runtime.Extensions.dll"));
 
-            using (var stream = new MemoryStream())
+            using var stream = new MemoryStream();
+            var result = compilation.Emit(stream);
+
+            if (!result.Success)
             {
-                var result = compilation.Emit(stream);
-
-                if (!result.Success)
-                {
-                    throw new Exception(String.Join(", ", result.Diagnostics
-                        .Where(diagnostic => diagnostic.IsWarningAsError || diagnostic.Severity == DiagnosticSeverity.Error)
-                        .Select(d => d.Location.GetLineSpan().StartLinePosition + " - " + d.GetMessage())) + "\n" + code);
-                }
-
-                return Assembly.Load(stream.GetBuffer());
+                throw new Exception(String.Join(", ", result.Diagnostics
+                    .Where(diagnostic => diagnostic.IsWarningAsError || diagnostic.Severity == DiagnosticSeverity.Error)
+                    .Select(d => d.Location.GetLineSpan().StartLinePosition + " - " + d.GetMessage())) + "\n" + code);
             }
+
+            return Assembly.Load(stream.GetBuffer());
         }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.Tests/LiquidTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/LiquidTests.cs
@@ -79,7 +79,7 @@ namespace NJsonSchema.CodeGeneration.Tests
             var template1 = templateFactory.CreateTemplate("csharp", "elseif", new object());
 
             // Act
-            var ex = Assert.Throws<InvalidOperationException>(() => template1.Render());
+            var ex = Assert.Throws<InvalidOperationException>(template1.Render);
 
             // Assert
             Assert.Contains(", did you use 'elseif' instead of correct 'elsif'?", ex.Message);

--- a/src/NJsonSchema.CodeGeneration.Tests/NJsonSchema.CodeGeneration.Tests.csproj
+++ b/src/NJsonSchema.CodeGeneration.Tests/NJsonSchema.CodeGeneration.Tests.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFrameworks>net8.0;net472</TargetFrameworks>
         <IsPackable>false</IsPackable>
-        <NoWarn>$(NoWarn),1998,1591,618</NoWarn>
+        <NoWarn>$(NoWarn),1998,1591,618,IDE1006</NoWarn>
         <Nullable>disable</Nullable>
         <EnableNETAnalyzers>false</EnableNETAnalyzers>
     </PropertyGroup>

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptGenerator.cs
@@ -53,8 +53,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
         /// <returns>The code.</returns>
         public override IEnumerable<CodeArtifact> GenerateTypes()
         {
-            _extensionCode = _extensionCode ??
-                new TypeScriptExtensionCode(Settings.ExtensionCode, Settings.ExtendedClasses);
+            _extensionCode ??= new TypeScriptExtensionCode(Settings.ExtensionCode, Settings.ExtendedClasses);
 
             return GenerateTypes(_extensionCode);
         }

--- a/src/NJsonSchema.CodeGeneration/DefaultEnumNameGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration/DefaultEnumNameGenerator.cs
@@ -14,8 +14,7 @@ namespace NJsonSchema.CodeGeneration
     /// <summary>The default enumeration name generator.</summary>
     public class DefaultEnumNameGenerator : IEnumNameGenerator
     {
-        private readonly static Regex _invalidNameCharactersPattern = new Regex(@"[^\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}\p{Mn}\p{Mc}\p{Nd}\p{Pc}\p{Cf}]");
-        private const string _defaultReplacementCharacter = "_";
+        private static readonly Regex _invalidNameCharactersPattern = new Regex(@"[^\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}\p{Mn}\p{Mc}\p{Nd}\p{Pc}\p{Cf}]");
 
         /// <summary>Generates the enumeration name/key of the given enumeration entry.</summary>
         /// <param name="index">The index of the enumeration value (check <see cref="JsonSchema.Enumeration" /> and <see cref="JsonSchema.EnumerationNames" />).</param>

--- a/src/NJsonSchema.CodeGeneration/DefaultTemplateFactory.cs
+++ b/src/NJsonSchema.CodeGeneration/DefaultTemplateFactory.cs
@@ -49,7 +49,7 @@ namespace NJsonSchema.CodeGeneration
             return new LiquidTemplate(
                 language,
                 template,
-                (lang, name) => GetLiquidTemplate(lang, name),
+                GetLiquidTemplate,
                 model,
                 GetToolchainVersion(),
                 _settings);
@@ -91,10 +91,8 @@ namespace NJsonSchema.CodeGeneration
             var resource = assembly.GetManifestResourceStream(resourceName);
             if (resource != null)
             {
-                using (var reader = new StreamReader(resource))
-                {
-                    return reader.ReadToEnd();
-                }
+                using var reader = new StreamReader(resource);
+                return reader.ReadToEnd();
             }
 
             throw new InvalidOperationException("Could not load template '" + template + "' for language '" + language + "'.");

--- a/src/NJsonSchema.Demo/Program.cs
+++ b/src/NJsonSchema.Demo/Program.cs
@@ -10,7 +10,7 @@ namespace NJsonSchema.Demo
 {
     public class Program
     {
-        static void Main(string[] args)
+        private static void Main(string[] args)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {

--- a/src/NJsonSchema.NewtonsoftJson/Converters/JsonExceptionConverter.cs
+++ b/src/NJsonSchema.NewtonsoftJson/Converters/JsonExceptionConverter.cs
@@ -106,14 +106,13 @@ namespace NJsonSchema.NewtonsoftJson.Converters
                 return null;
             }
 
-            var newSerializer = new JsonSerializer();
-            newSerializer.ContractResolver = (IContractResolver)Activator.CreateInstance(serializer.ContractResolver.GetType());
+            var newSerializer = new JsonSerializer
+            {
+                ContractResolver = (IContractResolver)Activator.CreateInstance(serializer.ContractResolver.GetType())
+            };
 
             var field = JsonExceptionConverter.GetField(typeof(DefaultContractResolver), "_sharedCache");
-            if (field != null)
-            {
-                field.SetValue(newSerializer.ContractResolver, false);
-            }
+            field?.SetValue(newSerializer.ContractResolver, false);
 
             dynamic resolver = newSerializer.ContractResolver;
             if (newSerializer.ContractResolver.GetType().GetRuntimeProperty("IgnoreSerializableAttribute") != null)
@@ -126,8 +125,7 @@ namespace NJsonSchema.NewtonsoftJson.Converters
                 resolver.IgnoreSerializableInterface = true;
             }
 
-            JToken? token;
-            if (jObject.TryGetValue("discriminator", StringComparison.OrdinalIgnoreCase, out token))
+            if (jObject.TryGetValue("discriminator", StringComparison.OrdinalIgnoreCase, out JToken? token))
             {
                 var discriminator = token.Value<string>();
                 if (objectType.Name.Equals(discriminator, StringComparison.Ordinal) == false)
@@ -175,10 +173,7 @@ namespace NJsonSchema.NewtonsoftJson.Converters
                         else
                         {
                             field = JsonExceptionConverter.GetField(objectType, "_" + fieldNameSuffix);
-                            if (field != null)
-                            {
-                                field.SetValue(value, propertyValue);
-                            }
+                            field?.SetValue(value, propertyValue);
                         }
                     }
                 }

--- a/src/NJsonSchema.NewtonsoftJson/Generation/NewtonsoftJsonSchemaGeneratorSettings.cs
+++ b/src/NJsonSchema.NewtonsoftJson/Generation/NewtonsoftJsonSchemaGeneratorSettings.cs
@@ -18,7 +18,7 @@ namespace NJsonSchema.NewtonsoftJson.Generation
     /// <inheritdoc />
     public class NewtonsoftJsonSchemaGeneratorSettings : JsonSchemaGeneratorSettings
     {
-        private Dictionary<string, JsonContract?> _cachedContracts = new Dictionary<string, JsonContract?>();
+        private readonly Dictionary<string, JsonContract?> _cachedContracts = new();
 
         private JsonSerializerSettings _serializerSettings;
 

--- a/src/NJsonSchema.Yaml/JsonAndYamlReferenceResolver.cs
+++ b/src/NJsonSchema.Yaml/JsonAndYamlReferenceResolver.cs
@@ -28,8 +28,10 @@ namespace NJsonSchema.Yaml
         /// <returns>The factory.</returns>
         public static Func<JsonSchema, JsonReferenceResolver> CreateJsonAndYamlReferenceResolverFactory(ITypeNameGenerator typeNameGenerator)
         {
-            JsonReferenceResolver ReferenceResolverFactory(JsonSchema schema) =>
-                new JsonAndYamlReferenceResolver(new JsonSchemaAppender(schema, typeNameGenerator));
+            JsonReferenceResolver ReferenceResolverFactory(JsonSchema schema)
+            {
+                return new JsonAndYamlReferenceResolver(new JsonSchemaAppender(schema, typeNameGenerator));
+            }
 
             return ReferenceResolverFactory;
         }

--- a/src/NJsonSchema/Collections/ObservableDictionary.cs
+++ b/src/NJsonSchema/Collections/ObservableDictionary.cs
@@ -107,8 +107,7 @@ namespace NJsonSchema.Collections
         /// <param name="add">If true and key already exists then an exception is thrown. </param>
         private void Insert(TKey key, TValue? value, bool add)
         {
-            TValue? item;
-            if (_dictionary.TryGetValue(key, out item))
+            if (_dictionary.TryGetValue(key, out TValue? item))
             {
                 if (add)
                 {
@@ -215,9 +214,6 @@ namespace NJsonSchema.Collections
             {
                 throw new ArgumentNullException(nameof(key));
             }
-
-            TValue? value;
-            _dictionary.TryGetValue(key, out value);
 
             var removed = _dictionary.Remove(key);
             if (removed)

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -270,7 +270,7 @@ namespace NJsonSchema.Generation
                             }
                             else
                             {
-                                schema.Type = schema.Type | JsonObjectType.Null;
+                                schema.Type |= JsonObjectType.Null;
                             }
                         }
                         else if (Settings.SchemaType == SchemaType.OpenApi3 || Settings.GenerateCustomNullableProperties)

--- a/src/NJsonSchema/Infrastructure/DynamicApis.cs
+++ b/src/NJsonSchema/Infrastructure/DynamicApis.cs
@@ -51,20 +51,18 @@ namespace NJsonSchema.Infrastructure
                 throw new NotSupportedException("The System.Net.Http.HttpClient API is not available on this platform.");
             }
 
-            using (dynamic handler = (IDisposable)Activator.CreateInstance(HttpClientHandlerType!)!)
-            using (dynamic client = (IDisposable)Activator.CreateInstance(HttpClientType!, new[] { handler })!)
-            {
-                handler.UseDefaultCredentials = true;
+            using dynamic handler = (IDisposable)Activator.CreateInstance(HttpClientHandlerType!)!;
+            using dynamic client = (IDisposable)Activator.CreateInstance(HttpClientType!, new[] { handler })!;
+            handler.UseDefaultCredentials = true;
 
-                // enable all decompression methods
-                var calculatedAllValue = GenerateAllDecompressionMethodsEnumValue();
-                var allDecompressionMethodsValue = Enum.ToObject(DecompressionMethodsType!, calculatedAllValue);
-                handler.AutomaticDecompression = (dynamic)allDecompressionMethodsValue;
+            // enable all decompression methods
+            var calculatedAllValue = GenerateAllDecompressionMethodsEnumValue();
+            var allDecompressionMethodsValue = Enum.ToObject(DecompressionMethodsType!, calculatedAllValue);
+            handler.AutomaticDecompression = (dynamic)allDecompressionMethodsValue;
 
-                var response = await client.GetAsync(url, cancellationToken).ConfigureAwait(false);
-                response.EnsureSuccessStatusCode();
-                return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-            }
+            var response = await client.GetAsync(url, cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
         }
 
         // see https://learn.microsoft.com/en-us/dotnet/api/system.net.decompressionmethods?view=net-7.0
@@ -121,8 +119,6 @@ namespace NJsonSchema.Infrastructure
                     if (Directory.Exists(fileDir))
                     {
                         var fileName = Path.GetFileName(fullPath);
-                        var pathPieces = fullPath.Replace("\\", "/").Split('/');
-                        var subDirPiece = pathPieces[pathPieces.Length - 2];
                         foreach (var subDir in Directory.GetDirectories(fileDir))
                         {
                             var expectedFile = Path.Combine(subDir, fileName);

--- a/src/NJsonSchema/Infrastructure/TypeExtensions.cs
+++ b/src/NJsonSchema/Infrastructure/TypeExtensions.cs
@@ -19,8 +19,8 @@ namespace NJsonSchema.Infrastructure
     /// <summary>Provides extension methods for reading contextual type names and descriptions.</summary>
     public static class TypeExtensions
     {
-        private static ReaderWriterLockSlim _namesLock = new ReaderWriterLockSlim();
-        private static Dictionary<ContextualMemberInfo, string> _names = new Dictionary<ContextualMemberInfo, string>();
+        private static readonly ReaderWriterLockSlim _namesLock = new();
+        private static readonly Dictionary<ContextualMemberInfo, string> _names = new();
 
         /// <summary>Gets the name of the property for JSON serialization.</summary>
         /// <returns>The name.</returns>

--- a/src/NJsonSchema/JsonReferenceResolver.cs
+++ b/src/NJsonSchema/JsonReferenceResolver.cs
@@ -40,8 +40,10 @@ namespace NJsonSchema
         /// <returns>The factory.</returns>
         public static Func<JsonSchema, JsonReferenceResolver> CreateJsonReferenceResolverFactory(ITypeNameGenerator typeNameGenerator)
         {
-            JsonReferenceResolver ReferenceResolverFactory(JsonSchema schema) =>
-                new JsonReferenceResolver(new JsonSchemaAppender(schema, typeNameGenerator));
+            JsonReferenceResolver ReferenceResolverFactory(JsonSchema schema)
+            {
+                return new JsonReferenceResolver(new JsonSchemaAppender(schema, typeNameGenerator));
+            }
 
             return ReferenceResolverFactory;
         }
@@ -99,16 +101,13 @@ namespace NJsonSchema
         public virtual IJsonReference ResolveDocumentReference(object rootObject, string jsonPath, Type targetType, IContractResolver contractResolver)
         {
             var allSegments = jsonPath.Split('/').Skip(1).ToList();
-            for (int i = 0; i < allSegments.Count; i++)
+            for (var i = 0; i < allSegments.Count; i++)
             {
                 allSegments[i] = UnescapeReferenceSegment(allSegments[i]);
             }
 
-            var schema = ResolveDocumentReference(rootObject, allSegments, targetType, contractResolver, new HashSet<object>());
-            if (schema == null)
-            {
-                throw new InvalidOperationException("Could not resolve the path '" + jsonPath + "'.");
-            }
+            var schema = ResolveDocumentReference(rootObject, allSegments, targetType, contractResolver, new HashSet<object>())
+                         ?? throw new InvalidOperationException($"Could not resolve the path '{jsonPath}'.");
 
             return schema;
         }
@@ -299,8 +298,7 @@ namespace NJsonSchema
             }
             else if (obj is IEnumerable)
             {
-                int index;
-                if (int.TryParse(firstSegment, out index))
+                if (int.TryParse(firstSegment, out var index))
                 {
                     var enumerable = ((IEnumerable)obj).Cast<object>().ToArray();
                     if (enumerable.Length > index)

--- a/src/NJsonSchema/JsonSchema.Serialization.cs
+++ b/src/NJsonSchema/JsonSchema.Serialization.cs
@@ -291,7 +291,7 @@ namespace NJsonSchema
             {
                 if (value is JArray)
                 {
-                    Items = new ObservableCollection<JsonSchema>(((JArray)value).Select(t => FromJsonWithCurrentSettings(t)));
+                    Items = new ObservableCollection<JsonSchema>(((JArray)value).Select(FromJsonWithCurrentSettings));
                 }
                 else if (value != null)
                 {

--- a/src/NJsonSchema/Validation/JsonSchemaValidator.cs
+++ b/src/NJsonSchema/Validation/JsonSchemaValidator.cs
@@ -49,15 +49,13 @@ namespace NJsonSchema.Validation
         /// <returns>The list of validation errors.</returns>
         public ICollection<ValidationError> Validate(string jsonData, JsonSchema schema, SchemaType schemaType = SchemaType.JsonSchema)
         {
-            using (var reader = new StringReader(jsonData))
-            using (var jsonReader = new JsonTextReader(reader)
+            using var reader = new StringReader(jsonData);
+            using var jsonReader = new JsonTextReader(reader)
             {
                 DateParseHandling = DateParseHandling.None
-            })
-            {
-                var jsonObject = JToken.ReadFrom(jsonReader);
-                return Validate(jsonObject, schema, schemaType);
-            }
+            };
+            var jsonObject = JToken.ReadFrom(jsonReader);
+            return Validate(jsonObject, schema, schemaType);
         }
 
         /// <summary>Validates the given JSON token.</summary>
@@ -417,7 +415,7 @@ namespace NJsonSchema.Validation
             return !string.IsNullOrEmpty(propertyPath) ? propertyPath + "." + propertyName : propertyName;
         }
 
-        private static void ValidateMaxProperties(JToken token, IList<JProperty> properties, JsonSchema schema, string? propertyName, string propertyPath, List<ValidationError> errors)
+        private static void ValidateMaxProperties(JToken token, List<JProperty> properties, JsonSchema schema, string? propertyName, string propertyPath, List<ValidationError> errors)
         {
             if (schema.MaxProperties > 0 && properties.Count > schema.MaxProperties)
             {
@@ -425,7 +423,7 @@ namespace NJsonSchema.Validation
             }
         }
 
-        private static void ValidateMinProperties(JToken token, IList<JProperty> properties, JsonSchema schema, string? propertyName, string propertyPath, List<ValidationError> errors)
+        private static void ValidateMinProperties(JToken token, List<JProperty> properties, JsonSchema schema, string? propertyName, string propertyPath, List<ValidationError> errors)
         {
             if (schema.MinProperties > 0 && properties.Count < schema.MinProperties)
             {


### PR DESCRIPTION
NET 9 SDK has more rules and will cause build problems. Creating a TODO list for focused PRs in `Directory.Build.props` via `NoWarn` items, fixing small easy wins inside the PR. Now compiles with NET 9 SDK. All changes made with IDE automation.