### PR TITLE
Add support for UTC date-only format (yyyy-MM-ddZ)

### DIFF
--- a/src/NJsonSchema.Tests/Validation/FormatDateTimeTests.cs
+++ b/src/NJsonSchema.Tests/Validation/FormatDateTimeTests.cs
@@ -107,5 +107,22 @@ namespace NJsonSchema.Tests.Validation
             // Assert
             Assert.Empty(errors);
         }
+        
+        [Fact]
+        public void When_format_date_time_with_utc_date_only_then_validation_succeeds()
+        {
+            // Arrange
+            var schema = new JsonSchema();
+            schema.Type = JsonObjectType.String;
+            schema.Format = JsonFormatStrings.DateTime;
+
+            var token = new JValue("2024-01-31Z");
+
+            // Act
+            var errors = schema.Validate(token);
+
+            // Assert
+            Assert.Empty(errors);
+        }
     }
 }

--- a/src/NJsonSchema/Validation/FormatValidators/DateTimeFormatValidator.cs
+++ b/src/NJsonSchema/Validation/FormatValidators/DateTimeFormatValidator.cs
@@ -26,7 +26,7 @@ namespace NJsonSchema.Validation.FormatValidators
             "yyyy-MM-dd'T'HH",
             "yyyy-MM-dd' 'HH",
             "yyyy-MM-dd",
-            "yyyy-MM-dd",
+            "yyyy-MM-dd'Z'",
             "yyyyMMdd",
             "yyyy-MM",
             "yyyy"


### PR DESCRIPTION
### Changes
- Add support for the UTC date-only format (`yyyy-MM-ddZ`) in the `DateTimeFormatValidator`.
- Removed a duplicate `yyyy-MM-dd` entry.
- Added test `When_format_date_time_with_utc_date_only_then_validation_succeeds`.