### PR TITLE
Use explicit using for System.Linq to make it easier to spot

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/AbstractSchemaTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/AbstractSchemaTests.cs
@@ -1,6 +1,5 @@
 ﻿using NJsonSchema.CodeGeneration.CSharp;
 using NJsonSchema.NewtonsoftJson.Generation;
-using Xunit;
 
 namespace NJsonSchema.CodeGeneration.Tests.CSharp.Generation
 {

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/AdditionalPropertiesTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/AdditionalPropertiesTests.cs
@@ -1,7 +1,6 @@
 using System.Text.RegularExpressions;
 using NJsonSchema.CodeGeneration.CSharp;
 using NJsonSchema.NewtonsoftJson.Generation;
-using Xunit;
 
 namespace NJsonSchema.CodeGeneration.Tests.CSharp
 {

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/AllOfTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/AllOfTests.cs
@@ -1,5 +1,4 @@
 ﻿using NJsonSchema.CodeGeneration.CSharp;
-using Xunit;
 
 namespace NJsonSchema.CodeGeneration.Tests.CSharp
 {

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/AnnotationsTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/AnnotationsTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using NJsonSchema.CodeGeneration.CSharp;
 using NJsonSchema.NewtonsoftJson.Generation;
-using Xunit;
 
 namespace NJsonSchema.CodeGeneration.Tests.CSharp
 {

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/ArrayTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/ArrayTests.cs
@@ -1,7 +1,6 @@
 ﻿using NJsonSchema.Annotations;
 using NJsonSchema.NewtonsoftJson.Generation;
 using System.ComponentModel.DataAnnotations;
-using Xunit;
 
 namespace NJsonSchema.CodeGeneration.CSharp.Tests
 {

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/CSharpJsonSerializerGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/CSharpJsonSerializerGeneratorTests.cs
@@ -1,6 +1,4 @@
-﻿using Xunit;
-
-namespace NJsonSchema.CodeGeneration.CSharp.Tests
+﻿namespace NJsonSchema.CodeGeneration.CSharp.Tests
 {
     public class CSharpJsonSerializerGeneratorTests
     {

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/DefaultPropertyTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/DefaultPropertyTests.cs
@@ -1,6 +1,4 @@
-﻿using Xunit;
-
-namespace NJsonSchema.CodeGeneration.CSharp.Tests
+﻿namespace NJsonSchema.CodeGeneration.CSharp.Tests
 {
     public class DefaultPropertyTests
     {

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/DictionaryTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/DictionaryTests.cs
@@ -1,6 +1,5 @@
 ﻿using NJsonSchema.NewtonsoftJson.Generation;
 using System.ComponentModel.DataAnnotations;
-using Xunit;
 
 namespace NJsonSchema.CodeGeneration.CSharp.Tests
 {

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/EnumTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/EnumTests.cs
@@ -2,7 +2,6 @@
 using Newtonsoft.Json.Converters;
 using NJsonSchema.CodeGeneration.CSharp;
 using NJsonSchema.NewtonsoftJson.Generation;
-using Xunit;
 
 namespace NJsonSchema.CodeGeneration.Tests.CSharp
 {

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/GeneralGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/GeneralGeneratorTests.cs
@@ -10,7 +10,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using NJsonSchema.Annotations;
 using NJsonSchema.NewtonsoftJson.Generation;
-using Xunit;
 
 namespace NJsonSchema.CodeGeneration.CSharp.Tests
 {

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/InheritanceInterfaceTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/InheritanceInterfaceTests.cs
@@ -3,7 +3,6 @@ using Newtonsoft.Json;
 using NJsonSchema.CodeGeneration.CSharp;
 using NJsonSchema.NewtonsoftJson.Converters;
 using NJsonSchema.NewtonsoftJson.Generation;
-using Xunit;
 
 namespace NJsonSchema.CodeGeneration.Tests.CSharp
 {

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/InheritanceTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/InheritanceTests.cs
@@ -4,7 +4,6 @@ using Newtonsoft.Json;
 using NJsonSchema.CodeGeneration.CSharp;
 using NJsonSchema.NewtonsoftJson.Converters;
 using NJsonSchema.NewtonsoftJson.Generation;
-using Xunit;
 
 namespace NJsonSchema.CodeGeneration.Tests.CSharp
 {

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/InterfaceTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/InterfaceTests.cs
@@ -1,5 +1,4 @@
 ﻿using NJsonSchema.NewtonsoftJson.Generation;
-using Xunit;
 
 namespace NJsonSchema.CodeGeneration.CSharp.Tests
 {

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/NullableEnumTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/NullableEnumTests.cs
@@ -1,5 +1,4 @@
 ﻿using NJsonSchema.CodeGeneration.CSharp;
-using Xunit;
 
 namespace NJsonSchema.CodeGeneration.Tests.CSharp
 {

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/NullableReferenceTypesTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/NullableReferenceTypesTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using NJsonSchema.CodeGeneration.CSharp;
 using NJsonSchema.NewtonsoftJson.Generation;
-using Xunit;
 
 namespace NJsonSchema.CodeGeneration.Tests.CSharp
 {

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/NullableTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/NullableTests.cs
@@ -1,7 +1,6 @@
 ﻿using NJsonSchema.CodeGeneration.CSharp;
 using NJsonSchema.NewtonsoftJson.Generation;
 using System.ComponentModel.DataAnnotations;
-using Xunit;
 
 namespace NJsonSchema.CodeGeneration.Tests.CSharp
 {

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/NumberTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/NumberTests.cs
@@ -1,5 +1,4 @@
 ﻿using NJsonSchema.CodeGeneration.CSharp;
-using Xunit;
 
 namespace NJsonSchema.CodeGeneration.Tests.CSharp;
 

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/ObjectPropertyRequiredTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/ObjectPropertyRequiredTests.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using NJsonSchema.CodeGeneration.CSharp;
 using NJsonSchema.NewtonsoftJson.Generation;
-using Xunit;
 
 namespace NJsonSchema.CodeGeneration.Tests.CSharp
 {

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/ObsoleteTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/ObsoleteTests.cs
@@ -1,6 +1,5 @@
 ﻿using NJsonSchema.CodeGeneration.CSharp;
 using NJsonSchema.NewtonsoftJson.Generation;
-using Xunit;
 
 namespace NJsonSchema.CodeGeneration.Tests.CSharp
 {

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/ReferencesTest.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/ReferencesTest.cs
@@ -2,7 +2,6 @@
 using NJsonSchema.CodeGeneration.CSharp;
 using NJsonSchema.Infrastructure;
 using System.Reflection;
-using Xunit;
 
 namespace NJsonSchema.CodeGeneration.Tests.CSharp
 {

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/StringPropertyRequiredTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/StringPropertyRequiredTests.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel.DataAnnotations;
 using NJsonSchema.NewtonsoftJson.Generation;
-using Xunit;
 
 namespace NJsonSchema.CodeGeneration.CSharp.Tests
 {

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/UriTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/UriTests.cs
@@ -1,6 +1,5 @@
 ﻿using Newtonsoft.Json;
 using NJsonSchema.NewtonsoftJson.Generation;
-using Xunit;
 
 namespace NJsonSchema.CodeGeneration.CSharp.Tests
 {

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpGenerator.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Linq;
 using NJsonSchema.CodeGeneration.CSharp.Models;
 
 namespace NJsonSchema.CodeGeneration.CSharp

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpJsonSerializerGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpJsonSerializerGenerator.cs
@@ -6,6 +6,8 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Linq;
+
 namespace NJsonSchema.CodeGeneration.CSharp
 {
     /// <summary>Generates JSON converter code.</summary>

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
@@ -6,6 +6,8 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Linq;
+
 namespace NJsonSchema.CodeGeneration.CSharp
 {
     /// <summary>Manages the generated types and converts JSON types to CSharp types. </summary>

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/ClassTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/ClassTemplateModel.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Linq;
 using NJsonSchema.CodeGeneration.Models;
 
 namespace NJsonSchema.CodeGeneration.CSharp.Models

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/DateFormatConverterTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/DateFormatConverterTemplateModel.cs
@@ -6,6 +6,8 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Linq;
+
 namespace NJsonSchema.CodeGeneration.CSharp.Models
 {
     /// <summary>The DateFormatConverterTemplateModel.</summary>

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/EnumTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/EnumTemplateModel.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.Globalization;
+using System.Linq;
 using NJsonSchema.CodeGeneration.Models;
 
 namespace NJsonSchema.CodeGeneration.CSharp.Models

--- a/src/NJsonSchema.CodeGeneration.CSharp/NJsonSchema.CodeGeneration.CSharp.csproj
+++ b/src/NJsonSchema.CodeGeneration.CSharp/NJsonSchema.CodeGeneration.CSharp.csproj
@@ -23,4 +23,8 @@
         <None Include="NuGetIcon.png" Pack="true" PackagePath="\" />
     </ItemGroup>
 
+    <ItemGroup>
+        <Using Remove="System.Linq" />
+    </ItemGroup>
+
 </Project>

--- a/src/NJsonSchema.CodeGeneration.Tests/DefaultGenerationTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/DefaultGenerationTests.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using NJsonSchema.CodeGeneration.CSharp;
 using NJsonSchema.NewtonsoftJson.Generation;
-using Xunit;
 
 namespace NJsonSchema.CodeGeneration.Tests
 {

--- a/src/NJsonSchema.CodeGeneration.Tests/DefaultValueGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/DefaultValueGeneratorTests.cs
@@ -1,6 +1,5 @@
 ﻿using NJsonSchema.CodeGeneration.CSharp;
 using NJsonSchema.CodeGeneration.TypeScript;
-using Xunit;
 
 namespace NJsonSchema.CodeGeneration.Tests
 {

--- a/src/NJsonSchema.CodeGeneration.Tests/EnumGenerationTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/EnumGenerationTests.cs
@@ -4,7 +4,6 @@ using Newtonsoft.Json.Converters;
 using NJsonSchema.CodeGeneration.CSharp;
 using NJsonSchema.CodeGeneration.TypeScript;
 using NJsonSchema.NewtonsoftJson.Generation;
-using Xunit;
 
 namespace NJsonSchema.CodeGeneration.Tests
 {

--- a/src/NJsonSchema.CodeGeneration.Tests/InheritanceSerializationTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/InheritanceSerializationTests.cs
@@ -5,7 +5,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using NJsonSchema.CodeGeneration.CSharp;
 using NJsonSchema.CodeGeneration.TypeScript;
-using Xunit;
 using System.Reflection;
 using System.CodeDom.Compiler;
 using NJsonSchema.NewtonsoftJson.Converters;

--- a/src/NJsonSchema.CodeGeneration.Tests/LiquidTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/LiquidTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Globalization;
 using Fluid;
 using NJsonSchema.CodeGeneration.TypeScript;
-using Xunit;
 
 namespace NJsonSchema.CodeGeneration.Tests
 {

--- a/src/NJsonSchema.CodeGeneration.Tests/Samples/SampleTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/Samples/SampleTests.cs
@@ -3,7 +3,6 @@ using System.ComponentModel.DataAnnotations;
 using Newtonsoft.Json.Linq;
 using NJsonSchema.CodeGeneration.TypeScript;
 using NJsonSchema.NewtonsoftJson.Generation;
-using Xunit;
 
 namespace NJsonSchema.CodeGeneration.Tests.Samples
 {

--- a/src/NJsonSchema.CodeGeneration.TypeScript/Models/ClassTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Models/ClassTemplateModel.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Linq;
 using NJsonSchema.CodeGeneration.Models;
 
 namespace NJsonSchema.CodeGeneration.TypeScript.Models

--- a/src/NJsonSchema.CodeGeneration.TypeScript/Models/EnumTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Models/EnumTemplateModel.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Linq;
 using NJsonSchema.CodeGeneration.Models;
 
 namespace NJsonSchema.CodeGeneration.TypeScript.Models

--- a/src/NJsonSchema.CodeGeneration.TypeScript/NJsonSchema.CodeGeneration.TypeScript.csproj
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/NJsonSchema.CodeGeneration.TypeScript.csproj
@@ -26,4 +26,8 @@
         <None Include="NuGetIcon.png" Pack="true" PackagePath="\" />
     </ItemGroup>
 
+    <ItemGroup>
+        <Using Remove="System.Linq" />
+    </ItemGroup>
+
 </Project>

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptExtensionCode.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptExtensionCode.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace NJsonSchema.CodeGeneration.TypeScript

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptGenerator.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Linq;
 using NJsonSchema.CodeGeneration.TypeScript.Models;
 
 namespace NJsonSchema.CodeGeneration.TypeScript

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptGeneratorSettings.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptGeneratorSettings.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Linq;
 using System.Reflection;
 
 namespace NJsonSchema.CodeGeneration.TypeScript

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
@@ -6,6 +6,8 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Linq;
+
 namespace NJsonSchema.CodeGeneration.TypeScript
 {
     /// <summary>Manages the generated types and converts JSON types to TypeScript types. </summary>

--- a/src/NJsonSchema.CodeGeneration/CodeArtifactExtensions.cs
+++ b/src/NJsonSchema.CodeGeneration/CodeArtifactExtensions.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace NJsonSchema.CodeGeneration

--- a/src/NJsonSchema.CodeGeneration/DefaultEnumNameGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration/DefaultEnumNameGenerator.cs
@@ -60,8 +60,9 @@ namespace NJsonSchema.CodeGeneration
             }
 #pragma warning restore CA1845
 
-            return _invalidNameCharactersPattern.Replace(ConversionUtilities.ConvertToUpperCamelCase(name
-                .Replace(":", "-").Replace(@"""", ""), firstCharacterMustBeAlpha: true), "_");
+            var cleaned = name.Replace(':', '-').Replace(@"""", "");
+            var camelCase = ConversionUtilities.ConvertToUpperCamelCase(cleaned, firstCharacterMustBeAlpha: true);
+            return _invalidNameCharactersPattern.Replace(camelCase, "_");
         }
     }
 }

--- a/src/NJsonSchema.CodeGeneration/GeneratorBase.cs
+++ b/src/NJsonSchema.CodeGeneration/GeneratorBase.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace NJsonSchema.CodeGeneration

--- a/src/NJsonSchema.CodeGeneration/Models/ClassTemplateModelBase.cs
+++ b/src/NJsonSchema.CodeGeneration/Models/ClassTemplateModelBase.cs
@@ -6,6 +6,8 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Linq;
+
 namespace NJsonSchema.CodeGeneration.Models
 {
     /// <summary>The class template base class.</summary>

--- a/src/NJsonSchema.CodeGeneration/NJsonSchema.CodeGeneration.csproj
+++ b/src/NJsonSchema.CodeGeneration/NJsonSchema.CodeGeneration.csproj
@@ -21,6 +21,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <Using Remove="System.Linq" />
+    </ItemGroup>
+
+    <ItemGroup>
         <Compile Include="..\NJsonSchema\Infrastructure\EnumExtensions.cs" Link="EnumExtensions.cs" />
         <Compile Include="..\NJsonSchema\Infrastructure\Polyfills.cs" Link="Polyfills.cs" />
     </ItemGroup>

--- a/src/NJsonSchema.CodeGeneration/TypeResolverBase.cs
+++ b/src/NJsonSchema.CodeGeneration/TypeResolverBase.cs
@@ -6,6 +6,8 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Linq;
+
 namespace NJsonSchema.CodeGeneration
 {
     /// <summary>The type resolver base.</summary>

--- a/src/NJsonSchema.CodeGeneration/ValueGeneratorBase.cs
+++ b/src/NJsonSchema.CodeGeneration/ValueGeneratorBase.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.Globalization;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace NJsonSchema.CodeGeneration

--- a/src/NJsonSchema.NewtonsoftJson/Converters/JsonExceptionConverter.cs
+++ b/src/NJsonSchema.NewtonsoftJson/Converters/JsonExceptionConverter.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Linq;
 using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/src/NJsonSchema.NewtonsoftJson/Converters/JsonInheritanceConverter.cs
+++ b/src/NJsonSchema.NewtonsoftJson/Converters/JsonInheritanceConverter.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Linq;
 using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/src/NJsonSchema.NewtonsoftJson/Generation/NewtonsoftJsonReflectionService.cs
+++ b/src/NJsonSchema.NewtonsoftJson/Generation/NewtonsoftJsonReflectionService.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Linq;
 using Newtonsoft.Json.Converters;
 using Namotion.Reflection;
 using Newtonsoft.Json;

--- a/src/NJsonSchema.NewtonsoftJson/NJsonSchema.NewtonsoftJson.csproj
+++ b/src/NJsonSchema.NewtonsoftJson/NJsonSchema.NewtonsoftJson.csproj
@@ -17,4 +17,8 @@
         <None Include="NuGetIcon.png" Pack="true" PackagePath="\" />
     </ItemGroup>
 
+    <ItemGroup>
+        <Using Remove="System.Linq" />
+    </ItemGroup>
+
 </Project>

--- a/src/NJsonSchema.Tests/Generation/ContractResolverTests.cs
+++ b/src/NJsonSchema.Tests/Generation/ContractResolverTests.cs
@@ -111,7 +111,7 @@ namespace NJsonSchema.Tests.Generation
 
             public string StringValue
             {
-                get { return string.Join("/", Path); ; }
+                get { return string.Join("/", Path); }
                 set { Path = new List<string>(value.Split('/')); }
             }
 

--- a/src/NJsonSchema.Tests/Generation/SystemTextJson/SystemTextJsonOptionsConverterTests.cs
+++ b/src/NJsonSchema.Tests/Generation/SystemTextJson/SystemTextJsonOptionsConverterTests.cs
@@ -2,7 +2,6 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 
 using NJsonSchema.Generation;
 

--- a/src/NJsonSchema/Collections/ObservableDictionary.cs
+++ b/src/NJsonSchema/Collections/ObservableDictionary.cs
@@ -9,6 +9,7 @@
 using System.Collections;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Linq;
 
 namespace NJsonSchema.Collections
 {

--- a/src/NJsonSchema/ConversionUtilities.cs
+++ b/src/NJsonSchema/ConversionUtilities.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.Globalization;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -28,10 +29,9 @@ namespace NJsonSchema
                 return string.Empty;
             }
 
-            input = ConvertDashesToCamelCase(
-                (input[0].ToString().ToLowerInvariant() + (input.Length > 1 ? input.Substring(1) : ""))
-                .Replace(" ", "_")
-                .Replace("/", "_"));
+            var lowered = char.ToLowerInvariant(input[0]) + (input.Length > 1 ? input.Substring(1) : "");
+            var cleaned = lowered.Replace(' ', '_').Replace('/', '_');
+            input = ConvertDashesToCamelCase(cleaned);
 
             if (string.IsNullOrEmpty(input))
             {
@@ -57,9 +57,8 @@ namespace NJsonSchema
                 return string.Empty;
             }
 
-            input = ConvertDashesToCamelCase(Capitalize(input)
-                .Replace(" ", "_")
-                .Replace("/", "_"));
+            var cleaned = Capitalize(input).Replace(' ', '_').Replace('/', '_');
+            input = ConvertDashesToCamelCase(cleaned);
 
             if (firstCharacterMustBeAlpha && char.IsNumber(input[0]))
             {

--- a/src/NJsonSchema/Converters/JsonInheritanceConverter.cs
+++ b/src/NJsonSchema/Converters/JsonInheritanceConverter.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/src/NJsonSchema/DefaultTypeNameGenerator.cs
+++ b/src/NJsonSchema/DefaultTypeNameGenerator.cs
@@ -6,7 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
-using System.Buffers;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -18,7 +18,7 @@ namespace NJsonSchema
         private static readonly char[] _typeNameHintCleanupChars = ['[', ']', '<', '>', ',', ' '];
 
 #if NET8_0_OR_GREATER
-        private static readonly SearchValues<char> TypeNameHintCleanupChars = SearchValues.Create(_typeNameHintCleanupChars);
+        private static readonly System.Buffers.SearchValues<char> TypeNameHintCleanupChars = System.Buffers.SearchValues.Create(_typeNameHintCleanupChars);
 #else
         private static readonly char[] TypeNameHintCleanupChars = _typeNameHintCleanupChars;
 #endif

--- a/src/NJsonSchema/Generation/DefaultSchemaNameGenerator.cs
+++ b/src/NJsonSchema/Generation/DefaultSchemaNameGenerator.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Linq;
 using Namotion.Reflection;
 using NJsonSchema.Annotations;
 

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -15,6 +15,7 @@ using NJsonSchema.Generation.TypeMappers;
 using NJsonSchema.Infrastructure;
 using System.Collections;
 using System.Globalization;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
 

--- a/src/NJsonSchema/Generation/JsonTypeDescription.cs
+++ b/src/NJsonSchema/Generation/JsonTypeDescription.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Linq;
 using System.Reflection;
 using Namotion.Reflection;
 using NJsonSchema.Generation.TypeMappers;

--- a/src/NJsonSchema/Generation/ReflectionServiceBase.cs
+++ b/src/NJsonSchema/Generation/ReflectionServiceBase.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.Collections;
+using System.Linq;
 using NJsonSchema.Annotations;
 using System.Reflection;
 using Namotion.Reflection;

--- a/src/NJsonSchema/Generation/SampleJsonDataGenerator.cs
+++ b/src/NJsonSchema/Generation/SampleJsonDataGenerator.cs
@@ -8,6 +8,7 @@
 
 using Newtonsoft.Json.Linq;
 using System.Globalization;
+using System.Linq;
 
 namespace NJsonSchema.Generation
 {

--- a/src/NJsonSchema/Generation/SystemTextJsonReflectionService.cs
+++ b/src/NJsonSchema/Generation/SystemTextJsonReflectionService.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Linq;
 using Namotion.Reflection;
 using System.Reflection;
 using System.Runtime.CompilerServices;

--- a/src/NJsonSchema/Infrastructure/DynamicApis.cs
+++ b/src/NJsonSchema/Infrastructure/DynamicApis.cs
@@ -6,6 +6,8 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Linq;
+
 namespace NJsonSchema.Infrastructure
 {
     /// <summary>Provides dynamic access to framework APIs.</summary>

--- a/src/NJsonSchema/Infrastructure/JsonSchemaSerialization.cs
+++ b/src/NJsonSchema/Infrastructure/JsonSchemaSerialization.cs
@@ -100,7 +100,7 @@ namespace NJsonSchema.Infrastructure
             Func<T, JsonReferenceResolver> referenceResolverFactory, IContractResolver contractResolver, CancellationToken cancellationToken = default)
             where T : notnull
         {
-            var loader = () => FromJson<T>(json, contractResolver);
+            var loader = () => FromJson<T>(json, contractResolver)!;
             return FromJsonWithLoaderAsync(loader, schemaType, documentPath, referenceResolverFactory, contractResolver, cancellationToken);
         }
 
@@ -116,7 +116,7 @@ namespace NJsonSchema.Infrastructure
             Func<T, JsonReferenceResolver> referenceResolverFactory, IContractResolver contractResolver, CancellationToken cancellationToken = default)
             where T : notnull
         {
-            var loader = () => FromJson<T>(stream, contractResolver);
+            var loader = () => FromJson<T>(stream, contractResolver)!;
             return FromJsonWithLoaderAsync(loader, schemaType, documentPath, referenceResolverFactory, contractResolver, cancellationToken);
         }
 

--- a/src/NJsonSchema/Infrastructure/XmlObjectExtension.cs
+++ b/src/NJsonSchema/Infrastructure/XmlObjectExtension.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Linq;
 using Namotion.Reflection;
 
 namespace NJsonSchema.Infrastructure

--- a/src/NJsonSchema/JsonExtensionObject.cs
+++ b/src/NJsonSchema/JsonExtensionObject.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/src/NJsonSchema/JsonPathUtilities.cs
+++ b/src/NJsonSchema/JsonPathUtilities.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.Collections;
+using System.Linq;
 using System.Reflection;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;

--- a/src/NJsonSchema/JsonReferenceResolver.cs
+++ b/src/NJsonSchema/JsonReferenceResolver.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.Collections;
+using System.Linq;
 using System.Net;
 using System.Text.RegularExpressions;
 using Namotion.Reflection;

--- a/src/NJsonSchema/JsonSchema.Serialization.cs
+++ b/src/NJsonSchema/JsonSchema.Serialization.cs
@@ -10,6 +10,7 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Linq;
 using System.Runtime.Serialization;
 using Namotion.Reflection;
 using Newtonsoft.Json;

--- a/src/NJsonSchema/JsonSchema.cs
+++ b/src/NJsonSchema/JsonSchema.cs
@@ -8,6 +8,7 @@
 
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using Namotion.Reflection;

--- a/src/NJsonSchema/JsonSchemaReferenceUtilities.cs
+++ b/src/NJsonSchema/JsonSchemaReferenceUtilities.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Linq;
 using Newtonsoft.Json.Serialization;
 using NJsonSchema.References;
 using NJsonSchema.Visitors;

--- a/src/NJsonSchema/NJsonSchema.csproj
+++ b/src/NJsonSchema/NJsonSchema.csproj
@@ -1,28 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462;net8.0</TargetFrameworks>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFrameworks>netstandard2.0;net462;net8.0</TargetFrameworks>
+    </PropertyGroup>
 
-  <PropertyGroup>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
-  </PropertyGroup>
+    <PropertyGroup>
+        <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\NJsonSchema.Annotations\NJsonSchema.Annotations.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\NJsonSchema.Annotations\NJsonSchema.Annotations.csproj" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Namotion.Reflection" />
-    <PackageReference Include="Newtonsoft.Json" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Namotion.Reflection" />
+        <PackageReference Include="Newtonsoft.Json" />
+    </ItemGroup>
 
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
-    <PackageReference Include="System.Text.Json" />
-  </ItemGroup>
+    <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+        <PackageReference Include="System.Text.Json" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <None Include="NuGetIcon.png" Pack="true" PackagePath="\" />
-  </ItemGroup>
+    <ItemGroup>
+        <Using Remove="System.Linq" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="NuGetIcon.png" Pack="true" PackagePath="\" />
+    </ItemGroup>
 
 </Project>

--- a/src/NJsonSchema/SampleJsonSchemaGenerator.cs
+++ b/src/NJsonSchema/SampleJsonSchemaGenerator.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Linq;
 using System.Text.RegularExpressions;
 
 using Newtonsoft.Json;

--- a/src/NJsonSchema/Validation/JsonSchemaValidator.cs
+++ b/src/NJsonSchema/Validation/JsonSchemaValidator.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.Globalization;
+using System.Linq;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/src/NJsonSchema/Validation/JsonSchemaValidatorOptions.cs
+++ b/src/NJsonSchema/Validation/JsonSchemaValidatorOptions.cs
@@ -1,4 +1,5 @@
-﻿using NJsonSchema.Validation.FormatValidators;
+﻿using System.Linq;
+using NJsonSchema.Validation.FormatValidators;
 
 namespace NJsonSchema.Validation
 {

--- a/src/NJsonSchema/Visitors/AsyncJsonReferenceVisitorBase.cs
+++ b/src/NJsonSchema/Visitors/AsyncJsonReferenceVisitorBase.cs
@@ -8,6 +8,7 @@
 
 using System.Collections;
 using System.Collections.ObjectModel;
+using System.Linq;
 using Namotion.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/src/NJsonSchema/Visitors/JsonReferenceVisitorBase.cs
+++ b/src/NJsonSchema/Visitors/JsonReferenceVisitorBase.cs
@@ -8,6 +8,7 @@
 
 using System.Collections;
 using System.Collections.ObjectModel;
+using System.Linq;
 using Namotion.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;


### PR DESCRIPTION
LINQ has performance considerations and hard to spot when when some extension method is being used instead of native library method.