### PR TITLE
Add support for high precision dates

### DIFF
--- a/src/NJsonSchema.Tests/Validation/FormatDateTimeTests.cs
+++ b/src/NJsonSchema.Tests/Validation/FormatDateTimeTests.cs
@@ -107,7 +107,24 @@ namespace NJsonSchema.Tests.Validation
             // Assert
             Assert.Empty(errors);
         }
-        
+
+        [Fact]
+        public void When_format_date_time_with_iso8601_and_highprecision_seconds_then_validation_succeeds()
+        {
+            // Arrange
+            var schema = new JsonSchema();
+            schema.Type = JsonObjectType.String;
+            schema.Format = JsonFormatStrings.DateTime;
+
+            var token = new JValue("2015-01-25T15:43:30.123456789Z");
+
+            // Act
+            var errors = schema.Validate(token);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
         [Fact]
         public void When_format_date_time_with_utc_date_only_then_validation_succeeds()
         {

--- a/src/NJsonSchema/Validation/FormatValidators/DateTimeFormatValidator.cs
+++ b/src/NJsonSchema/Validation/FormatValidators/DateTimeFormatValidator.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 using Newtonsoft.Json.Linq;
 using System.Globalization;
+using System.Text.RegularExpressions;
 
 namespace NJsonSchema.Validation.FormatValidators
 {
@@ -32,6 +33,8 @@ namespace NJsonSchema.Validation.FormatValidators
             "yyyy"
         ];
 
+            private static readonly Regex _dateTimeRegexPattern = new(@"^((?:(\d{4}-\d{2}-\d{2})([Tt_]| )(\d{2}:\d{2}:\d{2}(?:\.\d+)?))([Zz]|[\+-]\d{2}:\d{2}))$", RegexOptions.Compiled, TimeSpan.FromMilliseconds(250));
+
         /// <summary>Gets the format attribute's value.</summary>
         public string Format { get; } = JsonFormatStrings.DateTime;
 
@@ -45,7 +48,8 @@ namespace NJsonSchema.Validation.FormatValidators
         public bool IsValid(string value, JTokenType tokenType)
         {
             return tokenType == JTokenType.Date 
-                || DateTimeOffset.TryParseExact(value, _acceptableFormats, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTimeOffset dateTimeResult);
+                || DateTimeOffset.TryParseExact(value, _acceptableFormats, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTimeOffset _)
+                || _dateTimeRegexPattern.Match(value).Success;
         }
     }
 }

--- a/src/NJsonSchema/Validation/FormatValidators/DateTimeFormatValidator.cs
+++ b/src/NJsonSchema/Validation/FormatValidators/DateTimeFormatValidator.cs
@@ -33,7 +33,9 @@ namespace NJsonSchema.Validation.FormatValidators
             "yyyy"
         ];
 
-            private static readonly Regex _dateTimeRegexPattern = new(@"^((?:(\d{4}-\d{2}-\d{2})([Tt_]| )(\d{2}:\d{2}:\d{2}(?:\.\d+)?))([Zz]|[\+-]\d{2}:\d{2}))$", RegexOptions.Compiled, TimeSpan.FromMilliseconds(250));
+        private static readonly Regex DateTimeRegexPattern =
+            new(@"^((?:(\d{4}-\d{2}-\d{2})([Tt_]| )(\d{2}:\d{2}:\d{2}(?:\.\d+)?))([Zz]|[\+-]\d{2}:\d{2}))$",
+                RegexOptions.Compiled, TimeSpan.FromMilliseconds(250));
 
         /// <summary>Gets the format attribute's value.</summary>
         public string Format { get; } = JsonFormatStrings.DateTime;
@@ -47,9 +49,9 @@ namespace NJsonSchema.Validation.FormatValidators
         /// <returns></returns>
         public bool IsValid(string value, JTokenType tokenType)
         {
-            return tokenType == JTokenType.Date 
-                || DateTimeOffset.TryParseExact(value, _acceptableFormats, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTimeOffset _)
-                || _dateTimeRegexPattern.Match(value).Success;
+            return tokenType == JTokenType.Date
+                   || DateTimeOffset.TryParseExact(value, _acceptableFormats, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTimeOffset _)
+                   || DateTimeRegexPattern.IsMatch(value);
         }
     }
 }


### PR DESCRIPTION
Fixes #1537 

Adds regex validation of date times with a higher precision.

