### PR TITLE
Make IgnoreEmptyCollectionsContractResolver special case ICollection.Count check

### DIFF
--- a/src/NJsonSchema/Infrastructure/IgnoreEmptyCollectionsContractResolver.cs
+++ b/src/NJsonSchema/Infrastructure/IgnoreEmptyCollectionsContractResolver.cs
@@ -15,25 +15,30 @@ namespace NJsonSchema.Infrastructure
 {
     internal sealed class IgnoreEmptyCollectionsContractResolver : PropertyRenameAndIgnoreSerializerContractResolver
     {
+        private static readonly TypeInfo enumerableType = typeof(IEnumerable).GetTypeInfo();
+
         protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
         {
             var property = base.CreateProperty(member, memberSerialization);
 
-            if ((property.Required == Required.Default || property.Required == Required.DisallowNull) &&
+            if (property.Required is Required.Default or Required.DisallowNull &&
+                property.PropertyType is { IsPrimitive: false } &&
                 property.PropertyType != typeof(string) &&
-                typeof(IEnumerable).GetTypeInfo().IsAssignableFrom(property.PropertyType?.GetTypeInfo()))
+                enumerableType.IsAssignableFrom(property.PropertyType.GetTypeInfo()))
             {
                 property.ShouldSerialize = instance =>
                 {
-                    var enumerable = instance != null ? property.ValueProvider?.GetValue(instance) as IEnumerable : null;
-                    if (enumerable != null)
+                    var value = instance != null ? property.ValueProvider?.GetValue(instance) : null;
+                    if (value is ICollection collection)
+                    {
+                        return collection.Count > 0;
+                    }
+                    if (value is IEnumerable enumerable)
                     {
                         return enumerable.GetEnumerator().MoveNext();
                     }
-                    else
-                    {
-                        return true;
-                    }
+
+                    return true;
                 };
             }
 


### PR DESCRIPTION
When checked target is `IEnumerable`, it's highly likely to implement `ICollection`. `ICollection.Count` is basically free and doesn't require enumerator building and boxing.

Testing with https://github.com/martincostello/aspnetcore-openapi/tree/main/perf/TodoApp.Benchmarks configured to run against local sources.

master

3,273,252.20 ns

this PR:

3,064,969.34 ns

