### PR TITLE
Optimize AsyncJsonReferenceVisitorBase.Visit

### DIFF
--- a/src/NJsonSchema/JsonSchema.cs
+++ b/src/NJsonSchema/JsonSchema.cs
@@ -25,7 +25,9 @@ namespace NJsonSchema
     public partial class JsonSchema : IDocumentPathProvider
     {
         internal static readonly HashSet<string> JsonSchemaPropertiesCache =
-            [..typeof(JsonSchema).GetContextualProperties().Select(p => p.Name).ToArray()];
+        [
+            ..typeof(JsonSchema).GetContextualProperties().Select(p => p.Name)
+        ];
 
         private const SchemaType SerializationSchemaType = SchemaType.JsonSchema;
 


### PR DESCRIPTION
* remove LINQ, reduce duplicate checks
* don't recurse strings or primitive types

Using my custom large (1,3MB) swagger file.

### Before

| Method       | Mean     | Error   | StdDev  | Gen0      | Gen1      | Gen2     | Allocated |
|------------- |---------:|--------:|--------:|----------:|----------:|---------:|----------:|
| GenerateFile | 106.9 ms | 2.08 ms | 2.56 ms | 6500.0000 | 3500.0000 | 500.0000 |  74.28 MB |


### After


| Method       | Mean     | Error    | StdDev   | Gen0      | Gen1      | Allocated |
|------------- |---------:|---------:|---------:|----------:|----------:|----------:|
| GenerateFile | 86.33 ms | 1.454 ms | 1.215 ms | 5000.0000 | 2000.0000 |  67.83 MB |


