### PR TITLE
Make JsonSchema.Enumeration property setter public

### DIFF
--- a/src/NJsonSchema/JsonSchema.cs
+++ b/src/NJsonSchema/JsonSchema.cs
@@ -505,7 +505,7 @@ namespace NJsonSchema
 
         /// <summary>Gets the collection of required properties. </summary>
         [JsonIgnore]
-        public ICollection<object?> Enumeration { get; internal set; }
+        public ICollection<object?> Enumeration { get; set; }
 
         /// <summary>Gets a value indicating whether this is enumeration.</summary>
         [JsonIgnore]


### PR DESCRIPTION
An access to this property is needed when NSwag's OpenApiParameter is created manually. 
cc: @RicoSuter