### PR TITLE
Revert "C# generator: create anoymous types with camel casing (reworked)"

### DIFF
--- a/src/NJsonSchema/DefaultTypeNameGenerator.cs
+++ b/src/NJsonSchema/DefaultTypeNameGenerator.cs
@@ -103,7 +103,6 @@ namespace NJsonSchema
                 }
 
                 typeNameHint = GetLastSegment(typeNameHint)!;
-                typeNameHint = ConversionUtilities.ConvertToUpperCamelCase(typeNameHint, true);
 
                 if (typeNameHint != null &&
                     !reservedTypeNames.Contains(typeNameHint) && 
@@ -117,7 +116,7 @@ namespace NJsonSchema
                 do
                 {
                     count++;
-                    typeName = typeNameHint + count;
+                    typeName = ConversionUtilities.ConvertToUpperCamelCase(typeNameHint + count, true);
                 } while (reservedTypeNames.Contains(typeName));
 
                 return typeName;


### PR DESCRIPTION
Reverts RicoSuter/NJsonSchema#1788

Seems that this breaks NSwag tests, needs more testing - reverting.
![image](https://github.com/user-attachments/assets/9aa6367e-b683-4594-8734-e954e7388aa2)
