### PR TITLE
Cache NJsonSchema properties in JsonReferenceResolver

### DIFF
--- a/src/NJsonSchema.Benchmark/Directory.Build.props
+++ b/src/NJsonSchema.Benchmark/Directory.Build.props
@@ -1,0 +1,3 @@
+<Project>
+    <!-- here to avoid inheriting anything from root -->
+</Project>

--- a/src/NJsonSchema.Benchmark/NJsonSchema.Benchmark.csproj
+++ b/src/NJsonSchema.Benchmark/NJsonSchema.Benchmark.csproj
@@ -7,6 +7,7 @@
         <SignAssembly>false</SignAssembly>
         <Nullable>disable</Nullable>
         <EnableNETAnalyzers>false</EnableNETAnalyzers>
+        <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
There's high reflection cost the code path usually always hits `JsonSchema` type.

Using my custom large (1,3MB) swagger file.

### Before

| Method       | Mean     | Error   | StdDev  | Gen0      | Gen1      | Allocated |
|------------- |---------:|--------:|--------:|----------:|----------:|----------:|
| GenerateFile | 151.2 ms | 2.92 ms | 7.22 ms | 6000.0000 | 3000.0000 |  78.63 MB |

### After


| Method       | Mean     | Error   | StdDev  | Gen0      | Gen1      | Gen2     | Allocated |
|------------- |---------:|--------:|--------:|----------:|----------:|---------:|----------:|
| GenerateFile | 112.0 ms | 2.12 ms | 4.56 ms | 7000.0000 | 3000.0000 | 500.0000 |  78.27 MB |
