### PR TITLE
Remove unnecessary use of Type.GetTypeInfo()

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpGeneratorSettings.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpGeneratorSettings.cs
@@ -52,7 +52,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
             ValueGenerator = new CSharpValueGenerator(this);
             PropertyNameGenerator = new CSharpPropertyNameGenerator();
             TemplateFactory = new DefaultTemplateFactory(this, [
-                typeof(CSharpGeneratorSettings).GetTypeInfo().Assembly
+                typeof(CSharpGeneratorSettings).Assembly
             ]);
 
             InlineNamedArrays = false;

--- a/src/NJsonSchema.CodeGeneration.Tests/InheritanceSerializationTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/InheritanceSerializationTests.cs
@@ -304,7 +304,7 @@ namespace NJsonSchema.CodeGeneration.Tests
                 .WithOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
                 .AddSyntaxTrees(CSharpSyntaxTree.ParseText(code));
 
-            var coreDir = Directory.GetParent(typeof(Enumerable).GetTypeInfo().Assembly.Location);            
+            var coreDir = Directory.GetParent(typeof(Enumerable).Assembly.Location);            
             compilation = compilation.AddReferences(
                 MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
                 MetadataReference.CreateFromFile(typeof(JsonConvert).Assembly.Location),

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptGeneratorSettings.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptGeneratorSettings.cs
@@ -34,7 +34,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
             ValueGenerator = new TypeScriptValueGenerator(this);
             PropertyNameGenerator = new TypeScriptPropertyNameGenerator();
             TemplateFactory = new DefaultTemplateFactory(this, [
-                typeof(TypeScriptGeneratorSettings).GetTypeInfo().Assembly
+                typeof(TypeScriptGeneratorSettings).Assembly
             ]);
 
             ClassTypes = [];

--- a/src/NJsonSchema.NewtonsoftJson/Converters/JsonExceptionConverter.cs
+++ b/src/NJsonSchema.NewtonsoftJson/Converters/JsonExceptionConverter.cs
@@ -83,7 +83,7 @@ namespace NJsonSchema.NewtonsoftJson.Converters
         /// <returns><c>true</c> if this instance can convert the specified object type; otherwise, <c>false</c>.</returns>
         public override bool CanConvert(Type objectType)
         {
-            return typeof(Exception).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
+            return typeof(Exception).IsAssignableFrom(objectType);
         }
 
         /// <summary>Reads the JSON representation of the object.</summary>
@@ -185,8 +185,8 @@ namespace NJsonSchema.NewtonsoftJson.Converters
 
         private static FieldInfo? GetField(Type type, string fieldName)
         {
-            var typeInfo = type.GetTypeInfo();
-            var field = typeInfo.GetDeclaredField(fieldName);
+            var typeInfo = type;
+            var field = typeInfo.GetTypeInfo().GetDeclaredField(fieldName);
             if (field == null && typeInfo.BaseType != null)
             {
                 return GetField(typeInfo.BaseType, fieldName);
@@ -218,7 +218,7 @@ namespace NJsonSchema.NewtonsoftJson.Converters
         private static void SetExceptionFieldValue(JObject jObject, string propertyName, object value, string fieldName, IContractResolver resolver, JsonSerializer serializer)
         {
             var field = typeof(Exception).GetTypeInfo().GetDeclaredField(fieldName);
-            var jsonPropertyName = resolver is DefaultContractResolver ? ((DefaultContractResolver)resolver).GetResolvedPropertyName(propertyName) : propertyName;
+            var jsonPropertyName = resolver is DefaultContractResolver contractResolver ? contractResolver.GetResolvedPropertyName(propertyName) : propertyName;
             var property = jObject.Properties().FirstOrDefault(p => string.Equals(p.Name, jsonPropertyName, StringComparison.OrdinalIgnoreCase));
             if (property != null)
             {

--- a/src/NJsonSchema.NewtonsoftJson/Converters/JsonInheritanceConverter.cs
+++ b/src/NJsonSchema.NewtonsoftJson/Converters/JsonInheritanceConverter.cs
@@ -146,7 +146,7 @@ namespace NJsonSchema.NewtonsoftJson.Converters
                         return true;
                     }
 
-                    type = type.GetTypeInfo().BaseType;
+                    type = type.BaseType;
                 }
 
                 return false;
@@ -229,7 +229,7 @@ namespace NJsonSchema.NewtonsoftJson.Converters
                 }
 
                 var typeName = objectType.Namespace + "." + discriminatorValue;
-                var subtype = objectType.GetTypeInfo().Assembly.GetType(typeName);
+                var subtype = objectType.Assembly.GetType(typeName);
                 if (subtype != null)
                 {
                     return subtype;
@@ -253,7 +253,7 @@ namespace NJsonSchema.NewtonsoftJson.Converters
             var type = objectType;
             do
             {
-                var knownTypeAttributes = type.GetTypeInfo().GetCustomAttributes(false)
+                var knownTypeAttributes = type.GetCustomAttributes(false)
                     .Where(a => a.GetType().Name == "KnownTypeAttribute");
                 foreach (dynamic attribute in knownTypeAttributes)
                 {
@@ -278,7 +278,7 @@ namespace NJsonSchema.NewtonsoftJson.Converters
                         }
                     }
                 }
-                type = type.GetTypeInfo().BaseType;
+                type = type.BaseType;
             } while (type != null);
 
             return null;
@@ -287,7 +287,7 @@ namespace NJsonSchema.NewtonsoftJson.Converters
         private static Type? GetObjectSubtype(Type baseType, string discriminatorName)
         {
             var jsonInheritanceAttributes = baseType
-                .GetTypeInfo()
+                
                 .GetCustomAttributes(true)
                 .OfType<JsonInheritanceAttribute>();
 
@@ -297,7 +297,7 @@ namespace NJsonSchema.NewtonsoftJson.Converters
         private static string? GetSubtypeDiscriminator(Type objectType)
         {
             var jsonInheritanceAttributes = objectType
-                .GetTypeInfo()
+                
                 .GetCustomAttributes(true)
                 .OfType<JsonInheritanceAttribute>();
 

--- a/src/NJsonSchema.NewtonsoftJson/Generation/NewtonsoftJsonSchemaGeneratorSettings.cs
+++ b/src/NJsonSchema.NewtonsoftJson/Generation/NewtonsoftJsonSchemaGeneratorSettings.cs
@@ -57,7 +57,7 @@ namespace NJsonSchema.NewtonsoftJson.Generation
                 return null;
             }
 
-            return _cachedContracts.GetOrAdd(key, s => !type.GetTypeInfo().IsGenericTypeDefinition ? ActualContractResolver.ResolveContract(type) : null);
+            return _cachedContracts.GetOrAdd(key, s => !type.IsGenericTypeDefinition ? ActualContractResolver.ResolveContract(type) : null);
         }
     }
 }

--- a/src/NJsonSchema/Converters/JsonInheritanceConverter.cs
+++ b/src/NJsonSchema/Converters/JsonInheritanceConverter.cs
@@ -154,7 +154,7 @@ namespace NJsonSchema.Converters
                 }
 
                 var typeName = objectType.Namespace + "." + discriminatorValue;
-                var subtype = objectType.GetTypeInfo().Assembly.GetType(typeName);
+                var subtype = objectType.Assembly.GetType(typeName);
                 if (subtype != null)
                 {
                     return subtype;
@@ -170,7 +170,7 @@ namespace NJsonSchema.Converters
             do
             {
                 var knownTypeAttributes = type
-                    .GetTypeInfo()
+                    
                     .GetCustomAttributes(false)
                     .Where(a => a.GetType().Name == "KnownTypeAttribute");
 
@@ -200,7 +200,7 @@ namespace NJsonSchema.Converters
                     }
                 }
 
-                type = type.GetTypeInfo().BaseType;
+                type = type.BaseType;
             } while (type != null);
 
             return null;
@@ -209,7 +209,7 @@ namespace NJsonSchema.Converters
         private static Type? GetObjectSubtype(Type baseType, string discriminatorValue)
         {
             var jsonInheritanceAttributes = baseType
-                .GetTypeInfo()
+                
                 .GetCustomAttributes(true)
                 .OfType<JsonInheritanceAttribute>();
 
@@ -219,7 +219,7 @@ namespace NJsonSchema.Converters
         private static string? GetSubtypeDiscriminator(Type objectType)
         {
             var jsonInheritanceAttributes = objectType
-                .GetTypeInfo()
+                
                 .GetCustomAttributes(true)
                 .OfType<JsonInheritanceAttribute>();
 

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -442,7 +442,7 @@ namespace NJsonSchema.Generation
         /// <returns>The converted default value.</returns>
         public virtual object? ConvertDefaultValue(ContextualType type, object? defaultValue)
         {
-            if (defaultValue != null && defaultValue.GetType().GetTypeInfo().IsEnum)
+            if (defaultValue != null && defaultValue.GetType().IsEnum)
             {
                 var hasStringEnumConverter = Settings.ReflectionService.IsStringEnum(type, Settings);
                 if (hasStringEnumConverter)
@@ -544,7 +544,7 @@ namespace NJsonSchema.Generation
             schema.Description = type.ToCachedType().GetDescription(Settings);
             schema.Example = GenerateExample(type.ToContextualType());
 
-            dynamic? obsoleteAttribute = type.GetTypeInfo().GetCustomAttributes(false).FirstAssignableToTypeNameOrDefault("System.ObsoleteAttribute");
+            dynamic? obsoleteAttribute = type.GetCustomAttributes(false).FirstAssignableToTypeNameOrDefault("System.ObsoleteAttribute");
             if (obsoleteAttribute != null)
             {
                 schema.IsDeprecated = true;
@@ -553,7 +553,7 @@ namespace NJsonSchema.Generation
 
             if (Settings.GetActualGenerateAbstractSchema(type))
             {
-                schema.IsAbstract = type.GetTypeInfo().IsAbstract;
+                schema.IsAbstract = type.IsAbstract;
             }
 
             GenerateInheritanceDiscriminator(type, rootSchema, schema);
@@ -649,7 +649,7 @@ namespace NJsonSchema.Generation
             var genericTypeArguments = contextualType.GenericArguments;
 
             var keyType = genericTypeArguments.Length == 2 ? genericTypeArguments[0] : typeof(string).ToContextualType();
-            if (keyType.OriginalType.GetTypeInfo().IsEnum)
+            if (keyType.OriginalType.IsEnum)
             {
                 schema.DictionaryKey = GenerateWithReference<JsonSchema>(keyType, schemaResolver);
             }
@@ -803,7 +803,7 @@ namespace NJsonSchema.Generation
             where TSchemaType : JsonSchema, new()
         {
             var typeMapper = Settings.TypeMappers.FirstOrDefault(m => m.MappedType == contextualType.OriginalType);
-            if (typeMapper == null && contextualType.OriginalType.GetTypeInfo().IsGenericType)
+            if (typeMapper == null && contextualType.OriginalType.IsGenericType)
             {
                 var genericType = contextualType.OriginalType.GetGenericTypeDefinition();
                 typeMapper = Settings.TypeMappers.FirstOrDefault(m => m.MappedType == genericType);
@@ -870,13 +870,13 @@ namespace NJsonSchema.Generation
 #pragma warning restore CA1822
         {
             return memberInfo is ContextualPropertyInfo propertyInfo &&
-                   propertyInfo.PropertyInfo.DeclaringType?.GetTypeInfo().IsInterface == false &&
+                   propertyInfo.PropertyInfo.DeclaringType?.IsInterface == false &&
                    (propertyInfo.PropertyInfo.GetMethod?.IsAbstract == true || propertyInfo.PropertyInfo.SetMethod?.IsAbstract == true);
         }
 
         private void GenerateKnownTypes(Type type, JsonSchemaResolver schemaResolver)
         {
-            var attributes = type.GetTypeInfo()
+            var attributes = type
                 .GetCustomAttributes(Settings.GetActualFlattenInheritanceHierarchy(type));
 
             if (Settings.GenerateKnownTypes)
@@ -1023,7 +1023,7 @@ namespace NJsonSchema.Generation
                     var contextualType = implementedInterface.ToContextualType();
                     var typeDescription = Settings.ReflectionService.GetDescription(contextualType, Settings);
                     if (!typeDescription.IsDictionary && !type.Type.IsArray &&
-                        !typeof(IEnumerable).GetTypeInfo().IsAssignableFrom(implementedInterface.GetTypeInfo()))
+                        !typeof(IEnumerable).IsAssignableFrom(implementedInterface))
                     {
                         Settings.ReflectionService.GenerateProperties(schema, contextualType, Settings, this, schemaResolver);
                         var actualSchema = GenerateInheritance(contextualType, schema, schemaResolver);
@@ -1089,7 +1089,7 @@ namespace NJsonSchema.Generation
 #pragma warning disable CA1859
         private object? TryGetInheritanceDiscriminatorConverter(Type type)
         {
-            var typeAttributes = type.GetTypeInfo().GetCustomAttributes(false).OfType<Attribute>();
+            var typeAttributes = type.GetCustomAttributes(false).OfType<Attribute>();
 
             // support for NJsonSchema provided inheritance converters
             dynamic? jsonConverterAttribute = typeAttributes.FirstAssignableToTypeNameOrDefault(nameof(JsonConverterAttribute), TypeNameStyle.Name);

--- a/src/NJsonSchema/Generation/JsonSchemaGeneratorSettings.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGeneratorSettings.cs
@@ -120,7 +120,7 @@ namespace NJsonSchema.Generation
         /// <returns>The result.</returns>
         public bool GetActualGenerateAbstractSchema(Type type)
         {
-            var attribute = type.GetTypeInfo().GetCustomAttributes(false)
+            var attribute = type.GetCustomAttributes(false)
                 .FirstAssignableToTypeNameOrDefault("JsonSchemaAbstractAttribute", TypeNameStyle.Name);
 
             return (GenerateAbstractSchemas && attribute == null) || attribute?.TryGetPropertyValue("IsAbstract", true) == true;
@@ -131,7 +131,7 @@ namespace NJsonSchema.Generation
         /// <returns>The result.</returns>
         public bool GetActualFlattenInheritanceHierarchy(Type type)
         {
-            var attribute = type.GetTypeInfo().GetCustomAttributes(false)
+            var attribute = type.GetCustomAttributes(false)
                 .FirstAssignableToTypeNameOrDefault("JsonSchemaFlattenAttribute", TypeNameStyle.Name);
 
             return (FlattenInheritanceHierarchy && attribute == null) || attribute?.TryGetPropertyValue("Flatten", true) == true;

--- a/src/NJsonSchema/Generation/JsonTypeDescription.cs
+++ b/src/NJsonSchema/Generation/JsonTypeDescription.cs
@@ -93,7 +93,7 @@ namespace NJsonSchema.Generation
         public bool RequiresSchemaReference(IEnumerable<ITypeMapper> typeMappers)
         {
             var typeMapper = typeMappers.FirstOrDefault(m => m.MappedType == ContextualType.OriginalType);
-            if (typeMapper == null && ContextualType.OriginalType.GetTypeInfo().IsGenericType)
+            if (typeMapper == null && ContextualType.OriginalType.IsGenericType)
             {
                 var genericType = ContextualType.OriginalType.GetGenericTypeDefinition();
                 typeMapper = typeMappers.FirstOrDefault(m => m.MappedType == genericType);

--- a/src/NJsonSchema/Infrastructure/IgnoreEmptyCollectionsContractResolver.cs
+++ b/src/NJsonSchema/Infrastructure/IgnoreEmptyCollectionsContractResolver.cs
@@ -15,7 +15,7 @@ namespace NJsonSchema.Infrastructure
 {
     internal sealed class IgnoreEmptyCollectionsContractResolver : PropertyRenameAndIgnoreSerializerContractResolver
     {
-        private static readonly TypeInfo enumerableType = typeof(IEnumerable).GetTypeInfo();
+        private static readonly Type enumerableType = typeof(IEnumerable);
 
         protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
         {
@@ -24,7 +24,7 @@ namespace NJsonSchema.Infrastructure
             if (property.Required is Required.Default or Required.DisallowNull &&
                 property.PropertyType is { IsPrimitive: false } &&
                 property.PropertyType != typeof(string) &&
-                enumerableType.IsAssignableFrom(property.PropertyType.GetTypeInfo()))
+                enumerableType.IsAssignableFrom(property.PropertyType))
             {
                 property.ShouldSerialize = instance =>
                 {

--- a/src/NJsonSchema/JsonSchema.cs
+++ b/src/NJsonSchema/JsonSchema.cs
@@ -82,8 +82,8 @@ namespace NJsonSchema
         /// <summary>Gets the NJsonSchema toolchain version.</summary>
         public static string ToolchainVersion => version;
 
-        private static readonly string version = typeof(JsonSchema).GetTypeInfo().Assembly.GetName().Version +
-            " (Newtonsoft.Json v" + typeof(JToken).GetTypeInfo().Assembly.GetName().Version + ")";
+        private static readonly string version = typeof(JsonSchema).Assembly.GetName().Version +
+            " (Newtonsoft.Json v" + typeof(JToken).Assembly.GetName().Version + ")";
 
         /// <summary>Loads a JSON Schema from a given file path (only available in .NET 4.x).</summary>
         /// <param name="filePath">The file path.</param>


### PR DESCRIPTION
Many usages were from netstandard 1.x era and they always allocate wrappers.