### PR TITLE
Decode percent-encoded characters in $ref URIs - Fix issue #1539

### DIFF
--- a/src/NJsonSchema.Tests/References/LocalReferencesTests.cs
+++ b/src/NJsonSchema.Tests/References/LocalReferencesTests.cs
@@ -180,6 +180,34 @@ namespace NJsonSchema.Tests.References
             Assert.Equal(JsonObjectType.Integer, schema.ActualTypeSchema.Type);
         }
 
+        [Fact]
+        public async Task When_percent_encoded_reference_is_passed_then_it_is_resolved_to_decoded_character()
+        {
+            // Arrange
+            var json = @"{
+  ""type"": ""object"",
+  ""properties"": {
+    ""length"": {
+      ""$ref"": ""#/definitions/%C2%B5m""
+    }
+  },
+  ""additionalProperties"": false,
+	""definitions"": {
+		""µm"": {
+              ""type"": ""string""
+            }
+        }
+}";
+
+            // Act
+            var schema = await JsonSchema.FromJsonAsync(json);
+
+            // Assert
+            Assert.Equal(JsonObjectType.String, schema.Properties["length"].ActualTypeSchema.Type); ;
+        }
+
+
+
         private string GetTestDirectory()
         {
             var codeBase = Assembly.GetExecutingAssembly().CodeBase.Replace("#", "%23");

--- a/src/NJsonSchema/JsonReferenceResolver.cs
+++ b/src/NJsonSchema/JsonReferenceResolver.cs
@@ -7,7 +7,9 @@
 //-----------------------------------------------------------------------
 
 using System.Collections;
+using System.Net;
 using System.Text.RegularExpressions;
+using System.Web;
 using Namotion.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -82,7 +84,8 @@ namespace NJsonSchema
 
         private static string UnescapeReferenceSegment(string segment)
         {
-            return segment.Replace("~1", "/").Replace("~0", "~");
+            var urlDecoded = WebUtility.UrlDecode(segment);
+            return urlDecoded.Replace("~1", "/").Replace("~0", "~");
         }
 
         /// <summary>Resolves a document reference.</summary>

--- a/src/NJsonSchema/JsonReferenceResolver.cs
+++ b/src/NJsonSchema/JsonReferenceResolver.cs
@@ -9,7 +9,6 @@
 using System.Collections;
 using System.Net;
 using System.Text.RegularExpressions;
-using System.Web;
 using Namotion.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;


### PR DESCRIPTION
Local references are URIs. As such, special characters must be encoded, but the tool did not do that, as detailled in https://github.com/RicoSuter/NJsonSchema/issues/1539

This PR decodes the URIs to make references with special characters work.