### PR TITLE
C# generator: create anoymous types with camel casing (reworked)

### DIFF
--- a/src/NJsonSchema/DefaultTypeNameGenerator.cs
+++ b/src/NJsonSchema/DefaultTypeNameGenerator.cs
@@ -103,6 +103,7 @@ namespace NJsonSchema
                 }
 
                 typeNameHint = GetLastSegment(typeNameHint)!;
+                typeNameHint = ConversionUtilities.ConvertToUpperCamelCase(typeNameHint, true);
 
                 if (typeNameHint != null &&
                     !reservedTypeNames.Contains(typeNameHint) && 
@@ -116,7 +117,7 @@ namespace NJsonSchema
                 do
                 {
                     count++;
-                    typeName = ConversionUtilities.ConvertToUpperCamelCase(typeNameHint + count, true);
+                    typeName = typeNameHint + count;
                 } while (reservedTypeNames.Contains(typeName));
 
                 return typeName;


### PR DESCRIPTION
This is the second attempt to fix https://github.com/RicoSuter/NSwag/issues/4849 and https://github.com/RicoSuter/NSwag/issues/4837 and a followup for #1716: since NSwag 14, the resulting C# file generated from a yaml file might contain lower case class names.
This seems to happen if an array item has as lower case type name hint (e.g. "data"), and a class "Data" was already generated.
In this situation, `DefaultTypeNameGenerator.GenerateAnonymousTypeName` does not call `ConversionUtilities.ConvertToUpperCamelCase` and thus picks the lower case class name "data" as "not used".

With my fix, it would generate a class "Data2" again.

The first fix worked locally for me because I had one additional line that I forget to add to my pull request. This request adds this line and removes an unneccesary `ConvertToUpperCamelCase` from the previous pull request (variable `typeNameHint` is already camel cased now).

Sorry for the confusion, I had some problems building/running NSwag/NJsonSchema and first added workaround code to my local NSwag copy, then applied it to NJsonSchema, where I lost one important line. But this time I really tested a fixed "NJsonSchema.dll" with NSwag console and can confirm that the generated cs file is valid ;-).