### PR TITLE
Fix '#' in typescript property names

### DIFF
--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptPropertyNameGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptPropertyNameGenerator.cs
@@ -12,7 +12,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
     public sealed class TypeScriptPropertyNameGenerator : IPropertyNameGenerator
     {
         private static readonly char[] _reservedFirstPassChars = ['"', '@', '?', '.', '=', '+'];
-        private static readonly char[] _reservedSecondPassChars = ['*', ':', '-'];
+        private static readonly char[] _reservedSecondPassChars = ['*', '#', ':', '-'];
 
         /// <summary>Gets or sets the reserved names.</summary>
         public HashSet<string> ReservedPropertyNames { get; set; } = new(StringComparer.Ordinal) { "constructor", "init", "fromJS", "toJSON" };
@@ -37,6 +37,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
             if (name.IndexOfAny(_reservedSecondPassChars) != -1)
             {
                 name = name.Replace("*", "Star")
+                    .Replace("#", "_")
                     .Replace(":", "_")
                     .Replace("-", "_");
             }


### PR DESCRIPTION
The JWK RFC allows for the property x5t#S256, but using # in a typescript property name is not valid according to the spec. So we can convert it to a _ instead.

Similar fix for typescript as #1073 did for C#. 
