### PR TITLE
SampleJsonSchemaGenerator: Generate JSONSchema for openapi

### DIFF
--- a/src/NJsonSchema.Tests/Generation/SampleJsonSchemaGeneratorTests.cs
+++ b/src/NJsonSchema.Tests/Generation/SampleJsonSchemaGeneratorTests.cs
@@ -10,6 +10,7 @@ namespace NJsonSchema.Tests.Generation
             // Arrange
             var data = @"{
                 int: 1, 
+                float: 340282346638528859811704183484516925440.0,
                 str: ""abc"", 
                 bool: true, 
                 date: ""2012-07-19"", 
@@ -26,6 +27,7 @@ namespace NJsonSchema.Tests.Generation
             Assert.Equal(JsonObjectType.Integer, schema.Properties["int"].Type);
             Assert.Equal(JsonObjectType.String, schema.Properties["str"].Type);
             Assert.Equal(JsonObjectType.Boolean, schema.Properties["bool"].Type);
+            Assert.Equal(JsonObjectType.Number, schema.Properties["float"].Type);
 
             Assert.Equal(JsonObjectType.String, schema.Properties["date"].Type);
             Assert.Equal(JsonFormatStrings.Date, schema.Properties["date"].Format);
@@ -35,6 +37,36 @@ namespace NJsonSchema.Tests.Generation
 
             Assert.Equal(JsonObjectType.String, schema.Properties["timespan"].Type);
             Assert.Equal(JsonFormatStrings.Duration, schema.Properties["timespan"].Format);
+        }
+
+        [Fact]
+        public void OpenApi3Properties()
+        {
+            // Arrange
+            var data = @"{
+                int: 12345, 
+                long: 1736347656630,
+                float: 340282346638528859811704183484516925440.0,
+                double: 340282346638528859811704183484516925440123456.0,
+            }";
+            var generator = new SampleJsonSchemaGenerator(new SampleJsonSchemaGeneratorSettings {SchemaType = SchemaType.OpenApi3});
+
+            // Act
+            var schema = generator.Generate(data);
+            var json = schema.ToJson();
+
+            // Assert
+            Assert.Equal(JsonObjectType.Integer, schema.Properties["int"].Type);
+            Assert.Equal(JsonFormatStrings.Integer, schema.Properties["int"].Format);
+
+            Assert.Equal(JsonObjectType.Integer, schema.Properties["long"].Type);
+            Assert.Equal(JsonFormatStrings.Long, schema.Properties["long"].Format);
+
+            Assert.Equal(JsonObjectType.Number, schema.Properties["float"].Type);
+            Assert.Equal(JsonFormatStrings.Float, schema.Properties["float"].Format);
+
+            Assert.Equal(JsonObjectType.Number, schema.Properties["double"].Type);
+            Assert.Equal(JsonFormatStrings.Double, schema.Properties["double"].Format);
         }
 
         [Fact]

--- a/src/NJsonSchema/SampleJsonSchemaGenerator.cs
+++ b/src/NJsonSchema/SampleJsonSchemaGenerator.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.Text.RegularExpressions;
+
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -15,6 +16,25 @@ namespace NJsonSchema
     /// <summary>Generates a JSON Schema from sample JSON data.</summary>
     public class SampleJsonSchemaGenerator
     {
+        private readonly SampleJsonSchemaGeneratorSettings _settings;
+
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        public SampleJsonSchemaGenerator()
+        {
+            _settings = new SampleJsonSchemaGeneratorSettings();
+        }
+
+        /// <summary>
+        /// Constructor with settings
+        /// </summary>
+        /// <param name="settings"></param>
+        public SampleJsonSchemaGenerator(SampleJsonSchemaGeneratorSettings settings)
+        {
+            _settings = settings;
+        }
+
         /// <summary>Generates the JSON Schema for the given JSON data.</summary>
         /// <param name="json">The JSON data.</param>
         /// <returns>The JSON Schema.</returns>
@@ -155,6 +175,35 @@ namespace NJsonSchema
             if (schema.Type == JsonObjectType.String && Regex.IsMatch(token.Value<string>()!, "^[0-9][0-9]:[0-9][0-9](:[0-9][0-9])?$"))
             {
                 schema.Format = JsonFormatStrings.Duration;
+            }
+
+            if (_settings.SchemaType == SchemaType.OpenApi3)
+            {
+                if (schema.Type == JsonObjectType.Integer)
+                {
+                    var value = token.Value<long?>();
+                    if (value is < int.MinValue or > int.MaxValue)
+                    {
+                        schema.Format = JsonFormatStrings.Long;
+                    }
+                    else
+                    {
+                        schema.Format = JsonFormatStrings.Integer;
+                    }
+                }
+
+                if (schema.Type == JsonObjectType.Number)
+                {
+                    var value = token.Value<double?>();
+                    if (value is < float.MinValue or > float.MaxValue)
+                    {
+                        schema.Format = JsonFormatStrings.Double;
+                    }
+                    else
+                    {
+                        schema.Format = JsonFormatStrings.Float;
+                    }
+                }
             }
         }
 

--- a/src/NJsonSchema/SampleJsonSchemaGeneratorSettings.cs
+++ b/src/NJsonSchema/SampleJsonSchemaGeneratorSettings.cs
@@ -1,0 +1,13 @@
+﻿namespace NJsonSchema
+{
+    /// <summary>
+    /// Settings for generating sample json schema
+    /// </summary>
+    public class SampleJsonSchemaGeneratorSettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether to generate optional properties (default: <see cref="SchemaType.JsonSchema"/>).
+        /// </summary>
+        public SchemaType SchemaType { get; set; } = SchemaType.JsonSchema;
+    }
+}


### PR DESCRIPTION
This pull request introduces support for generating JSON Schema numeric properties that comply with the OpenAPI specification.
