### PR TITLE
Fix serialization of arrays with nullable items in TypeScript

### DIFF
--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/NullabilityTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/NullabilityTests.cs
@@ -186,5 +186,38 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
             Assert.True(schema.Properties["Items"].Item.IsNullable(SchemaType.JsonSchema));
             Assert.Contains(": (string | null)[]", output);
         }
+
+        public class Complex
+        {
+            public int A { get; set; }
+        }
+        
+        public class ClassWithComplexNullableArrayItems
+        {
+            [NotNull]
+            [ItemsCanBeNull]
+            public List<Complex> Items { get; set; }
+        }
+
+        [Fact]
+        public void When_complex_array_item_is_nullable_then_generated_TypeScript_is_nullsafe()
+        {
+            // Arrange
+            var schema = NewtonsoftJsonSchemaGenerator.FromType<ClassWithComplexNullableArrayItems>();
+            var json = schema.ToJson();
+            var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings
+            {
+                TypeScriptVersion = 2.7m,
+                NullValue = TypeScriptNullValue.Null
+            });
+
+            // Act
+            var output = generator.GenerateFile("MyClass");
+
+            // Assert
+            Assert.True(schema.Properties["Items"].Item.IsNullable(SchemaType.JsonSchema));
+            Assert.Contains(": (Complex | null)[]", output);
+            Assert.Contains(".push(item ? item.toJSON() : <any>null)", output);
+        }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/Snapshots/ClassGenerationTests.Verify_output_style=Class_version=1.8.verified.txt
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/Snapshots/ClassGenerationTests.Verify_output_style=Class_version=1.8.verified.txt
@@ -188,7 +188,7 @@ export class MyClass implements IMyClass {
         if (Array.isArray(this.array)) {
             data["Array"] = [];
             for (let item of this.array)
-                data["Array"].push(item.toJSON());
+                data["Array"].push(item ? item.toJSON() : <any>undefined);
         }
         if (this.dictionary) {
             data["Dictionary"] = {};

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/Snapshots/ClassGenerationTests.Verify_output_style=Class_version=2.1.verified.txt
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/Snapshots/ClassGenerationTests.Verify_output_style=Class_version=2.1.verified.txt
@@ -188,7 +188,7 @@ export class MyClass implements IMyClass {
         if (Array.isArray(this.array)) {
             data["Array"] = [];
             for (let item of this.array)
-                data["Array"].push(item.toJSON());
+                data["Array"].push(item ? item.toJSON() : <any>undefined);
         }
         if (this.dictionary) {
             data["Dictionary"] = {};

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/Snapshots/ClassGenerationTests.Verify_output_style=Class_version=2.7.verified.txt
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/Snapshots/ClassGenerationTests.Verify_output_style=Class_version=2.7.verified.txt
@@ -188,7 +188,7 @@ export class MyClass implements IMyClass {
         if (Array.isArray(this.array)) {
             data["Array"] = [];
             for (let item of this.array)
-                data["Array"].push(item.toJSON());
+                data["Array"].push(item ? item.toJSON() : <any>undefined);
         }
         if (this.dictionary) {
             data["Dictionary"] = {};

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/Snapshots/ClassGenerationTests.Verify_output_style=Class_version=4.3.verified.txt
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/Snapshots/ClassGenerationTests.Verify_output_style=Class_version=4.3.verified.txt
@@ -188,7 +188,7 @@ export class MyClass implements IMyClass {
         if (Array.isArray(this.array)) {
             data["Array"] = [];
             for (let item of this.array)
-                data["Array"].push(item.toJSON());
+                data["Array"].push(item ? item.toJSON() : <any>undefined);
         }
         if (this.dictionary) {
             data["Dictionary"] = {};

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/Snapshots/ClassGenerationTests.Verify_output_style=KnockoutClass_version=1.8.verified.txt
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/Snapshots/ClassGenerationTests.Verify_output_style=KnockoutClass_version=1.8.verified.txt
@@ -214,7 +214,7 @@ export class MyClass {
         if (Array.isArray(array_)) {
             data["Array"] = [];
             for (let item of array_)
-                data["Array"].push(item.toJSON());
+                data["Array"].push(item ? item.toJSON() : <any>undefined);
         }
 
         let dictionary_: any = this.dictionary();

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/Snapshots/ClassGenerationTests.Verify_output_style=KnockoutClass_version=2.1.verified.txt
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/Snapshots/ClassGenerationTests.Verify_output_style=KnockoutClass_version=2.1.verified.txt
@@ -214,7 +214,7 @@ export class MyClass {
         if (Array.isArray(array_)) {
             data["Array"] = [];
             for (let item of array_)
-                data["Array"].push(item.toJSON());
+                data["Array"].push(item ? item.toJSON() : <any>undefined);
         }
 
         let dictionary_: any = this.dictionary();

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/Snapshots/ClassGenerationTests.Verify_output_style=KnockoutClass_version=2.7.verified.txt
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/Snapshots/ClassGenerationTests.Verify_output_style=KnockoutClass_version=2.7.verified.txt
@@ -214,7 +214,7 @@ export class MyClass {
         if (Array.isArray(array_)) {
             data["Array"] = [];
             for (let item of array_)
-                data["Array"].push(item.toJSON());
+                data["Array"].push(item ? item.toJSON() : <any>undefined);
         }
 
         let dictionary_: any = this.dictionary();

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/Snapshots/ClassGenerationTests.Verify_output_style=KnockoutClass_version=4.3.verified.txt
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/Snapshots/ClassGenerationTests.Verify_output_style=KnockoutClass_version=4.3.verified.txt
@@ -214,7 +214,7 @@ export class MyClass {
         if (Array.isArray(array_)) {
             data["Array"] = [];
             for (let item of array_)
-                data["Array"].push(item.toJSON());
+                data["Array"].push(item ? item.toJSON() : <any>undefined);
         }
 
         let dictionary_: any = this.dictionary();

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/Snapshots/TypeScriptDiscriminatorTests.When_parameter_is_abstract_then_generate_union_class.verified.txt
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/Snapshots/TypeScriptDiscriminatorTests.When_parameter_is_abstract_then_generate_union_class.verified.txt
@@ -169,7 +169,7 @@ export class MyClass implements IMyClass {
         if (Array.isArray(this.children)) {
             data["Children"] = [];
             for (let item of this.children)
-                data["Children"].push(item.toJSON());
+                data["Children"].push(item ? item.toJSON() : <any>undefined);
         }
         return data;
     }

--- a/src/NJsonSchema.CodeGeneration.TypeScript/Templates/ConvertToJavaScript.liquid
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Templates/ConvertToJavaScript.liquid
@@ -5,7 +5,7 @@ if (Array.isArray({{ Value }})) {
     {{ Variable }} = [];
     for (let item of {{ Value }})
 {%-     if IsArrayItemNewableObject -%}
-        {{ Variable }}.push(item.toJSON());
+        {{ Variable }}.push(item ? item.toJSON() : <any>{{ NullValue }});
 {%-     elsif IsArrayItemDate -%}
         {{ Variable }}.push({% if UseJsDate %}formatDate(item){% else %}item.{{ DateToStringCode }}{% endif %});
 {%-     elsif IsArrayItemDateTime -%}


### PR DESCRIPTION
For nullable array elements, the generated TypeScript code can lead to `TS18048: 'item' is possibly 'undefined'.`. I think it can be fixed simply by adjusting the Liquid template.