### PR TITLE
Avoid trying JsonSchema construction for object having boolean required

### DIFF
--- a/src/NJsonSchema/JsonExtensionObject.cs
+++ b/src/NJsonSchema/JsonExtensionObject.cs
@@ -73,6 +73,19 @@ namespace NJsonSchema
             if (value is JObject obj)
             {
                 var isSchema = obj.Property("type") != null || obj.Property("properties") != null;
+
+                // special case "required" boolean property as it's contained in parameters for example and will always
+                // cause serialization exception when boolean value is tried to be injected to JsonSchema.Required which
+                // is a list of strings
+                if (isSchema)
+                {
+                    var requiredProperty = obj.Property("required");
+                    if (requiredProperty is { Value.Type: JTokenType.Boolean })
+                    {
+                        isSchema = false;
+                    }
+                }
+
                 if (isSchema)
                 {
                     try


### PR DESCRIPTION
`JsonSchema.Required` property doesn't allow injecting a boolean value, this will always cause a serialization exception under the hood.

### Before

![image](https://github.com/user-attachments/assets/f9af6d88-bc7d-4501-8b09-c8bb0522d9cf)

### After

No exceptions...

![image](https://github.com/user-attachments/assets/c676ae3a-20cc-4f50-964f-45ee605b32df)
