### PR TITLE
fix ApplyRangeAttribute failing when min/max is specified as string

### DIFF
--- a/src/NJsonSchema.Tests/Generation/AttributeGenerationTests.cs
+++ b/src/NJsonSchema.Tests/Generation/AttributeGenerationTests.cs
@@ -49,6 +49,25 @@ namespace NJsonSchema.Tests.Generation
             Assert.Equal(5.5m, property.Minimum);
             Assert.Equal(10.5m, property.Maximum);
         }
+        
+        [Theory]
+        [InlineData("en-US")]
+        [InlineData("de-DE")]
+        [InlineData("nb-NO")]
+        public async Task When_Range_attribute_is_set_on_decimal_then_minimum_and_maximum_are_set_regardless_of_culture(string culture)
+        {
+            // Arrange
+            System.Threading.Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo(culture);
+            System.Threading.Thread.CurrentThread.CurrentUICulture = new System.Globalization.CultureInfo(culture);
+
+            // Act
+            var schema = NewtonsoftJsonSchemaGenerator.FromType<AttributeTestClass>();
+            var property = schema.Properties["Decimal"];
+
+            // Assert
+            Assert.Equal(5.5m, property.Minimum);
+            Assert.Equal(10.5m, property.Maximum);
+        }
 
         [Fact]
         public async Task When_Range_attribute_has_double_max_then_max_is_not_set()
@@ -177,6 +196,9 @@ namespace NJsonSchema.Tests.Generation
 
             [Range(5.5, 10.5)]
             public double Double { get; set; }
+
+            [Range(typeof(decimal), "5.5", "10.5")]
+            public double Decimal { get; set; }
 
             [Range(5.5, double.MaxValue)]
             public double DoubleOnlyMin { get; set; }

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -1300,7 +1300,7 @@ namespace NJsonSchema.Generation
                 {
                     if (rangeAttribute.OperandType == typeof(double))
                     {
-                        var minimum = (double)Convert.ChangeType(rangeAttribute.Minimum, typeof(double));
+                        var minimum = (double)Convert.ChangeType(rangeAttribute.Minimum, typeof(double), CultureInfo.InvariantCulture);
                         if (minimum > double.MinValue)
                         {
                             schema.Minimum = (decimal)minimum;
@@ -1308,7 +1308,7 @@ namespace NJsonSchema.Generation
                     }
                     else
                     {
-                        var minimum = (decimal)Convert.ChangeType(rangeAttribute.Minimum, typeof(decimal));
+                        var minimum = (decimal)Convert.ChangeType(rangeAttribute.Minimum, typeof(decimal), CultureInfo.InvariantCulture);
                         if (minimum > decimal.MinValue)
                         {
                             schema.Minimum = minimum;
@@ -1320,7 +1320,7 @@ namespace NJsonSchema.Generation
                 {
                     if (rangeAttribute.OperandType == typeof(double))
                     {
-                        var maximum = (double)Convert.ChangeType(rangeAttribute.Maximum, typeof(double));
+                        var maximum = (double)Convert.ChangeType(rangeAttribute.Maximum, typeof(double), CultureInfo.InvariantCulture);
                         if (maximum < double.MaxValue)
                         {
                             schema.Maximum = (decimal)maximum;
@@ -1328,7 +1328,7 @@ namespace NJsonSchema.Generation
                     }
                     else
                     {
-                        var maximum = (decimal)Convert.ChangeType(rangeAttribute.Maximum, typeof(decimal));
+                        var maximum = (decimal)Convert.ChangeType(rangeAttribute.Maximum, typeof(decimal), CultureInfo.InvariantCulture);
                         if (maximum < decimal.MaxValue)
                         {
                             schema.Maximum = maximum;


### PR DESCRIPTION
For cultures not using '.' as the decimal separator, JsonSchemaGenerator.ApplyRangeAttribute fails for Range attributes like this
```
[Range(typeof(decimal), "5.5", "10.5")]
public double Decimal { get; set; }
```

This PR fixes that by using InvariantCulture