### PR TITLE
Keep Original Enum Names for Reuse in Custom Templates

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/EnumTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/EnumTemplateModel.cs
@@ -75,6 +75,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                                 entries.Add(new EnumerationItemModel
                                 {
                                     Name = _settings.EnumNameGenerator.Generate(i, name, value, _schema),
+                                    OriginalName = name,
                                     Value = value.ToString(),
                                     InternalValue = valueInt64.ToString(CultureInfo.InvariantCulture),
                                     InternalFlagValue = valueInt64.ToString(CultureInfo.InvariantCulture)
@@ -85,6 +86,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                                 entries.Add(new EnumerationItemModel
                                 {
                                     Name = _settings.EnumNameGenerator.Generate(i, name, value, _schema),
+                                    OriginalName = name,
                                     Value = value.ToString(),
                                     InternalValue = value.ToString(),
                                     InternalFlagValue = (1 << i).ToString(CultureInfo.InvariantCulture)
@@ -99,6 +101,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                             entries.Add(new EnumerationItemModel
                             {
                                 Name = _settings.EnumNameGenerator.Generate(i, name, value, _schema),
+                                OriginalName = name,
                                 Value = value.ToString(),
                                 InternalValue = i.ToString(CultureInfo.InvariantCulture),
                                 InternalFlagValue = (1 << i).ToString(CultureInfo.InvariantCulture)

--- a/src/NJsonSchema.CodeGeneration.TypeScript/Models/EnumTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Models/EnumTemplateModel.cs
@@ -60,6 +60,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Models
                         entries.Add(new EnumerationItemModel
                         {
                             Name = _settings.EnumNameGenerator.Generate(i, name, value, _schema),
+                            OriginalName = name,
                             Value = _schema.Type.IsInteger() ? value.ToString() : "\"" + value + "\"",
                         });
                     }

--- a/src/NJsonSchema.CodeGeneration/Models/EnumerationItemModel.cs
+++ b/src/NJsonSchema.CodeGeneration/Models/EnumerationItemModel.cs
@@ -14,6 +14,9 @@ namespace NJsonSchema.CodeGeneration.Models
         /// <summary>Gets or sets the name.</summary>
         public required string Name { get; set; }
 
+        /// <summary>Gets or sets the original name.</summary>
+        public required string OriginalName { get; set; }
+
         /// <summary>Gets or sets the value.</summary>
         public required string Value { get; set; }
 


### PR DESCRIPTION
This PR introduces a new feature to retain the original enum names in the schema, allowing them to be reused in custom templates.

Custom templates often require the original/unchanged enum names (for proper annotations or description as an example). This enhancement ensures greater flexibility and customization for developers using NJsonSchema with custom enum templates.