### PR TITLE
Allow customizing FluidParser construction

### DIFF
--- a/src/NJsonSchema.CodeGeneration.Tests/TemplateFactoryTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/TemplateFactoryTests.cs
@@ -1,0 +1,28 @@
+using Fluid;
+using NJsonSchema.CodeGeneration.CSharp;
+
+namespace NJsonSchema.CodeGeneration.Tests;
+
+public class TemplateFactoryTests
+{
+    [Fact]
+    public void Can_customize_liquid_parser()
+    {
+        var generatorSettings = new CSharpGeneratorSettings
+        {
+            TemplateDirectory = "Templates",
+        };
+
+        var factory = new DefaultTemplateFactory(generatorSettings, [typeof(CSharpGeneratorSettings).Assembly])
+        {
+            FluidParser = new LiquidParser(new FluidParserOptions { AllowLiquidTag = true }),
+        };
+        generatorSettings.TemplateFactory = factory;
+
+        var template = factory.CreateTemplate("csharp", "inline-liquid", new { });
+
+        var templateResult = template.Render();
+
+        Assert.Equal("WELCOME TO THE LIQUID TAG", templateResult);
+    }
+}

--- a/src/NJsonSchema.CodeGeneration.Tests/Templates/inline-liquid.liquid
+++ b/src/NJsonSchema.CodeGeneration.Tests/Templates/inline-liquid.liquid
@@ -1,0 +1,7 @@
+{%
+    liquid
+    echo
+    'welcome ' | upcase
+   echo 'to the liquid tag' 
+    | upcase 
+%}

--- a/src/NJsonSchema.CodeGeneration/LiquidParser.cs
+++ b/src/NJsonSchema.CodeGeneration/LiquidParser.cs
@@ -1,0 +1,65 @@
+using System.Text.Encodings.Web;
+using Fluid;
+using Fluid.Ast;
+using Parlot.Fluent;
+
+namespace NJsonSchema.CodeGeneration;
+
+/// <summary>
+/// A custom <see cref="FluidParser"/> implementation that can handle NJsonSchema liquid templating language extensions and customizations.
+/// </summary>
+public sealed class LiquidParser : FluidParser
+{
+    internal const string LanguageKey = "__language";
+    internal const string TemplateKey = "__template";
+    internal const string SettingsKey = "__settings";
+
+    /// <summary>
+    /// Creates a new instance of custom Liquid parser that can handle NJsonSchema templates.
+    /// </summary>
+    /// <param name="options"></param>
+    public LiquidParser(FluidParserOptions options) : base(options)
+    {
+        RegisterParserTag(DefaultTemplateFactory.TemplateTagName, Parsers.OneOrMany(Primary), RenderTemplate);
+    }
+
+    private static ValueTask<Completion> RenderTemplate(
+        IReadOnlyList<Expression> arguments,
+        TextWriter writer,
+        TextEncoder encoder,
+        TemplateContext context)
+    {
+        var templateName = ((LiteralExpression)arguments[0]).Value.ToStringValue();
+
+        var tabCount = -1;
+        if (arguments.Count > 1 && arguments[1] is LiteralExpression literalExpression)
+        {
+            tabCount = (int)literalExpression.Value.ToNumberValue();
+        }
+
+        var settings = (CodeGeneratorSettingsBase)context.AmbientValues[SettingsKey];
+        var language = (string)context.AmbientValues[LanguageKey];
+        templateName = !string.IsNullOrEmpty(templateName)
+            ? templateName
+            : (string)context.AmbientValues[TemplateKey] + "!";
+
+        var template = settings.TemplateFactory.CreateTemplate(language, templateName, context);
+        var output = template.Render();
+
+        if (string.IsNullOrWhiteSpace(output))
+        {
+            // signal cleanup
+            writer.Write("__EMPTY-TEMPLATE__");
+        }
+        else if (tabCount > 0)
+        {
+            ConversionUtilities.Tab(output, tabCount, writer);
+        }
+        else
+        {
+            writer.Write(output);
+        }
+
+        return new ValueTask<Completion>(Completion.Normal);
+    }
+}

--- a/src/NJsonSchema/JsonExtensionObject.cs
+++ b/src/NJsonSchema/JsonExtensionObject.cs
@@ -98,7 +98,7 @@ namespace NJsonSchema
                     }
                 }
 
-                var dictionary = new Dictionary<string, object?>();
+                var dictionary = new Dictionary<string, object?>(obj.Count);
                 foreach (var property in obj.Properties())
                 {
                     dictionary[property.Name] = TryDeserializeValueSchemas(property.Value, serializer);


### PR DESCRIPTION
This also allows template options customization which will help on NSwag side to track invalid templates via member access strategy.

fixes #1821