### PR TITLE
Add ability to overwrite templates multiple times using templateFolder

### DIFF
--- a/src/NJsonSchema.CodeGeneration.Tests/NJsonSchema.CodeGeneration.Tests.csproj
+++ b/src/NJsonSchema.CodeGeneration.Tests/NJsonSchema.CodeGeneration.Tests.csproj
@@ -29,6 +29,7 @@
 
     <ItemGroup>
         <None Update="Templates\*.liquid" CopyToOutputDirectory="PreserveNewest" />
+        <None Update="Templates2\*.liquid" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
 
 </Project>

--- a/src/NJsonSchema.CodeGeneration.Tests/TemplateFactoryTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/TemplateFactoryTests.cs
@@ -25,4 +25,35 @@ public class TemplateFactoryTests
 
         Assert.Equal("WELCOME TO THE LIQUID TAG", templateResult);
     }
+
+    [Theory]
+    [InlineData("Templates", "sample-1", "sample-1-in-templates")]
+    [InlineData("Templates", "sample-2", "sample-2-in-templates")]
+    [InlineData("Templates2", "sample-2", "sample-2-in-templates-2")]
+    [InlineData("Templates2", "sample-3", "sample-3-in-templates-2")]
+    [InlineData("Templates2;Templates", "sample-1", "sample-1-in-templates")]
+    [InlineData("Templates2;Templates", "sample-2", "sample-2-in-templates-2")]
+    [InlineData("Templates2;Templates", "sample-3", "sample-3-in-templates-2")]
+    [InlineData("Templates;Templates2", "sample-1", "sample-1-in-templates")]
+    [InlineData("Templates;Templates2", "sample-2", "sample-2-in-templates")]
+    [InlineData("Templates;Templates2", "sample-3", "sample-3-in-templates-2")]
+    public void Can_override_templates(string templateDirectory, string templateName, string expectedResult)
+    {
+        var generatorSettings = new CSharpGeneratorSettings
+        {
+            TemplateDirectory = templateDirectory,
+        };
+
+        var factory = new DefaultTemplateFactory(generatorSettings, [typeof(CSharpGeneratorSettings).Assembly])
+        {
+            FluidParser = new LiquidParser(new FluidParserOptions { AllowLiquidTag = true }),
+        };
+        generatorSettings.TemplateFactory = factory;
+
+        var template = factory.CreateTemplate("csharp", templateName, new { });
+
+        var templateResult = template.Render();
+
+        Assert.Equal(expectedResult, templateResult);
+    }
 }

--- a/src/NJsonSchema.CodeGeneration.Tests/Templates/sample-1.liquid
+++ b/src/NJsonSchema.CodeGeneration.Tests/Templates/sample-1.liquid
@@ -1,0 +1,3 @@
+{% if true %}
+sample-1-in-templates
+{% endif %}

--- a/src/NJsonSchema.CodeGeneration.Tests/Templates/sample-2.liquid
+++ b/src/NJsonSchema.CodeGeneration.Tests/Templates/sample-2.liquid
@@ -1,0 +1,3 @@
+{% if true %}
+sample-2-in-templates
+{% endif %}

--- a/src/NJsonSchema.CodeGeneration.Tests/Templates2/sample-2.liquid
+++ b/src/NJsonSchema.CodeGeneration.Tests/Templates2/sample-2.liquid
@@ -1,0 +1,3 @@
+{% if true %}
+sample-2-in-templates-2
+{% endif %}

--- a/src/NJsonSchema.CodeGeneration.Tests/Templates2/sample-3.liquid
+++ b/src/NJsonSchema.CodeGeneration.Tests/Templates2/sample-3.liquid
@@ -1,0 +1,3 @@
+{% if true %}
+sample-3-in-templates-2
+{% endif %}

--- a/src/NJsonSchema.CodeGeneration/DefaultTemplateFactory.cs
+++ b/src/NJsonSchema.CodeGeneration/DefaultTemplateFactory.cs
@@ -121,10 +121,13 @@ namespace NJsonSchema.CodeGeneration
         {
             if (!template.EndsWith('!') && !string.IsNullOrEmpty(templateDirectory))
             {
-                var templateFilePath = Path.Combine(templateDirectory, template + ".liquid");
-                if (File.Exists(templateFilePath))
+                foreach (var directory in templateDirectory.Split([';'], StringSplitOptions.RemoveEmptyEntries))
                 {
-                    return File.ReadAllText(templateFilePath);
+                    var templateFilePath = Path.Combine(directory, template + ".liquid");
+                    if (File.Exists(templateFilePath))
+                    {
+                        return File.ReadAllText(templateFilePath);
+                    }
                 }
             }
 


### PR DESCRIPTION
For most of imports I am using one set of templates. But for some services I need to change templates slightly.
In order to avoid keeping full copy of templates, I proppose to use multiple template directories. So template factory will try to find template in the first directory, than in the second directory and so on until it comes to the default templates.
To fulfil this without changing settings I propose to split templateDirectory by semicolon (`;`) and to use nonempty parts as pathes to template directories.

Existing settings will be affected if template directory path contains semicolon. That seems to be very rare case, that can be easily fixed.