### PR TITLE
Optimize camel-casing logic

### DIFF
--- a/src/NJsonSchema.Benchmark/ConversionUtilitiesBenchmark.cs
+++ b/src/NJsonSchema.Benchmark/ConversionUtilitiesBenchmark.cs
@@ -1,0 +1,22 @@
+using BenchmarkDotNet.Attributes;
+
+namespace NJsonSchema.Benchmark;
+
+[MemoryDiagnoser]
+public class ConversionUtilitiesBenchmark
+{
+    [Params("example_string", "1another_example", "ConversionUtilities", "ConvertToUpperCamelCase", "/foo/bar/baz", "")]
+    public string Input { get; set; }
+
+    [Benchmark]
+    public string ConvertToUpperCamelCase()
+    {
+        return ConversionUtilities.ConvertToUpperCamelCase(Input, firstCharacterMustBeAlpha: true);
+    }
+
+    [Benchmark]
+    public string ConvertToLowerCamelCase()
+    {
+        return ConversionUtilities.ConvertToLowerCamelCase(Input, firstCharacterMustBeAlpha: true);
+    }
+}

--- a/src/NJsonSchema.Benchmark/NJsonSchema.Benchmark.csproj
+++ b/src/NJsonSchema.Benchmark/NJsonSchema.Benchmark.csproj
@@ -8,6 +8,7 @@
         <Nullable>disable</Nullable>
         <EnableNETAnalyzers>false</EnableNETAnalyzers>
         <ImplicitUsings>enable</ImplicitUsings>
+        <OutputType>exe</OutputType>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/NJsonSchema.Benchmark/Program.cs
+++ b/src/NJsonSchema.Benchmark/Program.cs
@@ -7,7 +7,7 @@ namespace NJsonSchema.Benchmark
         public static void Main(string[] args)
         {
             // RunCsharpBenchmark();
-            BenchmarkDotNet.Running.BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).RunAllJoined();
+            BenchmarkDotNet.Running.BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run();
         }
 
 #pragma warning disable IDE0051


### PR DESCRIPTION
### Before

| Method                  | Input                | Mean       | Error     | StdDev    | Gen0   | Allocated |
|------------------------ |--------------------- |-----------:|----------:|----------:|-------:|----------:|
| ConvertToUpperCamelCase |                      |  0.3441 ns | 0.0040 ns | 0.0033 ns |      - |         - |
| ConvertToLowerCamelCase |                      |  0.5143 ns | 0.0480 ns | 0.0375 ns |      - |         - |
| ConvertToUpperCamelCase | /foo/bar/baz         | 29.5615 ns | 0.6327 ns | 0.6214 ns | 0.0086 |     144 B |
| ConvertToLowerCamelCase | /foo/bar/baz         | 28.9756 ns | 0.4955 ns | 0.4635 ns | 0.0086 |     144 B |
| ConvertToUpperCamelCase | 1another_example     | 29.6893 ns | 0.5814 ns | 0.5438 ns | 0.0100 |     168 B |
| ConvertToLowerCamelCase | 1another_example     | 25.0458 ns | 0.4806 ns | 0.4261 ns | 0.0100 |     168 B |
| ConvertToUpperCamelCase | ConversionUtilities  |  6.9826 ns | 0.1744 ns | 0.1546 ns |      - |         - |
| ConvertToLowerCamelCase | ConversionUtilities  | 21.7164 ns | 0.4572 ns | 0.4053 ns | 0.0076 |     128 B |
| ConvertToUpperCamelCase | Conve(...)lCase [23] |  6.9988 ns | 0.1648 ns | 0.1376 ns |      - |         - |
| ConvertToLowerCamelCase | Conve(...)lCase [23] | 21.4348 ns | 0.4195 ns | 0.4831 ns | 0.0086 |     144 B |
| ConvertToUpperCamelCase | example_string       | 19.8070 ns | 0.4333 ns | 0.4449 ns | 0.0062 |     104 B |
| ConvertToLowerCamelCase | example_string       | 20.0670 ns | 0.4133 ns | 0.4920 ns | 0.0062 |     104 B |


### After


| Method                  | Input                | Mean       | Error     | StdDev    | Gen0   | Allocated |
|------------------------ |--------------------- |-----------:|----------:|----------:|-------:|----------:|
| ConvertToUpperCamelCase |                      |  0.5602 ns | 0.0116 ns | 0.0103 ns |      - |         - |
| ConvertToLowerCamelCase |                      |  0.5521 ns | 0.0148 ns | 0.0139 ns |      - |         - |
| ConvertToUpperCamelCase | /foo/bar/baz         | 15.0831 ns | 0.1451 ns | 0.1358 ns | 0.0029 |      48 B |
| ConvertToLowerCamelCase | /foo/bar/baz         | 14.8413 ns | 0.0972 ns | 0.0861 ns | 0.0029 |      48 B |
| ConvertToUpperCamelCase | 1another_example     | 10.2729 ns | 0.1326 ns | 0.1240 ns | 0.0033 |      56 B |
| ConvertToLowerCamelCase | 1another_example     | 10.1963 ns | 0.0691 ns | 0.0577 ns | 0.0033 |      56 B |
| ConvertToUpperCamelCase | ConversionUtilities  |  5.0268 ns | 0.0271 ns | 0.0240 ns |      - |         - |
| ConvertToLowerCamelCase | ConversionUtilities  | 15.9074 ns | 0.1184 ns | 0.0989 ns | 0.0076 |     128 B |
| ConvertToUpperCamelCase | Conve(...)lCase [23] |  5.0397 ns | 0.0408 ns | 0.0362 ns |      - |         - |
| ConvertToLowerCamelCase | Conve(...)lCase [23] | 15.6864 ns | 0.2202 ns | 0.2060 ns | 0.0086 |     144 B |
| ConvertToUpperCamelCase | example_string       | 15.6225 ns | 0.1158 ns | 0.1026 ns | 0.0062 |     104 B |
| ConvertToLowerCamelCase | example_string       |  5.1091 ns | 0.0320 ns | 0.0299 ns |      - |         - |
