### PR TITLE
C# generator: create anoymous types with camel casing (3rd attempt)

### DIFF
--- a/src/NJsonSchema/DefaultTypeNameGenerator.cs
+++ b/src/NJsonSchema/DefaultTypeNameGenerator.cs
@@ -103,6 +103,7 @@ namespace NJsonSchema
                 }
 
                 typeNameHint = GetLastSegment(typeNameHint)!;
+                typeNameHint = ConversionUtilities.ConvertToUpperCamelCase(typeNameHint, true);
 
                 if (typeNameHint != null &&
                     !reservedTypeNames.Contains(typeNameHint) && 
@@ -116,7 +117,7 @@ namespace NJsonSchema
                 do
                 {
                     count++;
-                    typeName = ConversionUtilities.ConvertToUpperCamelCase(typeNameHint + count, true);
+                    typeName = typeNameHint + count;
                 } while (reservedTypeNames.Contains(typeName));
 
                 return typeName;


### PR DESCRIPTION
This is the same code change as #1788. The previous pull request was reverted later due to a test failure in NSwag that is caused by this change (see screenshot in https://github.com/RicoSuter/NJsonSchema/pull/1788#issuecomment-2836446630). After some struggle, I managed to run the NSwag testsuite and will send a pull request for it, too. The testsuite for the NSwag pull request will fail as long as the NJsonSchema version containing this change is not updated.

As it turned out, the NSwag testsuite already contains a test case for this change of mine :-)

=======================

This is the third attempt to fix https://github.com/RicoSuter/NSwag/issues/4849 and https://github.com/RicoSuter/NSwag/issues/4837 and a followup for #1716: since NSwag 14, the resulting C# file generated from a yaml file might contain lower case class names.
This seems to happen if an array item has as lower case type name hint (e.g. "data"), and a class "Data" was already generated.
In this situation, `DefaultTypeNameGenerator.GenerateAnonymousTypeName` does not call `ConversionUtilities.ConvertToUpperCamelCase` and thus picks the lower case class name "data" as "not used".

With my fix, it would generate a class "Data2" again.

The first fix worked locally for me because I had one additional line that I forget to add to my pull request. This request adds this line and removes an unneccesary `ConvertToUpperCamelCase` from the previous pull request (variable `typeNameHint` is already camel cased now).

By the way: it would be great to have a step by step guide how to build NJsonSchema and update it in NSwag ;-)

fixes https://github.com/RicoSuter/NSwag/issues/4837 