### PR TITLE
Support description for each x-enumNames value

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/EnumTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/EnumTemplateModel.cs
@@ -66,6 +66,8 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                     var value = _schema.Enumeration.ElementAt(i);
                     if (value != null)
                     {
+                        var description = _schema.EnumerationDescriptions.Count > i ?
+                            _schema.EnumerationDescriptions.ElementAt(i) : null;
                         if (_schema.Type.IsInteger())
                         {
                             var name = _schema.EnumerationNames.Count > i ?
@@ -78,6 +80,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                                     Name = _settings.EnumNameGenerator.Generate(i, name, value, _schema),
                                     OriginalName = name,
                                     Value = value.ToString()!,
+                                    Description = description,
                                     InternalValue = valueInt64.ToString(CultureInfo.InvariantCulture),
                                     InternalFlagValue = valueInt64.ToString(CultureInfo.InvariantCulture)
                                 });
@@ -89,6 +92,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                                     Name = _settings.EnumNameGenerator.Generate(i, name, value, _schema),
                                     OriginalName = name,
                                     Value = value.ToString()!,
+                                    Description = description,
                                     InternalValue = value.ToString(),
                                     InternalFlagValue = (1 << i).ToString(CultureInfo.InvariantCulture)
                                 });
@@ -104,6 +108,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                                 Name = _settings.EnumNameGenerator.Generate(i, name, value, _schema),
                                 OriginalName = name!,
                                 Value = value.ToString()!,
+                                Description = description,
                                 InternalValue = i.ToString(CultureInfo.InvariantCulture),
                                 InternalFlagValue = (1 << i).ToString(CultureInfo.InvariantCulture)
                             });

--- a/src/NJsonSchema.CodeGeneration.TypeScript/Models/EnumTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Models/EnumTemplateModel.cs
@@ -57,12 +57,15 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Models
                         var name = _schema.EnumerationNames.Count > i
                             ? _schema.EnumerationNames.ElementAt(i)
                             : _schema.Type.IsInteger() ? "_" + value : value.ToString()!;
+                        var description = _schema.EnumerationDescriptions.Count > i ?
+                            _schema.EnumerationDescriptions.ElementAt(i) : null;
 
                         entries.Add(new EnumerationItemModel
                         {
                             Name = _settings.EnumNameGenerator.Generate(i, name, value, _schema),
                             OriginalName = name,
                             Value = _schema.Type.IsInteger() ? value.ToString()! : "\"" + value + "\"",
+                            Description = description,
                         });
                     }
                 }

--- a/src/NJsonSchema.CodeGeneration/Models/EnumerationItemModel.cs
+++ b/src/NJsonSchema.CodeGeneration/Models/EnumerationItemModel.cs
@@ -20,6 +20,9 @@ namespace NJsonSchema.CodeGeneration.Models
         /// <summary>Gets or sets the value.</summary>
         public required string Value { get; set; }
 
+        /// <summary>Gets or sets the description.</summary>
+        public string? Description { get; set; }
+
         /// <summary>Gets or sets the internal value (e.g. the underlying/system value).</summary>
         public string? InternalValue { get; set; }
 

--- a/src/NJsonSchema.Tests/Generation/EnumTests.cs
+++ b/src/NJsonSchema.Tests/Generation/EnumTests.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using NJsonSchema.CodeGeneration.Tests;
 using NJsonSchema.NewtonsoftJson.Generation;
 
 namespace NJsonSchema.Tests.Generation
@@ -186,9 +187,7 @@ namespace NJsonSchema.Tests.Generation
             Assert.Null(schema.EnumerationDescriptions[2]); // No description for ThirdValue
 
             // Verify the JSON output contains the x-enumDescriptions property
-            Assert.Contains("\"x-enumDescriptions\"", json);
-            Assert.Contains("\"First value description\"", json);
-            Assert.Contains("\"Second value description\"", json);
+            await VerifyHelper.Verify(json);
         }
 
         [Fact]
@@ -210,9 +209,7 @@ namespace NJsonSchema.Tests.Generation
             var json = schema.ToJson();
 
             // Assert
-            Assert.Contains("\"x-enum-names\"", json);
-            Assert.Contains("\"Name1\"", json);
-            Assert.Contains("\"Name2\"", json);
+            await VerifyHelper.Verify(json);
         }
 
         [Fact]
@@ -234,9 +231,7 @@ namespace NJsonSchema.Tests.Generation
             var json = schema.ToJson();
 
             // Assert
-            Assert.Contains("\"x-enum-varnames\"", json);
-            Assert.Contains("\"VarName1\"", json);
-            Assert.Contains("\"VarName2\"", json);
+            await VerifyHelper.Verify(json);
         }
 
         [Fact]
@@ -260,9 +255,7 @@ namespace NJsonSchema.Tests.Generation
             var json = schema.ToJson();
 
             // Assert
-            Assert.Contains("\"x-enum-descriptions\"", json);
-            Assert.Contains("\"Desc1\"", json);
-            Assert.Contains("\"Desc2\"", json);
+            await VerifyHelper.Verify(json);
         }
     }
 }

--- a/src/NJsonSchema.Tests/Generation/Snapshots/EnumTests.When_enum_has_description_attributes_then_descriptions_are_included_in_schema.verified.txt
+++ b/src/NJsonSchema.Tests/Generation/Snapshots/EnumTests.When_enum_has_description_attributes_then_descriptions_are_included_in_schema.verified.txt
@@ -1,0 +1,36 @@
+﻿{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "EnumWithDescriptions",
+  "type": "string",
+  "description": "",
+  "x-enum-names": [
+    "FirstValue",
+    "SecondValue",
+    "ThirdValue"
+  ],
+  "x-enum-varnames": [
+    "FirstValue",
+    "SecondValue",
+    "ThirdValue"
+  ],
+  "x-enumNames": [
+    "FirstValue",
+    "SecondValue",
+    "ThirdValue"
+  ],
+  "x-enum-descriptions": [
+    "First value description",
+    "Second value description",
+    null
+  ],
+  "x-enumDescriptions": [
+    "First value description",
+    "Second value description",
+    null
+  ],
+  "enum": [
+    "FirstValue",
+    "SecondValue",
+    "ThirdValue"
+  ]
+}

--- a/src/NJsonSchema.Tests/Generation/Snapshots/EnumTests.When_schema_has_x_enum_descriptions_then_backward_compatibility_works.verified.txt
+++ b/src/NJsonSchema.Tests/Generation/Snapshots/EnumTests.When_schema_has_x_enum_descriptions_then_backward_compatibility_works.verified.txt
@@ -1,0 +1,19 @@
+﻿{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "string",
+  "x-enum-descriptions": [
+    "Desc1",
+    "Desc2",
+    null
+  ],
+  "x-enumDescriptions": [
+    "Desc1",
+    "Desc2",
+    null
+  ],
+  "enum": [
+    "value1",
+    "value2",
+    "value3"
+  ]
+}

--- a/src/NJsonSchema.Tests/Generation/Snapshots/EnumTests.When_schema_has_x_enum_names_then_backward_compatibility_works.verified.txt
+++ b/src/NJsonSchema.Tests/Generation/Snapshots/EnumTests.When_schema_has_x_enum_names_then_backward_compatibility_works.verified.txt
@@ -1,0 +1,20 @@
+﻿{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "string",
+  "x-enum-names": [
+    "Name1",
+    "Name2"
+  ],
+  "x-enum-varnames": [
+    "Name1",
+    "Name2"
+  ],
+  "x-enumNames": [
+    "Name1",
+    "Name2"
+  ],
+  "enum": [
+    "value1",
+    "value2"
+  ]
+}

--- a/src/NJsonSchema.Tests/Generation/Snapshots/EnumTests.When_schema_has_x_enum_varnames_then_backward_compatibility_works.verified.txt
+++ b/src/NJsonSchema.Tests/Generation/Snapshots/EnumTests.When_schema_has_x_enum_varnames_then_backward_compatibility_works.verified.txt
@@ -1,0 +1,20 @@
+﻿{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "string",
+  "x-enum-names": [
+    "VarName1",
+    "VarName2"
+  ],
+  "x-enum-varnames": [
+    "VarName1",
+    "VarName2"
+  ],
+  "x-enumNames": [
+    "VarName1",
+    "VarName2"
+  ],
+  "enum": [
+    "value1",
+    "value2"
+  ]
+}

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -14,6 +14,7 @@ using NJsonSchema.Converters;
 using NJsonSchema.Generation.TypeMappers;
 using NJsonSchema.Infrastructure;
 using System.Collections;
+using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -698,12 +699,23 @@ namespace NJsonSchema.Generation
             schema.Type = typeDescription.Type;
             schema.Enumeration.Clear();
             schema.EnumerationNames.Clear();
+            schema.EnumerationDescriptions.Clear();
             schema.IsFlagEnumerable = contextualType.IsAttributeDefined<FlagsAttribute>(true);
 
             Func<object, string?>? enumValueConverter = null;
             var underlyingType = Enum.GetUnderlyingType(contextualType.Type);
             foreach (var enumName in Enum.GetNames(contextualType.Type))
             {
+                string? enumDescription = null;
+                var field = contextualType.Type.GetRuntimeField(enumName);
+                // Retrieve the Description attribute value, if present.
+                var descriptionAttribute = field?.GetCustomAttribute<DescriptionAttribute>();
+
+                if (descriptionAttribute != null)
+                {
+                    enumDescription = descriptionAttribute.Description;
+                }
+
                 if (typeDescription.Type == JsonObjectType.Integer)
                 {
                     var value = Convert.ChangeType(Enum.Parse(contextualType.Type, enumName), underlyingType, CultureInfo.InvariantCulture);
@@ -712,7 +724,7 @@ namespace NJsonSchema.Generation
                 else
                 {
                     // EnumMember only checked if StringEnumConverter is used
-                    var enumMemberAttribute = contextualType.Type.GetRuntimeField(enumName)?.GetCustomAttribute<EnumMemberAttribute>();
+                    var enumMemberAttribute = field?.GetCustomAttribute<EnumMemberAttribute>();
                     if (enumMemberAttribute != null && !string.IsNullOrEmpty(enumMemberAttribute.Value))
                     {
                         schema.Enumeration.Add(enumMemberAttribute.Value);
@@ -726,6 +738,7 @@ namespace NJsonSchema.Generation
                 }
 
                 schema.EnumerationNames.Add(enumName);
+                schema.EnumerationDescriptions.Add(enumDescription);
             }
 
             if (typeDescription.Type == JsonObjectType.Integer && Settings.GenerateEnumMappingDescription)

--- a/src/NJsonSchema/JsonSchema.Serialization.cs
+++ b/src/NJsonSchema/JsonSchema.Serialization.cs
@@ -140,6 +140,10 @@ namespace NJsonSchema
         [JsonIgnore]
         public Collection<string> EnumerationNames { get; set; }
 
+        /// <summary>Gets or sets the enumeration descriptions (optional, draft v5). </summary>
+        [JsonIgnore]
+        public Collection<string?> EnumerationDescriptions { get; set; }
+
         /// <summary>Gets or sets a value indicating whether the maximum value is excluded. </summary>
         [JsonProperty("exclusiveMaximum", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         internal object? ExclusiveMaximumRaw
@@ -374,11 +378,58 @@ namespace NJsonSchema
         }
 
         /// <summary>Gets or sets the enumeration names (optional, draft v5). </summary>
+        [JsonProperty("x-enum-names", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        internal Collection<string>? EnumerationNamesDashedRaw
+        {
+            get => EnumerationNamesRaw;
+            set
+            {
+                if (EnumerationNamesRaw?.Count == 0 && value != null) {
+                    EnumerationNamesRaw = value;
+                }
+            }
+        }
+
+        /// <summary>Gets or sets the enumeration names (optional, draft v5). </summary>
+        [JsonProperty("x-enum-varnames", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        internal Collection<string>? EnumerationVarnamesRaw
+        {
+            get => EnumerationNamesRaw;
+            set
+            {
+                if (EnumerationNamesRaw?.Count == 0 && value != null) {
+                    EnumerationNamesRaw = value;
+                }
+            }
+        }
+
+        /// <summary>Gets or sets the enumeration names (optional, draft v5). </summary>
         [JsonProperty("x-enumNames", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         internal Collection<string>? EnumerationNamesRaw
         {
             get => EnumerationNames != null && EnumerationNames.Count > 0 ? EnumerationNames : null;
             set => EnumerationNames = value != null ? new ObservableCollection<string>(value) : [];
+        }
+
+        /// <summary>Gets or sets the enumeration descriptions (optional, draft v5). </summary>
+        [JsonProperty("x-enum-descriptions", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        internal Collection<string?>? EnumerationDescriptionsDashedRaw
+        {
+            get => EnumerationDescriptionsRaw;
+            set
+            {
+                if (EnumerationDescriptionsRaw?.Count == 0 && value != null) {
+                    EnumerationDescriptionsRaw = value;
+                }
+            }
+        }
+
+        /// <summary>Gets or sets the enumeration descriptions (optional, draft v5). </summary>
+        [JsonProperty("x-enumDescriptions", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        internal Collection<string?>? EnumerationDescriptionsRaw
+        {
+            get => EnumerationDescriptions != null && EnumerationDescriptions.Count > 0 ? EnumerationDescriptions : null;
+            set => EnumerationDescriptions = value != null ? new ObservableCollection<string?>(value) : [];
         }
 
         [JsonProperty("enum", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]

--- a/src/NJsonSchema/JsonSchema.cs
+++ b/src/NJsonSchema/JsonSchema.cs
@@ -1014,6 +1014,7 @@ namespace NJsonSchema
         [MemberNotNull(nameof(_oneOf))]
         [MemberNotNull(nameof(Enumeration))]
         [MemberNotNull(nameof(EnumerationNames))]
+        [MemberNotNull(nameof(EnumerationDescriptions))]
         private void Initialize()
 #pragma warning disable CS8774
         {
@@ -1027,6 +1028,7 @@ namespace NJsonSchema
             OneOf ??= new ObservableCollection<JsonSchema>();
             Enumeration ??= [];
             EnumerationNames ??= [];
+            EnumerationDescriptions ??= [];
         }
 #pragma warning restore CS8774
 


### PR DESCRIPTION
* **Enum Descriptions.** The code now extracts the description from the `System.ComponentModel.Description` attribute for each enum value and includes it in the schema under `x-enumDescriptions`.
* **Backward Compatibility for Enum Names.** Supports JSON property names by accepting `x-enumNames` as well as `x-enum-names` and `x-enum-varnames`.
* **Backward Compatibility for Enum Descriptions.** Similarly, the schema now accepts both `x-enumDescriptions` and `x-enum-descriptions`.

Close #1156