### PR TITLE
Make enum description reading tolerant to invalid data

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/NJsonSchema.CodeGeneration.CSharp.Tests.csproj
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/NJsonSchema.CodeGeneration.CSharp.Tests.csproj
@@ -11,7 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Content Include="References\*.json" CopyToOutputDirectory="Always" />
+        <Content Include="References\*.json" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NJsonSchema.NewtonsoftJson.Tests/NJsonSchema.NewtonsoftJson.Tests.csproj
+++ b/src/NJsonSchema.NewtonsoftJson.Tests/NJsonSchema.NewtonsoftJson.Tests.csproj
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Content Include="References\**\*.json" CopyToOutputDirectory="Always" />
+        <Content Include="References\**\*.json" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NJsonSchema.Tests/Deserialization/DeserializationTests.cs
+++ b/src/NJsonSchema.Tests/Deserialization/DeserializationTests.cs
@@ -1,0 +1,14 @@
+using NJsonSchema.CodeGeneration.Tests;
+
+namespace NJsonSchema.Tests.Deserialization;
+
+public class DeserializationTests
+{
+    [Fact]
+    public async Task CanRoundTripPayPalOpenApi()
+    {
+        var schema = await JsonSchema.FromJsonAsync(File.OpenRead(Path.Combine("Deserialization", "TestData", "paypal_billing_subscriptions_v1.json")));
+
+        await VerifyHelper.Verify(schema.ToJson());
+    }
+}

--- a/src/NJsonSchema.Tests/Deserialization/Snapshots/DeserializationTests.CanRoundTripPayPalOpenApi.verified.txt
+++ b/src/NJsonSchema.Tests/Deserialization/Snapshots/DeserializationTests.CanRoundTripPayPalOpenApi.verified.txt
@@ -3075,8 +3075,12 @@
       },
       "application_context": {
         "title": "Application Context",
-        "description": "The application context, which customizes the payer experience during the subscription approval process with PayPal.",
         "type": "object",
+        "description": "The application context, which customizes the payer experience during the subscription approval process with PayPal.",
+        "required": [
+          "return_url",
+          "cancel_url"
+        ],
         "properties": {
           "brand_name": {
             "type": "string",
@@ -3092,25 +3096,10 @@
           "shipping_preference": {
             "type": "string",
             "description": "The location from which the shipping address is derived.",
-            "minLength": 1,
-            "maxLength": 24,
-            "pattern": "^[A-Z_]+$",
             "default": "GET_FROM_FILE",
-            "x-enumDescriptions": [
-              {
-                "value": "GET_FROM_FILE",
-                "description": "Get the customer-provided shipping address on the PayPal site.",
-                "default": true
-              },
-              {
-                "value": "NO_SHIPPING",
-                "description": "Redacts the shipping address from the PayPal site. Recommended for digital goods."
-              },
-              {
-                "value": "SET_PROVIDED_ADDRESS",
-                "description": "Get the merchant-provided address. The customer cannot change this address on the PayPal site. If merchant does not pass an address, customer can choose the address on PayPal pages."
-              }
-            ],
+            "maxLength": 24,
+            "minLength": 1,
+            "pattern": "^[A-Z_]+$",
             "enum": [
               "GET_FROM_FILE",
               "NO_SHIPPING",
@@ -3120,21 +3109,10 @@
           "user_action": {
             "type": "string",
             "description": "Configures the label name to `Continue` or `Subscribe Now` for subscription consent experience.",
-            "minLength": 1,
-            "maxLength": 24,
-            "pattern": "^[A-Z_]+$",
             "default": "SUBSCRIBE_NOW",
-            "x-enumDescriptions": [
-              {
-                "value": "CONTINUE",
-                "description": "After you redirect the customer to the PayPal subscription consent page, a <strong>Continue</strong> button appears. Use this option when you want to control the activation of the subscription and do not want PayPal to activate the subscription.",
-                "default": true
-              },
-              {
-                "value": "SUBSCRIBE_NOW",
-                "description": "After you redirect the customer to the PayPal subscription consent page, a <strong>Subscribe Now</strong> button appears. Use this option when you want PayPal to activate the subscription."
-              }
-            ],
+            "maxLength": 24,
+            "minLength": 1,
+            "pattern": "^[A-Z_]+$",
             "enum": [
               "CONTINUE",
               "SUBSCRIBE_NOW"
@@ -3164,11 +3142,7 @@
             "maxLength": 4000,
             "minLength": 10
           }
-        },
-        "required": [
-          "return_url",
-          "cancel_url"
-        ]
+        }
       },
       "authentication_response": {
         "title": "Authentication Response",
@@ -3185,8 +3159,13 @@
       },
       "billing_cycle": {
         "title": "Billing Cycle",
-        "description": "The billing cycle details.",
         "type": "object",
+        "description": "The billing cycle details.",
+        "required": [
+          "frequency",
+          "tenure_type",
+          "sequence"
+        ],
         "properties": {
           "pricing_scheme": {
             "description": "The active pricing scheme for this billing cycle. A free trial billing cycle does not require a pricing scheme.",
@@ -3199,19 +3178,9 @@
           "tenure_type": {
             "type": "string",
             "description": "The tenure type of the billing cycle. In case of a plan having trial cycle, only 2 trial cycles are allowed per plan.",
-            "minLength": 1,
             "maxLength": 24,
+            "minLength": 1,
             "pattern": "^[A-Z_]+$",
-            "x-enumDescriptions": [
-              {
-                "value": "REGULAR",
-                "description": "A regular billing cycle."
-              },
-              {
-                "value": "TRIAL",
-                "description": "A trial billing cycle."
-              }
-            ],
             "enum": [
               "REGULAR",
               "TRIAL"
@@ -3230,12 +3199,7 @@
             "maximum": 999.0,
             "minimum": 0.0
           }
-        },
-        "required": [
-          "frequency",
-          "tenure_type",
-          "sequence"
-        ]
+        }
       },
       "billing_cycle_list": {
         "type": "array",
@@ -3337,110 +3301,12 @@
         }
       },
       "card_brand": {
-        "type": "string",
         "title": "Card Brand",
+        "type": "string",
         "description": "The card network or brand. Applies to credit, debit, gift, and payment cards.",
-        "minLength": 1,
         "maxLength": 255,
+        "minLength": 1,
         "pattern": "^[A-Z_]+$",
-        "x-enumDescriptions": [
-          {
-            "value": "VISA",
-            "description": "Visa card."
-          },
-          {
-            "value": "MASTERCARD",
-            "description": "Mastecard card."
-          },
-          {
-            "value": "DISCOVER",
-            "description": "Discover card."
-          },
-          {
-            "value": "AMEX",
-            "description": "American Express card."
-          },
-          {
-            "value": "SOLO",
-            "description": "Solo debit card."
-          },
-          {
-            "value": "JCB",
-            "description": "Japan Credit Bureau card."
-          },
-          {
-            "value": "STAR",
-            "description": "Military Star card."
-          },
-          {
-            "value": "DELTA",
-            "description": "Delta Airlines card."
-          },
-          {
-            "value": "SWITCH",
-            "description": "Switch credit card."
-          },
-          {
-            "value": "MAESTRO",
-            "description": "Maestro credit card."
-          },
-          {
-            "value": "CB_NATIONALE",
-            "description": "Carte Bancaire (CB) credit card."
-          },
-          {
-            "value": "CONFIGOGA",
-            "description": "Configoga credit card."
-          },
-          {
-            "value": "CONFIDIS",
-            "description": "Confidis credit card."
-          },
-          {
-            "value": "ELECTRON",
-            "description": "Visa Electron credit card."
-          },
-          {
-            "value": "CETELEM",
-            "description": "Cetelem credit card."
-          },
-          {
-            "value": "CHINA_UNION_PAY",
-            "description": "China union pay credit card."
-          },
-          {
-            "value": "DINERS",
-            "description": "The Diners Club International banking and payment services capability network owned by Discover Financial Services (DFS), one of the most recognized brands in US financial services."
-          },
-          {
-            "value": "ELO",
-            "description": "The Brazilian Elo card payment network."
-          },
-          {
-            "value": "HIPER",
-            "description": "The Hiper - Ingenico ePayment network."
-          },
-          {
-            "value": "HIPERCARD",
-            "description": "The Brazilian Hipercard payment network that's widely accepted in the retail market."
-          },
-          {
-            "value": "RUPAY",
-            "description": "The RuPay payment network."
-          },
-          {
-            "value": "GE",
-            "description": "The GE Credit Union 3Point card payment network."
-          },
-          {
-            "value": "SYNCHRONY",
-            "description": "The Synchrony Financial (SYF) payment network."
-          },
-          {
-            "value": "UNKNOWN",
-            "description": "UNKNOWN payment network."
-          }
-        ],
         "enum": [
           "VISA",
           "MASTERCARD",
@@ -3614,34 +3480,12 @@
         ]
       },
       "card_type": {
-        "type": "string",
         "title": "Card Type",
+        "type": "string",
         "description": "Type of card. i.e Credit, Debit and so on.",
-        "minLength": 1,
         "maxLength": 255,
+        "minLength": 1,
         "pattern": "^[A-Z_]+$",
-        "x-enumDescriptions": [
-          {
-            "value": "CREDIT",
-            "description": "A credit card."
-          },
-          {
-            "value": "DEBIT",
-            "description": "A debit card."
-          },
-          {
-            "value": "PREPAID",
-            "description": "A Prepaid card."
-          },
-          {
-            "value": "STORE",
-            "description": "A store card."
-          },
-          {
-            "value": "UNKNOWN",
-            "description": "Card type cannot be determined."
-          }
-        ],
         "enum": [
           "CREDIT",
           "DEBIT",
@@ -3651,37 +3495,17 @@
         ]
       },
       "card_verification": {
-        "type": "object",
         "title": "Card Verification",
+        "type": "object",
         "description": "The API caller can opt in to verify the card through PayPal offered verification services (e.g. Smart Dollar Auth, 3DS).",
         "properties": {
           "method": {
-            "description": "The method used for card verification.",
             "type": "string",
-            "minLength": 1,
-            "maxLength": 255,
-            "pattern": "^[0-9A-Z_]+$",
+            "description": "The method used for card verification.",
             "default": "SCA_WHEN_REQUIRED",
-            "x-enumDescriptions": [
-              {
-                "value": "SCA_ALWAYS",
-                "description": "Selecting this option will attempt to force a strong customer authentication for the authorization/transaction. In countries where SCA has been defined and implemented it will result in a contingency and HATEOAS link being returned.  The API caller should redirect the payer to that link so that they can authenticate themselves against their issuing bank or other entity. As noted, the HATEOAS link is only available in all regions where strong authentication is supported, (e.g. in European countries where 3DS is live). Merchants can use this setting as an additional layer of security if they choose to. In all cases, when an authorization is requested the AVS/CVV results will be returned in the response."
-              },
-              {
-                "value": "SCA_WHEN_REQUIRED",
-                "description": "This is the default. When an authorization or transaction is attempted this option will return a contingency and HATEOAS link only when local regulations require strong customer authentication, (e.g. 3DS in countries and use cases where it is mandated). The API caller should redirect the payer to the link so that they can authenticate themselves. In all cases, when an authorization is requested the AVS/CVV results will be returned in the response."
-              },
-              {
-                "value": "3D_SECURE",
-                "description": "The contingency surfaced as an additional security layer that helps prevent unauthorized card-not-present transactions and protects the merchant from exposure to fraud.",
-                "deprecated": true
-              },
-              {
-                "value": "AVS_CVV",
-                "description": "Places a temporary hold on the card to ensure its validity. This process protects the merchant from exposure to fraud. This verification method will confirm that the address information or CVV included matches what the issuing bank has on file for the associated card, ensuring that only authorized card users are able to make purchases from you.",
-                "deprecated": true
-              }
-            ],
+            "maxLength": 255,
+            "minLength": 1,
+            "pattern": "^[0-9A-Z_]+$",
             "enum": [
               "SCA_ALWAYS",
               "SCA_WHEN_REQUIRED",
@@ -3734,26 +3558,21 @@
       },
       "cycle_execution": {
         "title": "Billing Cycle Execution Details",
-        "description": "The regular and trial execution details for a billing cycle.",
         "type": "object",
+        "description": "The regular and trial execution details for a billing cycle.",
+        "required": [
+          "tenure_type",
+          "sequence",
+          "cycles_completed"
+        ],
         "properties": {
           "tenure_type": {
             "type": "string",
+            "readonly": true,
             "description": "The type of the billing cycle.",
-            "minLength": 1,
             "maxLength": 24,
+            "minLength": 1,
             "pattern": "^[A-Z_]+$",
-            "x-enumDescriptions": [
-              {
-                "value": "REGULAR",
-                "description": "A regular billing cycle."
-              },
-              {
-                "value": "TRIAL",
-                "description": "A trial billing cycle."
-              }
-            ],
-            "readOnly": true,
             "enum": [
               "REGULAR",
               "TRIAL"
@@ -3767,38 +3586,33 @@
           },
           "cycles_completed": {
             "type": "integer",
+            "readonly": true,
             "description": "The number of billing cycles that have completed.",
             "maximum": 9999.0,
-            "minimum": 0.0,
-            "readOnly": true
+            "minimum": 0.0
           },
           "cycles_remaining": {
             "type": "integer",
+            "readonly": true,
             "description": "For a finite billing cycle, cycles_remaining is the number of remaining cycles. For an infinite billing cycle, cycles_remaining is set as 0.",
             "maximum": 9999.0,
-            "minimum": 0.0,
-            "readOnly": true
+            "minimum": 0.0
           },
           "current_pricing_scheme_version": {
             "type": "integer",
+            "readonly": true,
             "description": "The active pricing scheme version for the billing cycle.",
             "maximum": 99.0,
-            "minimum": 1.0,
-            "readOnly": true
+            "minimum": 1.0
           },
           "total_cycles": {
             "type": "integer",
+            "readonly": true,
             "description": "The number of times this billing cycle gets executed. Trial billing cycles can only be executed a finite number of times (value between <code>1</code> and <code>999</code> for <code>total_cycles</code>). Regular billing cycles can be executed infinite times (value of <code>0</code> for <code>total_cycles</code>) or a finite number of times (value between <code>1</code> and <code>999</code> for <code>total_cycles</code>).",
             "maximum": 999.0,
-            "minimum": 0.0,
-            "readOnly": true
+            "minimum": 0.0
           }
-        },
-        "required": [
-          "tenure_type",
-          "sequence",
-          "cycles_completed"
-        ]
+        }
       },
       "cycle_execution_list": {
         "type": "array",
@@ -3852,28 +3666,10 @@
       },
       "enrolled": {
         "type": "string",
-        "minLength": 1,
-        "maxLength": 255,
-        "pattern": "^[0-9A-Z_]+$",
         "description": "Status of Authentication eligibility.",
-        "x-enumDescriptions": [
-          {
-            "value": "Y",
-            "description": "Yes. The bank is participating in 3-D Secure protocol and will return the ACSUrl."
-          },
-          {
-            "value": "N",
-            "description": "No. The bank is not participating in 3-D Secure protocol."
-          },
-          {
-            "value": "U",
-            "description": "Unavailable. The DS or ACS is not available for authentication at the time of the request."
-          },
-          {
-            "value": "B",
-            "description": "Bypass. The merchant authentication rule is triggered to bypass authentication."
-          }
-        ],
+        "maxLength": 255,
+        "minLength": 1,
+        "pattern": "^[0-9A-Z_]+$",
         "enum": [
           "Y",
           "N",
@@ -4331,60 +4127,30 @@
       },
       "failed_payment_details": {
         "title": "Failed Payment Details",
-        "description": "The details for the failed payment of the subscription.",
         "type": "object",
+        "description": "The details for the failed payment of the subscription.",
+        "required": [
+          "amount",
+          "time"
+        ],
         "properties": {
           "amount": {
+            "readonly": true,
             "description": "The failed payment amount.",
-            "readOnly": true,
             "$ref": "#/components/schemas/money"
           },
           "time": {
+            "readonly": true,
             "description": "The date and time when the failed payment was made, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
-            "readOnly": true,
             "$ref": "#/components/schemas/date_time"
           },
           "reason_code": {
             "type": "string",
+            "readonly": true,
             "description": "The reason code for the payment failure.",
-            "minLength": 1,
             "maxLength": 120,
+            "minLength": 1,
             "pattern": "^[A-Z_]+$",
-            "x-enumDescriptions": [
-              {
-                "value": "PAYMENT_DENIED",
-                "description": "PayPal declined the payment due to one or more customer issues."
-              },
-              {
-                "value": "INTERNAL_SERVER_ERROR",
-                "description": "An internal server error has occurred."
-              },
-              {
-                "value": "PAYEE_ACCOUNT_RESTRICTED",
-                "description": "The payee account is not in good standing and cannot receive payments."
-              },
-              {
-                "value": "PAYER_ACCOUNT_RESTRICTED",
-                "description": "The payer account is not in good standing and cannot make payments."
-              },
-              {
-                "value": "PAYER_CANNOT_PAY",
-                "description": "Payer cannot pay for this transaction."
-              },
-              {
-                "value": "SENDING_LIMIT_EXCEEDED",
-                "description": "The transaction exceeds the payer's sending limit."
-              },
-              {
-                "value": "TRANSACTION_RECEIVING_LIMIT_EXCEEDED",
-                "description": "The transaction exceeds the receiver's receiving limit."
-              },
-              {
-                "value": "CURRENCY_MISMATCH",
-                "description": "The transaction is declined due to a currency mismatch."
-              }
-            ],
-            "readOnly": true,
             "enum": [
               "PAYMENT_DENIED",
               "INTERNAL_SERVER_ERROR",
@@ -4397,45 +4163,26 @@
             ]
           },
           "next_payment_retry_time": {
+            "readonly": true,
             "description": "The time when the retry attempt for the failed payment occurs, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
-            "readOnly": true,
             "$ref": "#/components/schemas/date_time"
           }
-        },
-        "required": [
-          "amount",
-          "time"
-        ]
+        }
       },
       "frequency": {
         "title": "Billing Cycle Frequency",
-        "description": "The frequency of the billing cycle.",
         "type": "object",
+        "description": "The frequency of the billing cycle.",
+        "required": [
+          "interval_unit"
+        ],
         "properties": {
           "interval_unit": {
             "type": "string",
             "description": "The interval at which the subscription is charged or billed.",
-            "minLength": 1,
             "maxLength": 24,
+            "minLength": 1,
             "pattern": "^[A-Z_]+$",
-            "x-enumDescriptions": [
-              {
-                "value": "DAY",
-                "description": "A daily billing cycle."
-              },
-              {
-                "value": "WEEK",
-                "description": "A weekly billing cycle."
-              },
-              {
-                "value": "MONTH",
-                "description": "A monthly billing cycle."
-              },
-              {
-                "value": "YEAR",
-                "description": "A yearly billing cycle."
-              }
-            ],
             "enum": [
               "DAY",
               "WEEK",
@@ -4450,10 +4197,7 @@
             "maximum": 365.0,
             "minimum": 1.0
           }
-        },
-        "required": [
-          "interval_unit"
-        ]
+        }
       },
       "language": {
         "type": "string",
@@ -4490,24 +4234,10 @@
       },
       "liability_shift": {
         "type": "string",
-        "minLength": 1,
-        "maxLength": 255,
-        "pattern": "^[0-9A-Z_]+$",
         "description": "Liability shift indicator. The outcome of the issuer's authentication.",
-        "x-enumDescriptions": [
-          {
-            "value": "NO",
-            "description": "Liability is with the merchant."
-          },
-          {
-            "value": "POSSIBLE",
-            "description": "Liability may shift to the card issuer."
-          },
-          {
-            "value": "UNKNOWN",
-            "description": "The authentication system is not available."
-          }
-        ],
+        "maxLength": 255,
+        "minLength": 1,
+        "pattern": "^[0-9A-Z_]+$",
         "enum": [
           "NO",
           "POSSIBLE",
@@ -4624,44 +4354,10 @@
       },
       "pares_status": {
         "type": "string",
-        "minLength": 1,
-        "maxLength": 255,
-        "pattern": "^[0-9A-Z_]+$",
         "description": "Transactions status result identifier. The outcome of the issuer's authentication.",
-        "x-enumDescriptions": [
-          {
-            "value": "Y",
-            "description": "Successful authentication."
-          },
-          {
-            "value": "N",
-            "description": "Failed authentication / account not verified / transaction denied."
-          },
-          {
-            "value": "U",
-            "description": "Unable to complete authentication."
-          },
-          {
-            "value": "A",
-            "description": "Successful attempts transaction."
-          },
-          {
-            "value": "C",
-            "description": "Challenge required for authentication."
-          },
-          {
-            "value": "R",
-            "description": "Authentication rejected (merchant must not submit for authorization)."
-          },
-          {
-            "value": "D",
-            "description": "Challenge required; decoupled authentication confirmed."
-          },
-          {
-            "value": "I",
-            "description": "Informational only; 3DS requestor challenge preference acknowledged."
-          }
-        ],
+        "maxLength": 255,
+        "minLength": 1,
+        "pattern": "^[0-9A-Z_]+$",
         "enum": [
           "Y",
           "N",
@@ -4674,39 +4370,16 @@
         ]
       },
       "patch": {
-        "type": "object",
         "title": "Patch",
+        "type": "object",
         "description": "The JSON patch object to apply partial updates to resources.",
+        "required": [
+          "op"
+        ],
         "properties": {
           "op": {
             "type": "string",
             "description": "The operation.",
-            "x-enumDescriptions": [
-              {
-                "value": "add",
-                "description": "Depending on the target location reference, completes one of these functions:<ul><li><strong>The target location is an array index</strong>. Inserts a new value into the array at the specified index.</li><li><strong>The target location is an object parameter that does not already exist</strong>. Adds a new parameter to the object.</li><li><strong>The target location is an object parameter that does exist</strong>. Replaces that parameter's value.</li></ul>The <code>value</code> parameter defines the value to add. For more information, see <a href=\"https://tools.ietf.org/html/rfc6902#section-4.1\">4.1. add</a>."
-              },
-              {
-                "value": "remove",
-                "description": "Removes the value at the target location. For the operation to succeed, the target location must exist. For more information, see <a href=\"https://tools.ietf.org/html/rfc6902#section-4.2\">4.2. remove</a>."
-              },
-              {
-                "value": "replace",
-                "description": "Replaces the value at the target location with a new value. The operation object must contain a <code>value</code> parameter that defines the replacement value. For the operation to succeed, the target location must exist. For more information, see <a href=\"https://tools.ietf.org/html/rfc6902#section-4.3\">4.3. replace</a>."
-              },
-              {
-                "value": "move",
-                "description": "Removes the value at a specified location and adds it to the target location. The operation object must contain a <code>from</code> parameter, which is a string that contains a JSON pointer value that references the location in the target document from which to move the value. For the operation to succeed, the <code>from</code> location must exist. For more information, see <a href=\"https://tools.ietf.org/html/rfc6902#section-4.4\">4.4. move</a>."
-              },
-              {
-                "value": "copy",
-                "description": "Copies the value at a specified location to the target location. The operation object must contain a <code>from</code> parameter, which is a string that contains a JSON pointer value that references the location in the target document from which to copy the value. For the operation to succeed, the <code>from</code> location must exist. For more information, see <a href=\"https://tools.ietf.org/html/rfc6902#section-4.5\">4.5. copy</a>."
-              },
-              {
-                "value": "test",
-                "description": "Tests that a value at the target location is equal to a specified value. The operation object must contain a <code>value</code> parameter that defines the value to compare to the target location's value. For the operation to succeed, the target location must be equal to the <code>value</code> value. For test, <code>equal</code> indicates that the value at the target location and the value that <code>value</code> defines are of the same JSON type. The data type of the value determines how equality is defined:<table><thead align=\"left\"><tr><th>Type</th><th>Considered equal if both values</th></tr></thead><tbody align=\"left\"><tr><td><strong>strings</strong></td><td>Contain the same number of Unicode characters and their code points are byte-by-byte equal.</td></tr><tr><td><strong>numbers</strong></td><td>Are numerically equal.</td></tr><tr><td><strong>arrays</strong></td><td>Contain the same number of values, and each value is equal to the value at the corresponding position in the other array, by using these type-specific rules.</td></tr><tr><td><strong>objects</strong></td><td>Contain the same number of parameters, and each parameter is equal to a parameter in the other object, by comparing their keys (as strings) and their values (by using these type-specific rules).</td></tr><tr><td><strong>literals (<code>false</code>, <code>true</code>, and <code>null</code>)</strong></td><td>Are the same. The comparison is a logical comparison. For example, whitespace between the parameter values of an array is not significant. Also, ordering of the serialization of object parameters is not significant.</td></tr></tbody></table>For more information, see <a href=\"https://tools.ietf.org/html/rfc6902#section-4.6\">4.6. test</a>."
-              }
-            ],
             "enum": [
               "add",
               "remove",
@@ -4728,10 +4401,7 @@
             "type": "string",
             "description": "The <a href=\"https://tools.ietf.org/html/rfc6901\">JSON Pointer</a> to the target document location from which to move the value. Required for the <code>move</code> operation."
           }
-        },
-        "required": [
-          "op"
-        ]
+        }
       },
       "patch_request": {
         "title": "Patch Request",
@@ -4744,21 +4414,10 @@
       "payee_payment_method_preference": {
         "type": "string",
         "description": "The merchant-preferred payment methods.",
-        "minLength": 1,
-        "maxLength": 255,
-        "pattern": "^[0-9A-Z_]+$",
         "default": "UNRESTRICTED",
-        "x-enumDescriptions": [
-          {
-            "value": "UNRESTRICTED",
-            "description": "Accepts any type of payment from the customer.",
-            "default": true
-          },
-          {
-            "value": "IMMEDIATE_PAYMENT_REQUIRED",
-            "description": "Accepts only immediate payment from the customer. For example, credit card, PayPal balance, or instant ACH. Ensures that at the time of capture, the payment does not have the `pending` status."
-          }
-        ],
+        "maxLength": 255,
+        "minLength": 1,
+        "pattern": "^[0-9A-Z_]+$",
         "enum": [
           "UNRESTRICTED",
           "IMMEDIATE_PAYMENT_REQUIRED"
@@ -4782,8 +4441,8 @@
       },
       "payment_preferences": {
         "title": "Payment Preferences",
-        "description": "The payment preferences for a subscription.",
         "type": "object",
+        "description": "The payment preferences for a subscription.",
         "properties": {
           "auto_bill_outstanding": {
             "type": "boolean",
@@ -4797,20 +4456,10 @@
           "setup_fee_failure_action": {
             "type": "string",
             "description": "The action to take on the subscription if the initial payment for the setup fails.",
-            "minLength": 1,
-            "maxLength": 24,
-            "pattern": "^[A-Z_]+$",
             "default": "CANCEL",
-            "x-enumDescriptions": [
-              {
-                "value": "CONTINUE",
-                "description": "Continues the subscription if the initial payment for the setup fails."
-              },
-              {
-                "value": "CANCEL",
-                "description": "Cancels the subscription if the initial payment for the setup fails."
-              }
-            ],
+            "maxLength": 24,
+            "minLength": 1,
+            "pattern": "^[A-Z_]+$",
             "enum": [
               "CONTINUE",
               "CANCEL"
@@ -4827,8 +4476,8 @@
       },
       "payment_preferences_override": {
         "title": "Payment Preferences Override",
-        "description": "The payment preferences to override at subscription level.",
         "type": "object",
+        "description": "The payment preferences to override at subscription level.",
         "properties": {
           "auto_bill_outstanding": {
             "type": "boolean",
@@ -4841,19 +4490,9 @@
           "setup_fee_failure_action": {
             "type": "string",
             "description": "The action to take on the subscription if the initial payment for the setup fails.",
-            "minLength": 1,
             "maxLength": 24,
+            "minLength": 1,
             "pattern": "^[A-Z_]+$",
-            "x-enumDescriptions": [
-              {
-                "value": "CONTINUE",
-                "description": "Continues the subscription if the initial payment for the setup fails."
-              },
-              {
-                "value": "CANCEL",
-                "description": "Cancels the subscription if the initial payment for the setup fails."
-              }
-            ],
             "enum": [
               "CONTINUE",
               "CANCEL"
@@ -5016,16 +4655,16 @@
       },
       "plan": {
         "title": "Plan",
-        "description": "The plan details.",
         "type": "object",
+        "description": "The plan details.",
         "properties": {
           "id": {
             "type": "string",
+            "readonly": true,
             "description": "The unique PayPal-generated ID for the plan.",
             "maxLength": 26,
             "minLength": 26,
-            "pattern": "^P-[A-Z0-9]*$",
-            "readOnly": true
+            "pattern": "^P-[A-Z0-9]*$"
           },
           "product_id": {
             "type": "string",
@@ -5044,23 +4683,9 @@
           "status": {
             "type": "string",
             "description": "The plan status.",
-            "minLength": 1,
             "maxLength": 24,
+            "minLength": 1,
             "pattern": "^[A-Z_]+$",
-            "x-enumDescriptions": [
-              {
-                "value": "CREATED",
-                "description": "The plan was created. You cannot create subscriptions for a plan in this state."
-              },
-              {
-                "value": "INACTIVE",
-                "description": "The plan is inactive."
-              },
-              {
-                "value": "ACTIVE",
-                "description": "The plan is active. You can only create subscriptions for a plan in this state."
-              }
-            ],
             "enum": [
               "CREATED",
               "INACTIVE",
@@ -5089,13 +4714,13 @@
             "default": false
           },
           "create_time": {
+            "readonly": true,
             "description": "The date and time when the plan was created, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
-            "readOnly": true,
             "$ref": "#/components/schemas/date_time"
           },
           "update_time": {
+            "readonly": true,
             "description": "The date and time when the plan was last updated, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
-            "readOnly": true,
             "$ref": "#/components/schemas/date_time"
           },
           "links": {
@@ -5154,8 +4779,14 @@
       },
       "plan_request_POST": {
         "title": "Create Plan Request",
-        "description": "The create plan request details.",
         "type": "object",
+        "description": "The create plan request details.",
+        "required": [
+          "name",
+          "billing_cycles",
+          "payment_preferences",
+          "product_id"
+        ],
         "properties": {
           "product_id": {
             "type": "string",
@@ -5174,24 +4805,10 @@
           "status": {
             "type": "string",
             "description": "The initial state of the plan. Allowed input values are CREATED and ACTIVE.",
-            "minLength": 1,
-            "maxLength": 24,
-            "pattern": "^[A-Z_]+$",
             "default": "ACTIVE",
-            "x-enumDescriptions": [
-              {
-                "value": "CREATED",
-                "description": "The plan was created. You cannot create subscriptions for a plan in this state."
-              },
-              {
-                "value": "INACTIVE",
-                "description": "The plan is inactive."
-              },
-              {
-                "value": "ACTIVE",
-                "description": "The plan is active. You can only create subscriptions for a plan in this state."
-              }
-            ],
+            "maxLength": 24,
+            "minLength": 1,
+            "pattern": "^[A-Z_]+$",
             "enum": [
               "CREATED",
               "INACTIVE",
@@ -5219,13 +4836,7 @@
             "description": "Indicates whether you can subscribe to this plan by providing a quantity for the goods or service.",
             "default": false
           }
-        },
-        "required": [
-          "name",
-          "billing_cycles",
-          "payment_preferences",
-          "product_id"
-        ]
+        }
       },
       "plans.activate-422": {
         "properties": {
@@ -5833,15 +5444,15 @@
       },
       "pricing_scheme": {
         "title": "Pricing Scheme",
-        "description": "The pricing scheme details.",
         "type": "object",
+        "description": "The pricing scheme details.",
         "properties": {
           "version": {
             "type": "integer",
+            "readonly": true,
             "description": "The version of the pricing scheme.",
             "maximum": 999.0,
-            "minimum": 0.0,
-            "readOnly": true
+            "minimum": 0.0
           },
           "fixed_price": {
             "description": "The fixed amount to charge for the subscription. The changes to fixed amount are applicable to both existing and future subscriptions. For existing subscriptions, payments within 10 days of price change are not affected.",
@@ -5850,19 +5461,9 @@
           "pricing_model": {
             "type": "string",
             "description": "The pricing model for tiered plan. The `tiers` parameter is required.",
-            "minLength": 1,
             "maxLength": 24,
+            "minLength": 1,
             "pattern": "^[A-Z_]+$",
-            "x-enumDescriptions": [
-              {
-                "value": "VOLUME",
-                "description": "A volume pricing model."
-              },
-              {
-                "value": "TIERED",
-                "description": "A tiered pricing model."
-              }
-            ],
             "enum": [
               "VOLUME",
               "TIERED"
@@ -5872,13 +5473,13 @@
             "$ref": "#/components/schemas/pricing_tier_list"
           },
           "create_time": {
+            "readonly": true,
             "description": "The date and time when this pricing scheme was created, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
-            "readOnly": true,
             "$ref": "#/components/schemas/date_time"
           },
           "update_time": {
+            "readonly": true,
             "description": "The date and time when this pricing scheme was last updated, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
-            "readOnly": true,
             "$ref": "#/components/schemas/date_time"
           }
         }
@@ -5937,9 +5538,9 @@
         }
       },
       "shipping_detail": {
+        "title": "Shipping Details",
         "type": "object",
         "description": "The shipping details.",
-        "title": "Shipping Details",
         "properties": {
           "name": {
             "title": "Name",
@@ -5952,6 +5553,20 @@
                 "maxLength": 300
               }
             }
+          },
+          "type": {
+            "title": "Fullfillment Type",
+            "type": "string",
+            "description": "A classification for the method of purchase fulfillment (e.g shipping, in-store pickup, etc). Either `type` or `options` may be present, but not both.",
+            "maxLength": 255,
+            "minLength": 1,
+            "pattern": "^[0-9A-Z_]+$",
+            "enum": [
+              "SHIPPING",
+              "PICKUP_IN_PERSON",
+              "PICKUP_IN_STORE",
+              "PICKUP_FROM_PERSON"
+            ]
           },
           "options": {
             "$ref": "#/components/schemas/shipping_option_list"
@@ -6039,28 +5654,9 @@
         }
       },
       "shipping_type": {
-        "type": "string",
         "title": "Shipping Type",
+        "type": "string",
         "description": "A classification for the method of purchase fulfillment.",
-        "x-enumDescriptions": [
-          {
-            "value": "SHIPPING",
-            "description": "The payer intends to receive the items at a specified address.",
-            "default": true
-          },
-          {
-            "value": "PICKUP",
-            "description": "DEPRECATED. To ensure that seller protection is correctly assigned, please use 'PICKUP_IN_STORE' or 'PICKUP_FROM_PERSON' instead. Currently, this field indicates that the payer intends to pick up the items at a specified address (ie. a store address). "
-          },
-          {
-            "value": "PICKUP_IN_STORE",
-            "description": "The payer intends to pick up the item(s) from the payee's physical store. Also termed as BOPIS, \"Buy Online, Pick-up in Store\". Seller protection is provided with this option."
-          },
-          {
-            "value": "PICKUP_FROM_PERSON",
-            "description": "The payer intends to pick up the item(s) from the payee in person. Also termed as BOPIP, \"Buy Online, Pick-up in Person\". Seller protection is not available, since the payer is receiving the item from the payee in person, and can validate the item prior to payment."
-          }
-        ],
         "enum": [
           "SHIPPING",
           "PICKUP",
@@ -6071,15 +5667,9 @@
       "store_in_vault_instruction": {
         "type": "string",
         "description": "Defines how and when the payment source gets vaulted.",
-        "minLength": 1,
         "maxLength": 255,
+        "minLength": 1,
         "pattern": "^[0-9A-Z_]+$",
-        "x-enumDescriptions": [
-          {
-            "value": "ON_SUCCESS",
-            "description": "Defines that the payment_source will be vaulted only when at least one authorization or capture using that payment_source is successful."
-          }
-        ],
         "enum": [
           "ON_SUCCESS"
         ]
@@ -6383,8 +5973,13 @@
       },
       "subscription_capture_request": {
         "title": "Charge Amount from Subscriber",
-        "description": "The charge amount from the subscriber.",
         "type": "object",
+        "description": "The charge amount from the subscriber.",
+        "required": [
+          "note",
+          "capture_type",
+          "amount"
+        ],
         "properties": {
           "note": {
             "type": "string",
@@ -6396,29 +5991,18 @@
           "capture_type": {
             "type": "string",
             "description": "The type of capture.",
-            "minLength": 1,
             "maxLength": 24,
+            "minLength": 1,
             "pattern": "^[A-Z_]+$",
-            "x-enumDescriptions": [
-              {
-                "value": "OUTSTANDING_BALANCE",
-                "description": "The outstanding balance that the subscriber must clear."
-              }
-            ],
             "enum": [
               "OUTSTANDING_BALANCE"
             ]
           },
           "amount": {
-            "$ref": "#/components/schemas/money",
-            "description": "The amount of the outstanding balance. This value cannot be greater than the current outstanding balance amount."
+            "description": "The amount of the outstanding balance. This value cannot be greater than the current outstanding balance amount.",
+            "$ref": "#/components/schemas/money"
           }
-        },
-        "required": [
-          "note",
-          "capture_type",
-          "amount"
-        ]
+        }
       },
       "subscription_request_post": {
         "title": "Create Subscription Request",
@@ -6482,8 +6066,8 @@
       },
       "subscription_revise_request": {
         "title": "Subscription Modify Plan Request",
-        "description": "The request to update the quantity of the product or service in a subscription. You can also use this method to switch the plan and update the `shipping_amount` and `shipping_address` values for the subscription. This type of update requires the buyer's consent.",
         "type": "object",
+        "description": "The request to update the quantity of the product or service in a subscription. You can also use this method to switch the plan and update the `shipping_amount` and `shipping_address` values for the subscription. This type of update requires the buyer's consent.",
         "properties": {
           "plan_id": {
             "type": "string",
@@ -6509,8 +6093,12 @@
           },
           "application_context": {
             "title": "Application Context",
-            "description": "The application context, which customizes the payer experience during the subscription approval process with PayPal.",
             "type": "object",
+            "description": "The application context, which customizes the payer experience during the subscription approval process with PayPal.",
+            "required": [
+              "return_url",
+              "cancel_url"
+            ],
             "properties": {
               "brand_name": {
                 "type": "string",
@@ -6526,25 +6114,10 @@
               "shipping_preference": {
                 "type": "string",
                 "description": "The location from which the shipping address is derived.",
-                "minLength": 1,
-                "maxLength": 24,
-                "pattern": "^[A-Z_]+$",
                 "default": "GET_FROM_FILE",
-                "x-enumDescriptions": [
-                  {
-                    "value": "GET_FROM_FILE",
-                    "description": "Get the customer-provided shipping address on the PayPal site.",
-                    "default": true
-                  },
-                  {
-                    "value": "NO_SHIPPING",
-                    "description": "Redacts the shipping address from the PayPal site. Recommended for digital goods."
-                  },
-                  {
-                    "value": "SET_PROVIDED_ADDRESS",
-                    "description": "Get the merchant-provided address. The customer cannot change this address on the PayPal site. If merchant does not pass an address, customer can choose the address on PayPal pages."
-                  }
-                ],
+                "maxLength": 24,
+                "minLength": 1,
+                "pattern": "^[A-Z_]+$",
                 "enum": [
                   "GET_FROM_FILE",
                   "NO_SHIPPING",
@@ -6575,11 +6148,7 @@
                 "maxLength": 4000,
                 "minLength": 10
               }
-            },
-            "required": [
-              "return_url",
-              "cancel_url"
-            ]
+            }
           },
           "plan": {
             "description": "An inline plan object to customise the subscription. You can override plan level default attributes by providing customised values for the subscription in this object. Any existing overrides will not be carried forward during subscription revise.",
@@ -6638,41 +6207,15 @@
       },
       "subscription_status": {
         "title": "Subscription Status",
-        "description": "The subscription status details.",
         "type": "object",
+        "description": "The subscription status details.",
         "properties": {
           "status": {
             "type": "string",
             "description": "The status of the subscription.",
-            "minLength": 1,
             "maxLength": 24,
+            "minLength": 1,
             "pattern": "^[A-Z_]+$",
-            "x-enumDescriptions": [
-              {
-                "value": "APPROVAL_PENDING",
-                "description": "The subscription is created but not yet approved by the buyer."
-              },
-              {
-                "value": "APPROVED",
-                "description": "The buyer has approved the subscription."
-              },
-              {
-                "value": "ACTIVE",
-                "description": "The subscription is active."
-              },
-              {
-                "value": "SUSPENDED",
-                "description": "The subscription is suspended."
-              },
-              {
-                "value": "CANCELLED",
-                "description": "The subscription is cancelled."
-              },
-              {
-                "value": "EXPIRED",
-                "description": "The subscription is expired."
-              }
-            ],
             "enum": [
               "APPROVAL_PENDING",
               "APPROVED",
@@ -6690,7 +6233,7 @@
             "pattern": "^.*$"
           },
           "status_update_time": {
-            "readOnly": true,
+            "readonly": true,
             "$ref": "#/components/schemas/date_time"
           }
         }
@@ -8536,41 +8079,20 @@
         }
       },
       "transaction": {
-        "type": "object",
         "title": "Transaction Details",
+        "type": "object",
         "description": "The transaction details.",
+        "required": [
+          "id",
+          "amount_with_breakdown",
+          "time"
+        ],
         "properties": {
           "status": {
             "title": "Capture Status",
-            "description": "The status of the captured payment.",
             "type": "string",
-            "x-enumDescriptions": [
-              {
-                "value": "COMPLETED",
-                "description": "The funds for this captured payment were credited to the payee's PayPal account."
-              },
-              {
-                "value": "DECLINED",
-                "description": "The funds could not be captured."
-              },
-              {
-                "value": "PARTIALLY_REFUNDED",
-                "description": "An amount less than this captured payment's amount was partially refunded to the payer."
-              },
-              {
-                "value": "PENDING",
-                "description": "The funds for this captured payment was not yet credited to the payee's PayPal account. For more information, see <code>status.details</code>."
-              },
-              {
-                "value": "REFUNDED",
-                "description": "An amount greater than or equal to this captured payment's amount was refunded to the payer."
-              },
-              {
-                "value": "FAILED",
-                "description": "There was an error while capturing payment."
-              }
-            ],
-            "readOnly": true,
+            "readonly": true,
+            "description": "The status of the captured payment.",
             "enum": [
               "COMPLETED",
               "DECLINED",
@@ -8582,35 +8104,30 @@
           },
           "id": {
             "type": "string",
+            "readonly": true,
             "description": "The PayPal-generated transaction ID.",
             "maxLength": 50,
-            "minLength": 3,
-            "readOnly": true
+            "minLength": 3
           },
           "amount_with_breakdown": {
             "$ref": "#/components/schemas/amount_with_breakdown"
           },
           "payer_name": {
+            "readonly": true,
             "description": "The name of the customer.",
-            "readOnly": true,
             "$ref": "#/components/schemas/name"
           },
           "payer_email": {
+            "readonly": true,
             "description": "The email ID of the customer.",
-            "readOnly": true,
             "$ref": "#/components/schemas/email_address"
           },
           "time": {
+            "readonly": true,
             "description": "The date and time when the transaction was processed, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
-            "readOnly": true,
             "$ref": "#/components/schemas/date_time"
           }
-        },
-        "required": [
-          "id",
-          "amount_with_breakdown",
-          "time"
-        ]
+        }
       },
       "transaction_list": {
         "type": "array",
@@ -8698,8 +8215,8 @@
         }
       },
       "vault_response": {
-        "type": "object",
         "title": "Vault Response",
+        "type": "object",
         "description": "The details about a saved payment source.",
         "properties": {
           "id": {
@@ -8712,29 +8229,15 @@
             "title": "Vault Status",
             "type": "string",
             "description": "The vault status.",
-            "minLength": 1,
             "maxLength": 255,
+            "minLength": 1,
             "pattern": "^[0-9A-Z_]+$",
-            "x-enumDescriptions": [
-              {
-                "value": "VAULTED",
-                "description": "The payment source has been saved in your customer's vault. This vault status reflects `/v3/vault` status."
-              },
-              {
-                "value": "CREATED",
-                "description": "DEPRECATED. The payment source has been saved in your customer's vault. This status applies to deprecated integration patterns and will not be returned for v3/vault integrations."
-              },
-              {
-                "value": "APPROVED",
-                "description": "Customer has approved the action of saving the specified payment_source into their vault. Use v3/vault/payment-tokens with given setup_token to save the payment source in the vault"
-              }
-            ],
-            "deprecated": true,
             "enum": [
               "VAULTED",
               "CREATED",
               "APPROVED"
-            ]
+            ],
+            "deprecated": true
           },
           "customer": {
             "title": "Customer Information",

--- a/src/NJsonSchema.Tests/Deserialization/Snapshots/DeserializationTests.CanRoundTripPayPalOpenApi.verified.txt
+++ b/src/NJsonSchema.Tests/Deserialization/Snapshots/DeserializationTests.CanRoundTripPayPalOpenApi.verified.txt
@@ -1,0 +1,8862 @@
+﻿{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Subscriptions",
+    "description": "You can use billing plans and subscriptions to create subscriptions that process recurring PayPal payments for physical or digital goods, or services. A plan includes pricing and billing cycle information that defines the amount and frequency of charge for a subscription. You can also define a fixed plan, such as a $5 basic plan or a volume- or graduated-based plan with pricing tiers based on the quantity purchased. For more information, see <a href=\"/docs/subscriptions/\">Subscriptions Overview</a>.",
+    "version": "1.8",
+    "contact": {}
+  },
+  "servers": [
+    {
+      "url": "https://api-m.sandbox.paypal.com",
+      "description": "PayPal Sandbox Environment"
+    },
+    {
+      "url": "https://api-m.paypal.com",
+      "description": "PayPal Live Environment"
+    }
+  ],
+  "tags": [
+    {
+      "name": "plans",
+      "description": "Use the `/billing/plans` resource to create and manage plans."
+    },
+    {
+      "name": "subscriptions",
+      "description": "Use the `/billing/subscriptions` resource to create and manage subscriptions."
+    },
+    {
+      "name": "subscriptions-buyer-consent",
+      "description": "Use the `/billing/subscriptions/approval-tokens` resource for subscriptions buyer consent flow."
+    }
+  ],
+  "externalDocs": {
+    "url": "https://developer.paypal.com/docs/api/subscriptions/v1/"
+  },
+  "paths": {
+    "/v1/billing/plans": {
+      "post": {
+        "summary": "Create plan",
+        "description": "Creates a plan that defines pricing and billing cycle details for subscriptions.",
+        "operationId": "plans.create",
+        "responses": {
+          "200": {
+            "description": "A successful request returns the HTTP `200 OK` status code and a JSON response body that shows billing plan details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/plan"
+                },
+                "examples": {
+                  "plan": {
+                    "value": {
+                      "id": "P-5ML4271244454362WXNWU5NQ",
+                      "product_id": "PROD-XXCD1234QWER65782",
+                      "name": "Video Streaming Service Plan",
+                      "description": "Video Streaming Service basic plan",
+                      "status": "ACTIVE",
+                      "billing_cycles": [
+                        {
+                          "frequency": {
+                            "interval_unit": "MONTH",
+                            "interval_count": 1
+                          },
+                          "tenure_type": "TRIAL",
+                          "sequence": 1,
+                          "total_cycles": 2,
+                          "pricing_scheme": {
+                            "fixed_price": {
+                              "value": "3",
+                              "currency_code": "USD"
+                            },
+                            "version": 1,
+                            "create_time": "2020-05-27T12:13:51Z",
+                            "update_time": "2020-05-27T12:13:51Z"
+                          }
+                        },
+                        {
+                          "frequency": {
+                            "interval_unit": "MONTH",
+                            "interval_count": 1
+                          },
+                          "tenure_type": "TRIAL",
+                          "sequence": 2,
+                          "total_cycles": 3,
+                          "pricing_scheme": {
+                            "fixed_price": {
+                              "currency_code": "USD",
+                              "value": "6"
+                            },
+                            "version": 1,
+                            "create_time": "2020-05-27T12:13:51Z",
+                            "update_time": "2020-05-27T12:13:51Z"
+                          }
+                        },
+                        {
+                          "frequency": {
+                            "interval_unit": "MONTH",
+                            "interval_count": 1
+                          },
+                          "tenure_type": "REGULAR",
+                          "sequence": 3,
+                          "total_cycles": 12,
+                          "pricing_scheme": {
+                            "fixed_price": {
+                              "currency_code": "USD",
+                              "value": "10"
+                            },
+                            "version": 1,
+                            "create_time": "2020-05-27T12:13:51Z",
+                            "update_time": "2020-05-27T12:13:51Z"
+                          }
+                        }
+                      ],
+                      "payment_preferences": {
+                        "auto_bill_outstanding": true,
+                        "setup_fee": {
+                          "value": "10",
+                          "currency_code": "USD"
+                        },
+                        "setup_fee_failure_action": "CONTINUE",
+                        "payment_failure_threshold": 3
+                      },
+                      "taxes": {
+                        "percentage": "10",
+                        "inclusive": false
+                      },
+                      "create_time": "2020-05-27T12:13:51Z",
+                      "update_time": "2020-05-27T12:13:51Z",
+                      "links": [
+                        {
+                          "href": "https://api-m.paypal.com/v1/billing/plans/P-5ML4271244454362WXNWU5NQ",
+                          "rel": "self",
+                          "method": "GET"
+                        },
+                        {
+                          "href": "https://api-m.paypal.com/v1/billing/plans/P-5ML4271244454362WXNWU5NQ",
+                          "rel": "edit",
+                          "method": "PATCH"
+                        },
+                        {
+                          "href": "https://api-m.paypal.com/v1/billing/plans/P-5ML4271244454362WXNWU5NQ/deactivate",
+                          "rel": "deactivate",
+                          "method": "POST"
+                        },
+                        {
+                          "href": "https://api-m.paypal.com/v1/billing/plans/P-5ML4271244454362WXNWU5NQ/update-pricing-schemes",
+                          "rel": "edit",
+                          "method": "POST"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "A successful request returns the HTTP `201 Created` status code and a JSON response body that shows billing plan details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/plan"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request. Request is not well-formed, syntactically incorrect, or violates schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_400"
+                    },
+                    {
+                      "$ref": "#/components/schemas/plans.create-400"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The requested action could not be performed, semantically incorrect, or failed business validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_422"
+                    },
+                    {
+                      "$ref": "#/components/schemas/422"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/prefer"
+          },
+          {
+            "$ref": "#/components/parameters/paypal_request_id"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/plan_request_POST"
+              },
+              "examples": {
+                "plan_request_post": {
+                  "value": {
+                    "product_id": "PROD-XXCD1234QWER65782",
+                    "name": "Video Streaming Service Plan",
+                    "description": "Video Streaming Service basic plan",
+                    "status": "ACTIVE",
+                    "billing_cycles": [
+                      {
+                        "frequency": {
+                          "interval_unit": "MONTH",
+                          "interval_count": 1
+                        },
+                        "tenure_type": "TRIAL",
+                        "sequence": 1,
+                        "total_cycles": 2,
+                        "pricing_scheme": {
+                          "fixed_price": {
+                            "value": "3",
+                            "currency_code": "USD"
+                          }
+                        }
+                      },
+                      {
+                        "frequency": {
+                          "interval_unit": "MONTH",
+                          "interval_count": 1
+                        },
+                        "tenure_type": "TRIAL",
+                        "sequence": 2,
+                        "total_cycles": 3,
+                        "pricing_scheme": {
+                          "fixed_price": {
+                            "value": "6",
+                            "currency_code": "USD"
+                          }
+                        }
+                      },
+                      {
+                        "frequency": {
+                          "interval_unit": "MONTH",
+                          "interval_count": 1
+                        },
+                        "tenure_type": "REGULAR",
+                        "sequence": 3,
+                        "total_cycles": 12,
+                        "pricing_scheme": {
+                          "fixed_price": {
+                            "value": "10",
+                            "currency_code": "USD"
+                          }
+                        }
+                      }
+                    ],
+                    "payment_preferences": {
+                      "auto_bill_outstanding": true,
+                      "setup_fee": {
+                        "value": "10",
+                        "currency_code": "USD"
+                      },
+                      "setup_fee_failure_action": "CONTINUE",
+                      "payment_failure_threshold": 3
+                    },
+                    "taxes": {
+                      "percentage": "10",
+                      "inclusive": false
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Oauth2": [
+              "https://uri.paypal.com/services/subscriptions"
+            ]
+          }
+        ],
+        "tags": [
+          "plans"
+        ]
+      },
+      "get": {
+        "summary": "List plans",
+        "description": "Lists billing plans.",
+        "operationId": "plans.list",
+        "responses": {
+          "200": {
+            "description": "A successful request returns the HTTP `200 OK` status code and a JSON response body that lists billing plans.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/plan_collection"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Request is not well-formed, syntactically incorrect, or violates schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_400"
+                    },
+                    {
+                      "$ref": "#/components/schemas/400"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The specified resource does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_404"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/prefer"
+          },
+          {
+            "$ref": "#/components/parameters/product_id"
+          },
+          {
+            "$ref": "#/components/parameters/page_size"
+          },
+          {
+            "$ref": "#/components/parameters/page"
+          },
+          {
+            "$ref": "#/components/parameters/total_required"
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://uri.paypal.com/services/subscriptions"
+            ]
+          }
+        ],
+        "tags": [
+          "plans"
+        ]
+      }
+    },
+    "/v1/billing/plans/{id}": {
+      "get": {
+        "summary": "Show plan details",
+        "description": "Shows details for a plan, by ID.",
+        "operationId": "plans.get",
+        "responses": {
+          "200": {
+            "description": "A successful request returns the HTTP `200 OK` status code and a JSON response body that shows plan details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/plan"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The specified resource does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_404"
+                    },
+                    {
+                      "$ref": "#/components/schemas/404"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://uri.paypal.com/services/subscriptions"
+            ]
+          }
+        ],
+        "tags": [
+          "plans"
+        ]
+      },
+      "patch": {
+        "summary": "Update plan",
+        "description": "Updates a plan with the `CREATED` or `ACTIVE` status. For an `INACTIVE` plan, you can make only status updates.<br/>You can patch these attributes and objects:<table><thead><tr><th>Attribute or object</th><th>Operations</th></tr></thead><tbody><tr><td><code>description</code></td><td>replace</td></tr><tr><td><code>payment_preferences.auto_bill_outstanding</code></td><td>replace</td></tr><tr><td><code>taxes.percentage</code></td><td>replace</td></tr><tr><td><code>payment_preferences.payment_failure_threshold</code></td><td>replace</td></tr><tr><td><code>payment_preferences.setup_fee</code></td><td>replace</td></tr><tr><td><code>payment_preferences.setup_fee_failure_action</code></td><td>replace</td></tr><tr><td><code>name</code></td><td>replace</td></tr></tbody></table>",
+        "operationId": "plans.patch",
+        "responses": {
+          "204": {
+            "description": "A successful request returns the HTTP `204 No Content` status code with no JSON response body."
+          },
+          "400": {
+            "description": "Request is not well-formed, syntactically incorrect, or violates schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_400"
+                    },
+                    {
+                      "$ref": "#/components/schemas/plans.patch-400"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The specified resource does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_404"
+                    },
+                    {
+                      "$ref": "#/components/schemas/404"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The requested action could not be performed, semantically incorrect, or failed business validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_422"
+                    },
+                    {
+                      "$ref": "#/components/schemas/plans.patch-422"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/patch_request"
+        },
+        "security": [
+          {
+            "Oauth2": [
+              "https://uri.paypal.com/services/subscriptions"
+            ]
+          }
+        ],
+        "tags": [
+          "plans"
+        ]
+      }
+    },
+    "/v1/billing/plans/{id}/activate": {
+      "post": {
+        "summary": "Activate plan",
+        "description": "Activates a plan, by ID.",
+        "operationId": "plans.activate",
+        "responses": {
+          "204": {
+            "description": "A successful request returns the HTTP `204 No Content` status code with no JSON response body."
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The specified resource does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_404"
+                    },
+                    {
+                      "$ref": "#/components/schemas/404"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The requested action could not be performed, semantically incorrect, or failed business validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_422"
+                    },
+                    {
+                      "$ref": "#/components/schemas/plans.activate-422"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://uri.paypal.com/services/subscriptions"
+            ]
+          }
+        ],
+        "tags": [
+          "plans"
+        ]
+      }
+    },
+    "/v1/billing/plans/{id}/deactivate": {
+      "post": {
+        "summary": "Deactivate plan",
+        "description": "Deactivates a plan, by ID.",
+        "operationId": "plans.deactivate",
+        "responses": {
+          "204": {
+            "description": "A successful request returns the HTTP `204 No Content` status code with no JSON response body."
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The specified resource does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_404"
+                    },
+                    {
+                      "$ref": "#/components/schemas/404"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The requested action could not be performed, semantically incorrect, or failed business validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_422"
+                    },
+                    {
+                      "$ref": "#/components/schemas/plans.deactivate-422"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://uri.paypal.com/services/subscriptions"
+            ]
+          }
+        ],
+        "tags": [
+          "plans"
+        ]
+      }
+    },
+    "/v1/billing/plans/{id}/update-pricing-schemes": {
+      "post": {
+        "summary": "Update pricing",
+        "description": "Updates pricing for a plan. For example, you can update a regular billing cycle from $5 per month to $7 per month.",
+        "operationId": "plans.update-pricing-schemes",
+        "responses": {
+          "204": {
+            "description": "A successful request returns the HTTP `204 No Content` status code with no JSON response body."
+          },
+          "400": {
+            "description": "Bad Request. Request is not well-formed, syntactically incorrect, or violates schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_400"
+                    },
+                    {
+                      "$ref": "#/components/schemas/plans.update-pricing-schemes-400"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The specified resource does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_404"
+                    },
+                    {
+                      "$ref": "#/components/schemas/404"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The requested action could not be performed, semantically incorrect, or failed business validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_422"
+                    },
+                    {
+                      "$ref": "#/components/schemas/plans.update-pricing-schemes-422"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/update_pricing_schemes_list_request"
+              },
+              "examples": {
+                "update_pricing_schemes_list_request": {
+                  "value": {
+                    "pricing_schemes": [
+                      {
+                        "billing_cycle_sequence": 1,
+                        "pricing_scheme": {
+                          "fixed_price": {
+                            "value": "50",
+                            "currency_code": "USD"
+                          }
+                        }
+                      },
+                      {
+                        "billing_cycle_sequence": 2,
+                        "pricing_scheme": {
+                          "fixed_price": {
+                            "value": "100",
+                            "currency_code": "USD"
+                          },
+                          "pricing_model": "VOLUME",
+                          "tiers": [
+                            {
+                              "starting_quantity": "1",
+                              "ending_quantity": "1000",
+                              "amount": {
+                                "value": "150",
+                                "currency_code": "USD"
+                              }
+                            },
+                            {
+                              "starting_quantity": "1001",
+                              "amount": {
+                                "value": "250",
+                                "currency_code": "USD"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Oauth2": [
+              "https://uri.paypal.com/services/subscriptions"
+            ]
+          }
+        ],
+        "tags": [
+          "plans"
+        ]
+      }
+    },
+    "/v1/billing/subscriptions": {
+      "post": {
+        "summary": "Create subscription",
+        "description": "Creates a subscription.",
+        "operationId": "subscriptions.create",
+        "responses": {
+          "200": {
+            "description": "A successful request returns the HTTP `200 OK` status code and a JSON response body that shows subscription details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/subscription"
+                },
+                "examples": {
+                  "subscription": {
+                    "value": {
+                      "id": "I-BW452GLLEP1G",
+                      "status": "APPROVAL_PENDING",
+                      "status_update_time": "2018-12-10T21:20:49Z",
+                      "plan_id": "P-5ML4271244454362WXNWU5NQ",
+                      "plan_overridden": false,
+                      "start_time": "2018-11-01T00:00:00Z",
+                      "quantity": "20",
+                      "shipping_amount": {
+                        "currency_code": "USD",
+                        "value": "10.00"
+                      },
+                      "subscriber": {
+                        "name": {
+                          "given_name": "John",
+                          "surname": "Doe"
+                        },
+                        "email_address": "customer@example.com",
+                        "payer_id": "2J6QB8YJQSJRJ",
+                        "shipping_address": {
+                          "name": {
+                            "full_name": "John Doe"
+                          },
+                          "address": {
+                            "address_line_1": "2211 N First Street",
+                            "address_line_2": "Building 17",
+                            "admin_area_2": "San Jose",
+                            "admin_area_1": "CA",
+                            "postal_code": "95131",
+                            "country_code": "US"
+                          }
+                        }
+                      },
+                      "create_time": "2018-12-10T21:20:49Z",
+                      "links": [
+                        {
+                          "href": "https://www.paypal.com/webapps/billing/subscriptions?ba_token=BA-2M539689T3856352J",
+                          "rel": "approve",
+                          "method": "GET"
+                        },
+                        {
+                          "href": "https://api-m.paypal.com/v1/billing/subscriptions/I-BW452GLLEP1G",
+                          "rel": "edit",
+                          "method": "PATCH"
+                        },
+                        {
+                          "href": "https://api-m.paypal.com/v1/billing/subscriptions/I-BW452GLLEP1G",
+                          "rel": "self",
+                          "method": "GET"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "A successful request returns the HTTP `201 Created` status code and a JSON response body that shows subscription details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/subscription"
+                },
+                "examples": {
+                  "subscription": {
+                    "value": {
+                      "id": "I-BW452GLLEP1G",
+                      "status": "APPROVAL_PENDING",
+                      "status_update_time": "2018-12-10T21:20:49Z",
+                      "plan_id": "P-5ML4271244454362WXNWU5NQ",
+                      "plan_overridden": false,
+                      "start_time": "2018-11-01T00:00:00Z",
+                      "quantity": "20",
+                      "shipping_amount": {
+                        "currency_code": "USD",
+                        "value": "10.00"
+                      },
+                      "subscriber": {
+                        "name": {
+                          "given_name": "John",
+                          "surname": "Doe"
+                        },
+                        "email_address": "customer@example.com",
+                        "payer_id": "2J6QB8YJQSJRJ",
+                        "shipping_address": {
+                          "name": {
+                            "full_name": "John Doe"
+                          },
+                          "address": {
+                            "address_line_1": "2211 N First Street",
+                            "address_line_2": "Building 17",
+                            "admin_area_2": "San Jose",
+                            "admin_area_1": "CA",
+                            "postal_code": "95131",
+                            "country_code": "US"
+                          }
+                        }
+                      },
+                      "create_time": "2018-12-10T21:20:49Z",
+                      "links": [
+                        {
+                          "href": "https://www.paypal.com/webapps/billing/subscriptions?ba_token=BA-2M539689T3856352J",
+                          "rel": "approve",
+                          "method": "GET"
+                        },
+                        {
+                          "href": "https://api-m.paypal.com/v1/billing/subscriptions/I-BW452GLLEP1G",
+                          "rel": "edit",
+                          "method": "PATCH"
+                        },
+                        {
+                          "href": "https://api-m.paypal.com/v1/billing/subscriptions/I-BW452GLLEP1G",
+                          "rel": "self",
+                          "method": "GET"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request. Request is not well-formed, syntactically incorrect, or violates schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_400"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.create-400"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The requested action could not be performed, semantically incorrect, or failed business validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_422"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.create-422"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/prefer"
+          },
+          {
+            "$ref": "#/components/parameters/paypal_request_id"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/subscription_request_post"
+              },
+              "examples": {
+                "subscription_request_post": {
+                  "value": {
+                    "plan_id": "P-5ML4271244454362WXNWU5NQ",
+                    "start_time": "2018-11-01T00:00:00Z",
+                    "quantity": "20",
+                    "shipping_amount": {
+                      "currency_code": "USD",
+                      "value": "10.00"
+                    },
+                    "subscriber": {
+                      "name": {
+                        "given_name": "John",
+                        "surname": "Doe"
+                      },
+                      "email_address": "customer@example.com",
+                      "shipping_address": {
+                        "name": {
+                          "full_name": "John Doe"
+                        },
+                        "address": {
+                          "address_line_1": "2211 N First Street",
+                          "address_line_2": "Building 17",
+                          "admin_area_2": "San Jose",
+                          "admin_area_1": "CA",
+                          "postal_code": "95131",
+                          "country_code": "US"
+                        }
+                      }
+                    },
+                    "application_context": {
+                      "brand_name": "walmart",
+                      "locale": "en-US",
+                      "shipping_preference": "SET_PROVIDED_ADDRESS",
+                      "user_action": "SUBSCRIBE_NOW",
+                      "payment_method": {
+                        "payer_selected": "PAYPAL",
+                        "payee_preferred": "IMMEDIATE_PAYMENT_REQUIRED"
+                      },
+                      "return_url": "https://example.com/returnUrl",
+                      "cancel_url": "https://example.com/cancelUrl"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Oauth2": [
+              "https://uri.paypal.com/services/subscriptions"
+            ]
+          }
+        ],
+        "tags": [
+          "subscriptions"
+        ]
+      }
+    },
+    "/v1/billing/subscriptions/{id}": {
+      "get": {
+        "summary": "Show subscription details",
+        "description": "Shows details for a subscription, by ID.",
+        "operationId": "subscriptions.get",
+        "responses": {
+          "200": {
+            "description": "A successful request returns the HTTP `200 OK` status code and a JSON response body that shows subscription details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/subscription"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The specified resource does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_404"
+                    },
+                    {
+                      "$ref": "#/components/schemas/404"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://uri.paypal.com/services/subscriptions"
+            ]
+          }
+        ],
+        "tags": [
+          "subscriptions"
+        ]
+      },
+      "patch": {
+        "summary": "Update subscription",
+        "description": "Updates a subscription which could be in <code>ACTIVE</code> or <code>SUSPENDED</code> status. You can override plan level default attributes by providing customised values for plan path in the patch request.<br /> <ul> <li>You cannot update attributes that have already completed (Example - trial cycles can’t be updated if completed).</li> <li>Once overridden, changes to plan resource will not impact subscription.</li> <li>Any price update will not impact billing cycles within next 10 days (Applicable only for subscriptions funded by PayPal account).</li> </ul> Following are the fields eligible for patch.<table><thead><tr><th>Attribute or object</th><th>Operations</th></tr></thead><tbody><tr><td><code>billing_info.outstanding_balance</code></td><td>replace</td></tr><tr><td><code>custom_id</code></td><td>add,replace</td></tr><tr><td><code>plan.billing_cycles[@sequence==n].<br/>pricing_scheme.fixed_price</code></td><td>add,replace</td></tr><tr><td><code>plan.billing_cycles[@sequence==n].<br/>pricing_scheme.tiers</code></td><td>replace</td></tr><tr><td><code>plan.billing_cycles[@sequence==n].<br/>total_cycles</code></td><td>replace</td></tr><tr><td><code>plan.payment_preferences.<br/>auto_bill_outstanding</code></td><td>replace</td></tr><tr><td><code>plan.payment_preferences.<br/>payment_failure_threshold</code></td><td>replace</td></tr><tr><td><code>plan.taxes.inclusive</code></td><td>add,replace</td></tr><tr><td><code>plan.taxes.percentage</code></td><td>add,replace</td></tr><tr><td><code>shipping_amount</code></td><td>add,replace</td></tr><tr><td><code>start_time</code></td><td>replace</td></tr><tr><td><code>subscriber.shipping_address</code></td><td>add,replace</td></tr><tr><td><code>subscriber.payment_source (for subscriptions funded<br/>by card payments)</code></td><td>replace</td></tr></tbody></table>",
+        "operationId": "subscriptions.patch",
+        "responses": {
+          "204": {
+            "description": "A successful request returns the HTTP `204 No Content` status code with no JSON response body."
+          },
+          "400": {
+            "description": "Request is not well-formed, syntactically incorrect, or violates schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_400"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.patch-400"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The specified resource does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_404"
+                    },
+                    {
+                      "$ref": "#/components/schemas/404"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The requested action could not be performed, semantically incorrect, or failed business validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_422"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.patch-422"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/patch_request"
+        },
+        "security": [
+          {
+            "Oauth2": [
+              "https://uri.paypal.com/services/subscriptions"
+            ]
+          }
+        ],
+        "tags": [
+          "subscriptions"
+        ]
+      }
+    },
+    "/v1/billing/subscriptions/{id}/revise": {
+      "post": {
+        "summary": "Revise plan or quantity of subscription",
+        "description": "Updates the quantity of the product or service in a subscription. You can also use this method to switch the plan and update the `shipping_amount`, `shipping_address` values for the subscription. This type of update requires the buyer's consent.",
+        "operationId": "subscriptions.revise",
+        "responses": {
+          "200": {
+            "description": "A successful request returns the HTTP `200 OK` status code and a JSON response body that shows subscription details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/subscription_revise_response"
+                },
+                "examples": {
+                  "subscription_revise_response": {
+                    "value": {
+                      "plan_id": "P-5ML4271244454362WXNWU5NQ",
+                      "plan_overridden": false,
+                      "shipping_amount": {
+                        "currency_code": "USD",
+                        "value": "10.00"
+                      },
+                      "shipping_address": {
+                        "name": {
+                          "full_name": "John Doe"
+                        },
+                        "address": {
+                          "address_line_1": "2211 N First Street",
+                          "address_line_2": "Building 17",
+                          "admin_area_2": "San Jose",
+                          "admin_area_1": "CA",
+                          "postal_code": "95131",
+                          "country_code": "US"
+                        }
+                      },
+                      "links": [
+                        {
+                          "href": "https://www.paypal.com/webapps/billing/subscriptions/update?ba_token=BA-2M539689T3856352J",
+                          "rel": "approve",
+                          "method": "GET"
+                        },
+                        {
+                          "href": "https://api-m.paypal.com/v1/billing/subscriptions/I-BW452GLLEP1G",
+                          "rel": "edit",
+                          "method": "PATCH"
+                        },
+                        {
+                          "href": "https://api-m.paypal.com/v1/billing/subscriptions/I-BW452GLLEP1G",
+                          "rel": "self",
+                          "method": "GET"
+                        },
+                        {
+                          "href": "https://api-m.paypal.com/v1/billing/subscriptions/I-BW452GLLEP1G/cancel",
+                          "rel": "cancel",
+                          "method": "POST"
+                        },
+                        {
+                          "href": "https://api-m.paypal.com/v1/billing/subscriptions/I-BW452GLLEP1G/suspend",
+                          "rel": "suspend",
+                          "method": "POST"
+                        },
+                        {
+                          "href": "https://api-m.paypal.com/v1/billing/subscriptions/I-BW452GLLEP1G/capture",
+                          "rel": "capture",
+                          "method": "POST"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request. Request is not well-formed, syntactically incorrect, or violates schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_400"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.revise-400"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The specified resource does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_404"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.revise-404"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The requested action could not be performed, semantically incorrect, or failed business validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_422"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.revise-422"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/subscription_revise_request"
+              },
+              "examples": {
+                "subscription_revise_request": {
+                  "value": {
+                    "plan_id": "P-5ML4271244454362WXNWU5NQ",
+                    "shipping_amount": {
+                      "currency_code": "USD",
+                      "value": "10.00"
+                    },
+                    "shipping_address": {
+                      "name": {
+                        "full_name": "John Doe"
+                      },
+                      "address": {
+                        "address_line_1": "2211 N First Street",
+                        "address_line_2": "Building 17",
+                        "admin_area_2": "San Jose",
+                        "admin_area_1": "CA",
+                        "postal_code": "95131",
+                        "country_code": "US"
+                      }
+                    },
+                    "application_context": {
+                      "brand_name": "walmart",
+                      "locale": "en-US",
+                      "shipping_preference": "SET_PROVIDED_ADDRESS",
+                      "payment_method": {
+                        "payer_selected": "PAYPAL",
+                        "payee_preferred": "IMMEDIATE_PAYMENT_REQUIRED"
+                      },
+                      "return_url": "https://example.com/returnUrl",
+                      "cancel_url": "https://example.com/cancelUrl"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Oauth2": [
+              "https://uri.paypal.com/services/subscriptions"
+            ]
+          }
+        ],
+        "tags": [
+          "subscriptions"
+        ]
+      }
+    },
+    "/v1/billing/subscriptions/{id}/suspend": {
+      "post": {
+        "summary": "Suspend subscription",
+        "description": "Suspends the subscription.",
+        "operationId": "subscriptions.suspend",
+        "responses": {
+          "204": {
+            "description": "A successful request returns the HTTP `204 No Content` status code with no JSON response body."
+          },
+          "400": {
+            "description": "Bad Request. Request is not well-formed, syntactically incorrect, or violates schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_400"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.suspend-400"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The specified resource does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_404"
+                    },
+                    {
+                      "$ref": "#/components/schemas/404"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The requested action could not be performed, semantically incorrect, or failed business validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_422"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.suspend-422"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/subscription_suspend_request"
+              },
+              "examples": {
+                "subscription_suspend_request": {
+                  "value": {
+                    "reason": "Item out of stock"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Oauth2": [
+              "https://uri.paypal.com/services/subscriptions"
+            ]
+          }
+        ],
+        "tags": [
+          "subscriptions"
+        ]
+      }
+    },
+    "/v1/billing/subscriptions/{id}/cancel": {
+      "post": {
+        "summary": "Cancel subscription",
+        "description": "Cancels the subscription.",
+        "operationId": "subscriptions.cancel",
+        "responses": {
+          "204": {
+            "description": "A successful request returns the HTTP `204 No Content` status code with no JSON response body."
+          },
+          "400": {
+            "description": "Bad Request. Request is not well-formed, syntactically incorrect, or violates schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_400"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.cancel-400"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The specified resource does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_404"
+                    },
+                    {
+                      "$ref": "#/components/schemas/404"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The requested action could not be performed, semantically incorrect, or failed business validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_422"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.cancel-422"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/subscription_cancel_request"
+              },
+              "examples": {
+                "subscription_cancel_request": {
+                  "value": {
+                    "reason": "Not satisfied with the service"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Oauth2": [
+              "https://uri.paypal.com/services/subscriptions"
+            ]
+          }
+        ],
+        "tags": [
+          "subscriptions"
+        ]
+      }
+    },
+    "/v1/billing/subscriptions/{id}/activate": {
+      "post": {
+        "summary": "Activate subscription",
+        "description": "Activates the subscription.",
+        "operationId": "subscriptions.activate",
+        "responses": {
+          "204": {
+            "description": "A successful request returns the HTTP `204 No Content` status code with no JSON response body."
+          },
+          "400": {
+            "description": "Bad Request. Request is not well-formed, syntactically incorrect, or violates schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_400"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.activate-400"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The specified resource does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_404"
+                    },
+                    {
+                      "$ref": "#/components/schemas/404"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The requested action could not be performed, semantically incorrect, or failed business validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_422"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.activate-422"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/subscription_activate_request"
+              },
+              "examples": {
+                "subscription_activate_request": {
+                  "value": {
+                    "reason": "Reactivating the subscription"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Oauth2": [
+              "https://uri.paypal.com/services/subscriptions"
+            ]
+          }
+        ],
+        "tags": [
+          "subscriptions"
+        ]
+      }
+    },
+    "/v1/billing/subscriptions/{id}/capture": {
+      "post": {
+        "summary": "Capture authorized payment on subscription",
+        "description": "Captures an authorized payment from the subscriber on the subscription.",
+        "operationId": "subscriptions.capture",
+        "responses": {
+          "200": {
+            "description": "A successful request returns the HTTP `200 OK` status code and a JSON response body that shows subscription details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/transaction"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Request Accepted."
+          },
+          "400": {
+            "description": "Bad Request. Request is not well-formed, syntactically incorrect, or violates schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_400"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.capture-400"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The specified resource does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_404"
+                    },
+                    {
+                      "$ref": "#/components/schemas/404"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The requested action could not be performed, semantically incorrect, or failed business validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_422"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.capture-422"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/paypal_request_id"
+          },
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/subscription_capture_request"
+              },
+              "examples": {
+                "subscription_capture_request": {
+                  "value": {
+                    "note": "Charging as the balance reached the limit",
+                    "capture_type": "OUTSTANDING_BALANCE",
+                    "amount": {
+                      "currency_code": "USD",
+                      "value": "100"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Oauth2": [
+              "https://uri.paypal.com/services/subscriptions"
+            ]
+          }
+        ],
+        "tags": [
+          "subscriptions"
+        ]
+      }
+    },
+    "/v1/billing/subscriptions/{id}/transactions": {
+      "get": {
+        "summary": "List transactions for subscription",
+        "description": "Lists transactions for a subscription.",
+        "operationId": "subscriptions.transactions",
+        "responses": {
+          "200": {
+            "description": "A successful request returns the HTTP `200 OK` status code and a JSON response body that shows subscription details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/transactions_list"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request. Request is not well-formed, syntactically incorrect, or violates schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_400"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.transactions-400"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The specified resource does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_404"
+                    },
+                    {
+                      "$ref": "#/components/schemas/404"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          },
+          {
+            "$ref": "#/components/parameters/start_time"
+          },
+          {
+            "$ref": "#/components/parameters/end_time"
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://uri.paypal.com/services/subscriptions"
+            ]
+          }
+        ],
+        "tags": [
+          "subscriptions"
+        ]
+      }
+    }
+  },
+  "components": {
+    "requestBodies": {
+      "patch_request": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/patch_request"
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "Oauth2": {
+        "description": "Oauth 2.0 authentication",
+        "flows": {
+          "clientCredentials": {
+            "tokenUrl": "/v1/oauth2/token",
+            "scopes": {
+              "https://uri.paypal.com/services/subscriptions": "Manage plan & subscription"
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "default": {
+        "description": "The default response.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/error_default"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "400": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "INVALID_PARAMETER_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PARAMETER_VALUE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field is invalid."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "401": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "INVALID_ACCOUNT_STATUS",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_ACCOUNT_STATUS"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Account validations failed for the user."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "403": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "PERMISSION_DENIED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "PERMISSION_DENIED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "You do not have permission to access or perform operations on this resource."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "404": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "INVALID_RESOURCE_ID",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_RESOURCE_ID"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Specified resource ID does not exist. Please check the resource ID and try again."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "422": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "USER_ACCOUNT_CLOSED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "USER_ACCOUNT_CLOSED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "User account locked or closed."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "CURRENCY_MISMATCH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "CURRENCY_MISMATCH"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "All currency codes in the request should be of similar value."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "MULTIPLE_FREE_TRIAL_BILLING_CYCLES_NOT_SUPPORTED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "MULTIPLE_FREE_TRIAL_BILLING_CYCLES_NOT_SUPPORTED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Only one free trial billing cycle is allowed."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "MORE_THAN_TWO_TRIAL_BILLING_CYCLE_NOT_SUPPORTED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "MORE_THAN_TWO_TRIAL_BILLING_CYCLE_NOT_SUPPORTED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Only two trial billing cycles are allowed."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_REGULAR_BILLING_CYCLE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "MISSING_REGULAR_BILLING_CYCLE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Plan should have at least one regular billing cycle."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "MULTIPLE_REGULAR_BILLING_CYCLES_NOT_SUPPORTED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "MULTIPLE_REGULAR_BILLING_CYCLES_NOT_SUPPORTED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Only one regular billing cycle is allowed."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_BILLING_CYCLE_SEQUENCE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_BILLING_CYCLE_SEQUENCE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Billing cycle sequence should start with `1` and be consecutive."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_BILLING_CYCLE_SEQUENCE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_BILLING_CYCLE_SEQUENCE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Trial Billing cycle should precede regular billing cycle."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_TRIAL_BILLING_TOTAL_CYCLES",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_TRIAL_BILLING_TOTAL_CYCLES"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Total cycles for trial billing must be greater than '0'."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_TIER_AMOUNT",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PRICING_TIER_AMOUNT"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Free tiers are not supported."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_PRICING_SCHEME_TIERS",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "MISSING_PRICING_SCHEME_TIERS"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Tier(s) are missing for some quantities."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "OVERLAPPING_PRICING_SCHEME_TIERS",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "OVERLAPPING_PRICING_SCHEME_TIERS"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The specified quantity overlaps with multiple pricing tiers."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_MODEL",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PRICING_MODEL"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The specified pricing model is not supported for trial billing cycle."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "FIXED_PRICE_NOT_SUPPORTED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "FIXED_PRICE_NOT_SUPPORTED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Fixed price is not supported for tiered pricing schemes."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_TIER_QUANTITY",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PRICING_TIER_QUANTITY"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Tier starting quantity must be less than ending quantity."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_QUANTITY_SUPPORTED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_QUANTITY_SUPPORTED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Quantity is always supported for volume and tiered plans."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "CURRENCY_NOT_SUPPORTED_FOR_RECEIVER",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "CURRENCY_NOT_SUPPORTED_FOR_RECEIVER"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "This currency cannot be accepted for this recipient’s account."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_METADATA_CUSTOM_NOTE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_METADATA_CUSTOM_NOTE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Merchant custom note cannot exceed 255 characters."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_METADATA_INVOICE_ID",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_METADATA_INVOICE_ID"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Invoice id cannot exceed 127 characters."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "account_id": {
+        "title": "PayPal Account Identifier",
+        "type": "string",
+        "description": "The account identifier for a PayPal account.",
+        "format": "ppaas_payer_id_v3",
+        "maxLength": 13,
+        "minLength": 13,
+        "pattern": "^[2-9A-HJ-NP-Z]{13}$"
+      },
+      "amount_with_breakdown": {
+        "title": "Amount with Breakdown",
+        "type": "object",
+        "description": "The breakdown details for the amount. Includes the gross, tax, fee, and shipping amounts.",
+        "required": [
+          "gross_amount"
+        ],
+        "properties": {
+          "gross_amount": {
+            "readonly": true,
+            "description": "The amount for this transaction.",
+            "$ref": "#/components/schemas/money"
+          },
+          "total_item_amount": {
+            "readonly": true,
+            "description": "The item total for the transaction.",
+            "$ref": "#/components/schemas/money"
+          },
+          "fee_amount": {
+            "readonly": true,
+            "description": "The fee details for the transaction.",
+            "$ref": "#/components/schemas/money"
+          },
+          "shipping_amount": {
+            "readonly": true,
+            "description": "The shipping amount for the transaction.",
+            "$ref": "#/components/schemas/money"
+          },
+          "tax_amount": {
+            "readonly": true,
+            "description": "The tax amount for the transaction.",
+            "$ref": "#/components/schemas/money"
+          },
+          "net_amount": {
+            "readonly": true,
+            "description": "The net amount that the payee receives for this transaction in their PayPal account. The net amount is computed as <code>gross_amount</code> minus the <code>paypal_fee</code>.",
+            "$ref": "#/components/schemas/money"
+          }
+        }
+      },
+      "application_context": {
+        "title": "Application Context",
+        "description": "The application context, which customizes the payer experience during the subscription approval process with PayPal.",
+        "type": "object",
+        "properties": {
+          "brand_name": {
+            "type": "string",
+            "description": "The label that overrides the business name in the PayPal account on the PayPal site.",
+            "maxLength": 127,
+            "minLength": 1,
+            "pattern": "^.*$"
+          },
+          "locale": {
+            "description": "The BCP 47-formatted locale of pages that the PayPal payment experience shows. PayPal supports a five-character code. For example, `da-DK`, `he-IL`, `id-ID`, `ja-JP`, `no-NO`, `pt-BR`, `ru-RU`, `sv-SE`, `th-TH`, `zh-CN`, `zh-HK`, or `zh-TW`.",
+            "$ref": "#/components/schemas/language"
+          },
+          "shipping_preference": {
+            "type": "string",
+            "description": "The location from which the shipping address is derived.",
+            "minLength": 1,
+            "maxLength": 24,
+            "pattern": "^[A-Z_]+$",
+            "default": "GET_FROM_FILE",
+            "x-enumDescriptions": [
+              {
+                "value": "GET_FROM_FILE",
+                "description": "Get the customer-provided shipping address on the PayPal site.",
+                "default": true
+              },
+              {
+                "value": "NO_SHIPPING",
+                "description": "Redacts the shipping address from the PayPal site. Recommended for digital goods."
+              },
+              {
+                "value": "SET_PROVIDED_ADDRESS",
+                "description": "Get the merchant-provided address. The customer cannot change this address on the PayPal site. If merchant does not pass an address, customer can choose the address on PayPal pages."
+              }
+            ],
+            "enum": [
+              "GET_FROM_FILE",
+              "NO_SHIPPING",
+              "SET_PROVIDED_ADDRESS"
+            ]
+          },
+          "user_action": {
+            "type": "string",
+            "description": "Configures the label name to `Continue` or `Subscribe Now` for subscription consent experience.",
+            "minLength": 1,
+            "maxLength": 24,
+            "pattern": "^[A-Z_]+$",
+            "default": "SUBSCRIBE_NOW",
+            "x-enumDescriptions": [
+              {
+                "value": "CONTINUE",
+                "description": "After you redirect the customer to the PayPal subscription consent page, a <strong>Continue</strong> button appears. Use this option when you want to control the activation of the subscription and do not want PayPal to activate the subscription.",
+                "default": true
+              },
+              {
+                "value": "SUBSCRIBE_NOW",
+                "description": "After you redirect the customer to the PayPal subscription consent page, a <strong>Subscribe Now</strong> button appears. Use this option when you want PayPal to activate the subscription."
+              }
+            ],
+            "enum": [
+              "CONTINUE",
+              "SUBSCRIBE_NOW"
+            ]
+          },
+          "payment_method": {
+            "title": "Payment Method",
+            "type": "object",
+            "description": "The customer and merchant payment preferences.",
+            "properties": {
+              "payee_preferred": {
+                "$ref": "#/components/schemas/payee_payment_method_preference"
+              }
+            }
+          },
+          "return_url": {
+            "type": "string",
+            "description": "The URL where the customer is redirected after the customer approves the payment.",
+            "format": "uri",
+            "maxLength": 4000,
+            "minLength": 10
+          },
+          "cancel_url": {
+            "type": "string",
+            "description": "The URL where the customer is redirected after the customer cancels the payment.",
+            "format": "uri",
+            "maxLength": 4000,
+            "minLength": 10
+          }
+        },
+        "required": [
+          "return_url",
+          "cancel_url"
+        ]
+      },
+      "authentication_response": {
+        "title": "Authentication Response",
+        "type": "object",
+        "description": "Results of Authentication such as 3D Secure.",
+        "properties": {
+          "liability_shift": {
+            "$ref": "#/components/schemas/liability_shift"
+          },
+          "three_d_secure": {
+            "$ref": "#/components/schemas/three_d_secure_authentication_response"
+          }
+        }
+      },
+      "billing_cycle": {
+        "title": "Billing Cycle",
+        "description": "The billing cycle details.",
+        "type": "object",
+        "properties": {
+          "pricing_scheme": {
+            "description": "The active pricing scheme for this billing cycle. A free trial billing cycle does not require a pricing scheme.",
+            "$ref": "#/components/schemas/pricing_scheme"
+          },
+          "frequency": {
+            "description": "The frequency details for this billing cycle.",
+            "$ref": "#/components/schemas/frequency"
+          },
+          "tenure_type": {
+            "type": "string",
+            "description": "The tenure type of the billing cycle. In case of a plan having trial cycle, only 2 trial cycles are allowed per plan.",
+            "minLength": 1,
+            "maxLength": 24,
+            "pattern": "^[A-Z_]+$",
+            "x-enumDescriptions": [
+              {
+                "value": "REGULAR",
+                "description": "A regular billing cycle."
+              },
+              {
+                "value": "TRIAL",
+                "description": "A trial billing cycle."
+              }
+            ],
+            "enum": [
+              "REGULAR",
+              "TRIAL"
+            ]
+          },
+          "sequence": {
+            "type": "integer",
+            "description": "The order in which this cycle is to run among other billing cycles. For example, a trial billing cycle has a `sequence` of `1` while a regular billing cycle has a `sequence` of `2`, so that trial cycle runs before the regular cycle.",
+            "maximum": 99.0,
+            "minimum": 1.0
+          },
+          "total_cycles": {
+            "type": "integer",
+            "description": "The number of times this billing cycle gets executed. Trial billing cycles can only be executed a finite number of times (value between <code>1</code> and <code>999</code> for <code>total_cycles</code>). Regular billing cycles can be executed infinite times (value of <code>0</code> for <code>total_cycles</code>) or a finite number of times (value between <code>1</code> and <code>999</code> for <code>total_cycles</code>).",
+            "default": 1,
+            "maximum": 999.0,
+            "minimum": 0.0
+          }
+        },
+        "required": [
+          "frequency",
+          "tenure_type",
+          "sequence"
+        ]
+      },
+      "billing_cycle_list": {
+        "type": "array",
+        "description": "An array of billing cycles for trial billing and regular billing. A plan can have at most two trial cycles and only one regular cycle.",
+        "maxItems": 12,
+        "minItems": 1,
+        "items": {
+          "$ref": "#/components/schemas/billing_cycle"
+        }
+      },
+      "billing_cycle_override": {
+        "title": "Billing Cycle Override",
+        "type": "object",
+        "description": "The billing cycle details to override at subscription level. The subscription billing cycle definition has to adhere to the plan billing cycle definition.",
+        "required": [
+          "sequence"
+        ],
+        "properties": {
+          "pricing_scheme": {
+            "description": "The active pricing scheme for this billing cycle. A free trial billing cycle does not require a pricing scheme.",
+            "$ref": "#/components/schemas/pricing_scheme"
+          },
+          "sequence": {
+            "type": "integer",
+            "description": "The order in which this cycle is to run among other billing cycles. For example, a trial billing cycle has a `sequence` of `1` while a regular billing cycle has a `sequence` of `2`, so that trial cycle runs before the regular cycle.",
+            "maximum": 99.0,
+            "minimum": 1.0
+          },
+          "total_cycles": {
+            "type": "integer",
+            "description": "The number of times this billing cycle gets executed. Trial billing cycles can only be executed a finite number of times (value between <code>1</code> and <code>999</code> for <code>total_cycles</code>). Regular billing cycles can be executed infinite times (value of <code>0</code> for <code>total_cycles</code>) or a finite number of times (value between <code>1</code> and <code>999</code> for <code>total_cycles</code>).",
+            "maximum": 999.0,
+            "minimum": 0.0
+          }
+        }
+      },
+      "billing_cycle_override_list": {
+        "type": "array",
+        "description": "An array of billing cycles for trial billing and regular billing. The subscription billing cycle definition has to adhere to the plan billing cycle definition.",
+        "maxItems": 12,
+        "minItems": 1,
+        "items": {
+          "$ref": "#/components/schemas/billing_cycle_override"
+        }
+      },
+      "bin_details": {
+        "title": "Bin Details",
+        "type": "object",
+        "description": "Bank Identification Number (BIN) details used to fund a payment.",
+        "properties": {
+          "bin": {
+            "type": "string",
+            "description": "The Bank Identification Number (BIN) signifies the number that is being used to identify the granular level details (except the PII information) of the card.",
+            "maxLength": 25,
+            "minLength": 1,
+            "pattern": "^[0-9]+$"
+          },
+          "issuing_bank": {
+            "type": "string",
+            "description": "The issuer of the card instrument.",
+            "maxLength": 64,
+            "minLength": 1
+          },
+          "bin_country_code": {
+            "description": "The [two-character ISO-3166-1 country code](/docs/integration/direct/rest/country-codes/) of the bank.",
+            "$ref": "#/components/schemas/country_code-2"
+          },
+          "products": {
+            "$ref": "#/components/schemas/products_list"
+          }
+        }
+      },
+      "card_attributes": {
+        "title": "Card Attributes",
+        "type": "object",
+        "description": "Additional attributes associated with the use of this card.",
+        "properties": {
+          "customer": {
+            "$ref": "#/components/schemas/customer"
+          },
+          "vault": {
+            "description": "Instruction to vault the card based on the specified strategy.",
+            "$ref": "#/components/schemas/vault_instruction_base"
+          },
+          "verification": {
+            "description": "Instruction to optionally verify the card based on the specified strategy.",
+            "$ref": "#/components/schemas/card_verification"
+          }
+        }
+      },
+      "card_attributes_response": {
+        "title": "Card Attributes Response",
+        "type": "object",
+        "description": "Additional attributes associated with the use of this card.",
+        "properties": {
+          "vault": {
+            "$ref": "#/components/schemas/vault_response"
+          }
+        }
+      },
+      "card_brand": {
+        "type": "string",
+        "title": "Card Brand",
+        "description": "The card network or brand. Applies to credit, debit, gift, and payment cards.",
+        "minLength": 1,
+        "maxLength": 255,
+        "pattern": "^[A-Z_]+$",
+        "x-enumDescriptions": [
+          {
+            "value": "VISA",
+            "description": "Visa card."
+          },
+          {
+            "value": "MASTERCARD",
+            "description": "Mastecard card."
+          },
+          {
+            "value": "DISCOVER",
+            "description": "Discover card."
+          },
+          {
+            "value": "AMEX",
+            "description": "American Express card."
+          },
+          {
+            "value": "SOLO",
+            "description": "Solo debit card."
+          },
+          {
+            "value": "JCB",
+            "description": "Japan Credit Bureau card."
+          },
+          {
+            "value": "STAR",
+            "description": "Military Star card."
+          },
+          {
+            "value": "DELTA",
+            "description": "Delta Airlines card."
+          },
+          {
+            "value": "SWITCH",
+            "description": "Switch credit card."
+          },
+          {
+            "value": "MAESTRO",
+            "description": "Maestro credit card."
+          },
+          {
+            "value": "CB_NATIONALE",
+            "description": "Carte Bancaire (CB) credit card."
+          },
+          {
+            "value": "CONFIGOGA",
+            "description": "Configoga credit card."
+          },
+          {
+            "value": "CONFIDIS",
+            "description": "Confidis credit card."
+          },
+          {
+            "value": "ELECTRON",
+            "description": "Visa Electron credit card."
+          },
+          {
+            "value": "CETELEM",
+            "description": "Cetelem credit card."
+          },
+          {
+            "value": "CHINA_UNION_PAY",
+            "description": "China union pay credit card."
+          },
+          {
+            "value": "DINERS",
+            "description": "The Diners Club International banking and payment services capability network owned by Discover Financial Services (DFS), one of the most recognized brands in US financial services."
+          },
+          {
+            "value": "ELO",
+            "description": "The Brazilian Elo card payment network."
+          },
+          {
+            "value": "HIPER",
+            "description": "The Hiper - Ingenico ePayment network."
+          },
+          {
+            "value": "HIPERCARD",
+            "description": "The Brazilian Hipercard payment network that's widely accepted in the retail market."
+          },
+          {
+            "value": "RUPAY",
+            "description": "The RuPay payment network."
+          },
+          {
+            "value": "GE",
+            "description": "The GE Credit Union 3Point card payment network."
+          },
+          {
+            "value": "SYNCHRONY",
+            "description": "The Synchrony Financial (SYF) payment network."
+          },
+          {
+            "value": "UNKNOWN",
+            "description": "UNKNOWN payment network."
+          }
+        ],
+        "enum": [
+          "VISA",
+          "MASTERCARD",
+          "DISCOVER",
+          "AMEX",
+          "SOLO",
+          "JCB",
+          "STAR",
+          "DELTA",
+          "SWITCH",
+          "MAESTRO",
+          "CB_NATIONALE",
+          "CONFIGOGA",
+          "CONFIDIS",
+          "ELECTRON",
+          "CETELEM",
+          "CHINA_UNION_PAY",
+          "DINERS",
+          "ELO",
+          "HIPER",
+          "HIPERCARD",
+          "RUPAY",
+          "GE",
+          "SYNCHRONY",
+          "UNKNOWN"
+        ]
+      },
+      "card_brand_list": {
+        "type": "array",
+        "description": "Array of brands or networks associated with the card.",
+        "maxItems": 256,
+        "minItems": 1,
+        "items": {
+          "$ref": "#/components/schemas/card_brand"
+        },
+        "readOnly": true
+      },
+      "card_from_request": {
+        "title": "Card from Request",
+        "type": "object",
+        "description": "Representation of card details as received in the request.",
+        "properties": {
+          "expiry": {
+            "description": "The card expiration year and month, in [Internet date format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+            "$ref": "#/components/schemas/date_year_month"
+          },
+          "last_digits": {
+            "type": "string",
+            "readonly": true,
+            "description": "The last digits of the payment card.",
+            "maxLength": 4,
+            "minLength": 2,
+            "pattern": "[0-9]{2,}"
+          }
+        }
+      },
+      "card_response": {
+        "title": "Card Response",
+        "type": "object",
+        "description": "The payment card to use to fund a payment. Card can be a credit or debit card.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The card holder's name as it appears on the card.",
+            "maxLength": 300,
+            "minLength": 2
+          },
+          "last_digits": {
+            "type": "string",
+            "readonly": true,
+            "description": "The last digits of the payment card.",
+            "pattern": "[0-9]{2,}"
+          },
+          "brand": {
+            "readonly": true,
+            "description": "The card brand or network. Typically used in the response.",
+            "$ref": "#/components/schemas/card_brand"
+          },
+          "available_networks": {
+            "$ref": "#/components/schemas/card_brand_list"
+          },
+          "type": {
+            "description": "The payment card type.",
+            "$ref": "#/components/schemas/card_type"
+          },
+          "authentication_result": {
+            "$ref": "#/components/schemas/authentication_response"
+          },
+          "attributes": {
+            "$ref": "#/components/schemas/card_attributes_response"
+          },
+          "from_request": {
+            "$ref": "#/components/schemas/card_from_request"
+          },
+          "expiry": {
+            "description": "The card expiration year and month, in [Internet date format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+            "$ref": "#/components/schemas/date_year_month"
+          },
+          "bin_details": {
+            "description": "Bank Identification Number (BIN) details used to fund a payment.",
+            "$ref": "#/components/schemas/bin_details"
+          }
+        }
+      },
+      "card_response_with_billing_address": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/card_response"
+          },
+          {
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The card holder's name as it appears on the card.",
+                "maxLength": 300,
+                "minLength": 2
+              },
+              "billing_address": {
+                "title": "Portable Postal Address (Medium-Grained)",
+                "type": "object",
+                "description": "The portable international postal address. Maps to [AddressValidationMetadata](https://github.com/googlei18n/libaddressinput/wiki/AddressValidationMetadata) and HTML 5.1 [Autofilling form controls: the autocomplete attribute](https://www.w3.org/TR/html51/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).",
+                "required": [
+                  "country_code"
+                ],
+                "properties": {
+                  "address_line_1": {
+                    "type": "string",
+                    "description": "The first line of the address, such as number and street, for example, `173 Drury Lane`. Needed for data entry, and Compliance and Risk checks. This field needs to pass the full address.",
+                    "maxLength": 300
+                  },
+                  "address_line_2": {
+                    "type": "string",
+                    "description": "The second line of the address, for example, a suite or apartment number.",
+                    "maxLength": 300
+                  },
+                  "admin_area_2": {
+                    "type": "string",
+                    "description": "A city, town, or village. Smaller than `admin_area_level_1`.",
+                    "maxLength": 120
+                  },
+                  "admin_area_1": {
+                    "type": "string",
+                    "description": "The highest-level sub-division in a country, which is usually a province, state, or ISO-3166-2 subdivision. This data is formatted for postal delivery, for example, `CA` and not `California`. Value, by country, is:<ul><li>UK. A county.</li><li>US. A state.</li><li>Canada. A province.</li><li>Japan. A prefecture.</li><li>Switzerland. A *kanton*.</li></ul>",
+                    "maxLength": 300
+                  },
+                  "postal_code": {
+                    "type": "string",
+                    "description": "The postal code, which is the ZIP code or equivalent. Typically required for countries with a postal code or an equivalent. See [postal code](https://en.wikipedia.org/wiki/Postal_code).",
+                    "maxLength": 60
+                  },
+                  "country_code": {
+                    "$ref": "#/components/schemas/country_code"
+                  }
+                }
+              },
+              "expiry": {
+                "description": "The card expiration year and month, in [Internet date format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+                "$ref": "#/components/schemas/date_year_month"
+              },
+              "currency_code": {
+                "description": "Currency code of the given instrument",
+                "$ref": "#/components/schemas/currency_code"
+              }
+            }
+          },
+          {
+            "title": "Card Response with billing address and name",
+            "type": "object",
+            "description": "The payment card used to fund the payment. Card can be a credit or debit card."
+          }
+        ]
+      },
+      "card_type": {
+        "type": "string",
+        "title": "Card Type",
+        "description": "Type of card. i.e Credit, Debit and so on.",
+        "minLength": 1,
+        "maxLength": 255,
+        "pattern": "^[A-Z_]+$",
+        "x-enumDescriptions": [
+          {
+            "value": "CREDIT",
+            "description": "A credit card."
+          },
+          {
+            "value": "DEBIT",
+            "description": "A debit card."
+          },
+          {
+            "value": "PREPAID",
+            "description": "A Prepaid card."
+          },
+          {
+            "value": "STORE",
+            "description": "A store card."
+          },
+          {
+            "value": "UNKNOWN",
+            "description": "Card type cannot be determined."
+          }
+        ],
+        "enum": [
+          "CREDIT",
+          "DEBIT",
+          "PREPAID",
+          "STORE",
+          "UNKNOWN"
+        ]
+      },
+      "card_verification": {
+        "type": "object",
+        "title": "Card Verification",
+        "description": "The API caller can opt in to verify the card through PayPal offered verification services (e.g. Smart Dollar Auth, 3DS).",
+        "properties": {
+          "method": {
+            "description": "The method used for card verification.",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "pattern": "^[0-9A-Z_]+$",
+            "default": "SCA_WHEN_REQUIRED",
+            "x-enumDescriptions": [
+              {
+                "value": "SCA_ALWAYS",
+                "description": "Selecting this option will attempt to force a strong customer authentication for the authorization/transaction. In countries where SCA has been defined and implemented it will result in a contingency and HATEOAS link being returned.  The API caller should redirect the payer to that link so that they can authenticate themselves against their issuing bank or other entity. As noted, the HATEOAS link is only available in all regions where strong authentication is supported, (e.g. in European countries where 3DS is live). Merchants can use this setting as an additional layer of security if they choose to. In all cases, when an authorization is requested the AVS/CVV results will be returned in the response."
+              },
+              {
+                "value": "SCA_WHEN_REQUIRED",
+                "description": "This is the default. When an authorization or transaction is attempted this option will return a contingency and HATEOAS link only when local regulations require strong customer authentication, (e.g. 3DS in countries and use cases where it is mandated). The API caller should redirect the payer to the link so that they can authenticate themselves. In all cases, when an authorization is requested the AVS/CVV results will be returned in the response."
+              },
+              {
+                "value": "3D_SECURE",
+                "description": "The contingency surfaced as an additional security layer that helps prevent unauthorized card-not-present transactions and protects the merchant from exposure to fraud.",
+                "deprecated": true
+              },
+              {
+                "value": "AVS_CVV",
+                "description": "Places a temporary hold on the card to ensure its validity. This process protects the merchant from exposure to fraud. This verification method will confirm that the address information or CVV included matches what the issuing bank has on file for the associated card, ensuring that only authorized card users are able to make purchases from you.",
+                "deprecated": true
+              }
+            ],
+            "enum": [
+              "SCA_ALWAYS",
+              "SCA_WHEN_REQUIRED",
+              "3D_SECURE",
+              "AVS_CVV"
+            ]
+          }
+        }
+      },
+      "country_code": {
+        "type": "string",
+        "description": "The [2-character ISO 3166-1 code](/api/rest/reference/country-codes/) that identifies the country or region.<blockquote><strong>Note:</strong> The country code for Great Britain is <code>GB</code> and not <code>UK</code> as used in the top-level domain names for that country. Use the `C2` country code for China worldwide for comparable uncontrolled price (CUP) method, bank card, and cross-border transactions.</blockquote>",
+        "format": "ppaas_common_country_code_v2",
+        "maxLength": 2,
+        "minLength": 2,
+        "pattern": "^([A-Z]{2}|C2)$"
+      },
+      "country_code-2": {
+        "type": "string",
+        "description": "The [two-character ISO 3166-1 code](/api/rest/reference/country-codes/) that identifies the country or region.<blockquote><strong>Note:</strong> The country code for Great Britain is <code>GB</code> and not <code>UK</code> as used in the top-level domain names for that country. Use the `C2` country code for China worldwide for comparable uncontrolled price (CUP) method, bank card, and cross-border transactions.</blockquote>",
+        "format": "ppaas_common_country_code_v2",
+        "maxLength": 2,
+        "minLength": 2,
+        "pattern": "^([A-Z]{2}|C2)$"
+      },
+      "currency_code": {
+        "type": "string",
+        "description": "The [three-character ISO-4217 currency code](/api/rest/reference/currency-codes/) that identifies the currency.",
+        "format": "ppaas_common_currency_code_v2",
+        "maxLength": 3,
+        "minLength": 3
+      },
+      "customer": {
+        "title": "Customer Information",
+        "type": "object",
+        "description": "The details about a customer in PayPal's system of record.",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/merchant_partner_customer_id"
+          },
+          "email_address": {
+            "description": "Email address of the buyer as provided to the merchant or on file with the merchant. Email Address is required if you are processing the transaction using PayPal Guest Processing which is offered to select partners and merchants. For all other use cases we do not expect partners/merchant to send email_address of their customer.",
+            "$ref": "#/components/schemas/email"
+          },
+          "phone": {
+            "description": "The phone number of the buyer as provided to the merchant or on file with the merchant. The `phone.phone_number` supports only `national_number`.",
+            "$ref": "#/components/schemas/phone_with_type"
+          }
+        }
+      },
+      "cycle_execution": {
+        "title": "Billing Cycle Execution Details",
+        "description": "The regular and trial execution details for a billing cycle.",
+        "type": "object",
+        "properties": {
+          "tenure_type": {
+            "type": "string",
+            "description": "The type of the billing cycle.",
+            "minLength": 1,
+            "maxLength": 24,
+            "pattern": "^[A-Z_]+$",
+            "x-enumDescriptions": [
+              {
+                "value": "REGULAR",
+                "description": "A regular billing cycle."
+              },
+              {
+                "value": "TRIAL",
+                "description": "A trial billing cycle."
+              }
+            ],
+            "readOnly": true,
+            "enum": [
+              "REGULAR",
+              "TRIAL"
+            ]
+          },
+          "sequence": {
+            "type": "integer",
+            "description": "The order in which to run this cycle among other billing cycles.",
+            "maximum": 99.0,
+            "minimum": 0.0
+          },
+          "cycles_completed": {
+            "type": "integer",
+            "description": "The number of billing cycles that have completed.",
+            "maximum": 9999.0,
+            "minimum": 0.0,
+            "readOnly": true
+          },
+          "cycles_remaining": {
+            "type": "integer",
+            "description": "For a finite billing cycle, cycles_remaining is the number of remaining cycles. For an infinite billing cycle, cycles_remaining is set as 0.",
+            "maximum": 9999.0,
+            "minimum": 0.0,
+            "readOnly": true
+          },
+          "current_pricing_scheme_version": {
+            "type": "integer",
+            "description": "The active pricing scheme version for the billing cycle.",
+            "maximum": 99.0,
+            "minimum": 1.0,
+            "readOnly": true
+          },
+          "total_cycles": {
+            "type": "integer",
+            "description": "The number of times this billing cycle gets executed. Trial billing cycles can only be executed a finite number of times (value between <code>1</code> and <code>999</code> for <code>total_cycles</code>). Regular billing cycles can be executed infinite times (value of <code>0</code> for <code>total_cycles</code>) or a finite number of times (value between <code>1</code> and <code>999</code> for <code>total_cycles</code>).",
+            "maximum": 999.0,
+            "minimum": 0.0,
+            "readOnly": true
+          }
+        },
+        "required": [
+          "tenure_type",
+          "sequence",
+          "cycles_completed"
+        ]
+      },
+      "cycle_execution_list": {
+        "type": "array",
+        "description": "The trial and regular billing executions.",
+        "maxItems": 3,
+        "items": {
+          "$ref": "#/components/schemas/cycle_execution"
+        },
+        "readOnly": true
+      },
+      "date_time": {
+        "type": "string",
+        "description": "The date and time, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6). Seconds are required while fractional seconds are optional.<blockquote><strong>Note:</strong> The regular expression provides guidance but does not reject all invalid dates.</blockquote>",
+        "format": "ppaas_date_time_v3",
+        "maxLength": 64,
+        "minLength": 20,
+        "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])[T,t]([0-1][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)([.][0-9]+)?([Zz]|[+-][0-9]{2}:[0-9]{2})$"
+      },
+      "date_year_month": {
+        "type": "string",
+        "description": "The year and month, in ISO-8601 `YYYY-MM` date format. See [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+        "maxLength": 7,
+        "minLength": 7,
+        "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])$"
+      },
+      "definitions-link_description_list": {
+        "type": "array",
+        "description": "An array of request-related HATEOAS links.",
+        "maxItems": 10,
+        "minItems": 1,
+        "items": {
+          "$ref": "#/components/schemas/link_description"
+        },
+        "readOnly": true
+      },
+      "email": {
+        "type": "string",
+        "description": "The internationalized email address.<blockquote><strong>Note:</strong> Up to 64 characters are allowed before and 255 characters are allowed after the <code>@</code> sign. However, the generally accepted maximum length for an email address is 254 characters. The pattern verifies that an unquoted <code>@</code> sign exists.</blockquote>",
+        "format": "merchant_common_email_address_v2",
+        "maxLength": 254,
+        "minLength": 3,
+        "pattern": "(?:[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+)*|(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\\.)+[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?|\\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-zA-Z0-9-]*[a-zA-Z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])"
+      },
+      "email_address": {
+        "type": "string",
+        "description": "The internationalized email address.<blockquote><strong>Note:</strong> Up to 64 characters are allowed before and 255 characters are allowed after the <code>@</code> sign. However, the generally accepted maximum length for an email address is 254 characters. The pattern verifies that an unquoted <code>@</code> sign exists.</blockquote>",
+        "format": "ppaas_common_email_address_v2",
+        "maxLength": 254,
+        "minLength": 3,
+        "pattern": "^(?:[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\\.)+[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[A-Za-z0-9-]*[A-Za-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])$"
+      },
+      "enrolled": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 255,
+        "pattern": "^[0-9A-Z_]+$",
+        "description": "Status of Authentication eligibility.",
+        "x-enumDescriptions": [
+          {
+            "value": "Y",
+            "description": "Yes. The bank is participating in 3-D Secure protocol and will return the ACSUrl."
+          },
+          {
+            "value": "N",
+            "description": "No. The bank is not participating in 3-D Secure protocol."
+          },
+          {
+            "value": "U",
+            "description": "Unavailable. The DS or ACS is not available for authentication at the time of the request."
+          },
+          {
+            "value": "B",
+            "description": "Bypass. The merchant authentication rule is triggered to bypass authentication."
+          }
+        ],
+        "enum": [
+          "Y",
+          "N",
+          "U",
+          "B"
+        ]
+      },
+      "error_400": {
+        "title": "Bad Request Error",
+        "type": "object",
+        "description": "Request is not well-formed, syntactically incorrect, or violates schema.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "INVALID_REQUEST"
+            ]
+          },
+          "message": {
+            "type": "string",
+            "enum": [
+              "Request is not well-formed, syntactically incorrect, or violates schema."
+            ]
+          },
+          "details": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/error_details"
+            }
+          },
+          "debug_id": {
+            "type": "string",
+            "description": "The PayPal internal ID. Used for correlation purposes."
+          },
+          "links": {
+            "type": "array",
+            "description": "An array of request-related [HATEOAS links](https://en.wikipedia.org/wiki/HATEOAS).",
+            "maxItems": 10000,
+            "items": {
+              "$ref": "#/components/schemas/error_link_description"
+            }
+          }
+        }
+      },
+      "error_401": {
+        "title": "Unauthorized Error",
+        "type": "object",
+        "description": "Authentication failed due to missing Authorization header, or invalid authentication credentials.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "AUTHENTICATION_FAILURE"
+            ]
+          },
+          "message": {
+            "type": "string",
+            "enum": [
+              "Authentication failed due to missing authorization header, or invalid authentication credentials."
+            ]
+          },
+          "details": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/error_details"
+            }
+          },
+          "debug_id": {
+            "type": "string",
+            "description": "The PayPal internal ID. Used for correlation purposes."
+          },
+          "links": {
+            "type": "array",
+            "description": "An array of request-related [HATEOAS links](https://en.wikipedia.org/wiki/HATEOAS).",
+            "maxItems": 10000,
+            "items": {
+              "$ref": "#/components/schemas/error_link_description"
+            }
+          }
+        }
+      },
+      "error_403": {
+        "title": "Not Authorized Error",
+        "type": "object",
+        "description": "The client is not authorized to access this resource, although it may have valid credentials. ",
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "NOT_AUTHORIZED"
+            ]
+          },
+          "message": {
+            "type": "string",
+            "enum": [
+              "Authorization failed due to insufficient permissions."
+            ]
+          },
+          "details": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/error_details"
+            }
+          },
+          "debug_id": {
+            "type": "string",
+            "description": "The PayPal internal ID. Used for correlation purposes."
+          },
+          "links": {
+            "type": "array",
+            "description": "An array of request-related [HATEOAS links](https://en.wikipedia.org/wiki/HATEOAS).",
+            "maxItems": 10000,
+            "items": {
+              "$ref": "#/components/schemas/error_link_description"
+            }
+          }
+        }
+      },
+      "error_404": {
+        "title": "Not found Error",
+        "type": "object",
+        "description": "The server has not found anything matching the request URI. This either means that the URI is incorrect or the resource is not available.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "RESOURCE_NOT_FOUND"
+            ]
+          },
+          "message": {
+            "type": "string",
+            "enum": [
+              "The specified resource does not exist."
+            ]
+          },
+          "details": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/error_details"
+            }
+          },
+          "debug_id": {
+            "type": "string",
+            "description": "The PayPal internal ID. Used for correlation purposes."
+          },
+          "links": {
+            "type": "array",
+            "description": "An array of request-related [HATEOAS links](https://en.wikipedia.org/wiki/HATEOAS).",
+            "maxItems": 10000,
+            "items": {
+              "$ref": "#/components/schemas/error_link_description"
+            }
+          }
+        }
+      },
+      "error_409": {
+        "title": "Resource Conflict Error",
+        "type": "object",
+        "description": "The server has detected a conflict while processing this request.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "RESOURCE_CONFLICT"
+            ]
+          },
+          "message": {
+            "type": "string",
+            "enum": [
+              "The server has detected a conflict while processing this request."
+            ]
+          },
+          "details": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/error_details"
+            }
+          },
+          "debug_id": {
+            "type": "string",
+            "description": "The PayPal internal ID. Used for correlation purposes."
+          },
+          "links": {
+            "type": "array",
+            "description": "An array of request-related [HATEOAS links](https://en.wikipedia.org/wiki/HATEOAS).",
+            "maxItems": 10000,
+            "items": {
+              "$ref": "#/components/schemas/error_link_description"
+            }
+          }
+        }
+      },
+      "error_415": {
+        "title": "Unsupported Media Type Error",
+        "type": "object",
+        "description": "The server does not support the request payload's media type.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "UNSUPPORTED_MEDIA_TYPE"
+            ]
+          },
+          "message": {
+            "type": "string",
+            "enum": [
+              "The server does not support the request payload's media type."
+            ]
+          },
+          "details": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/error_details"
+            }
+          },
+          "debug_id": {
+            "type": "string",
+            "description": "The PayPal internal ID. Used for correlation purposes."
+          },
+          "links": {
+            "type": "array",
+            "description": "An array of request-related [HATEOAS links](https://en.wikipedia.org/wiki/HATEOAS).",
+            "maxItems": 10000,
+            "items": {
+              "$ref": "#/components/schemas/error_link_description"
+            }
+          }
+        }
+      },
+      "error_422": {
+        "title": "Unprocessable Entity Error",
+        "type": "object",
+        "description": "The requested action cannot be performed and may require interaction with APIs or processes outside of the current request. This is distinct from a 500 response in that there are no systemic problems limiting the API from performing the request.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "UNPROCESSABLE_ENTITY"
+            ]
+          },
+          "message": {
+            "type": "string",
+            "enum": [
+              "The requested action could not be performed, semantically incorrect, or failed business validation."
+            ]
+          },
+          "details": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/error_details"
+            }
+          },
+          "debug_id": {
+            "type": "string",
+            "description": "The PayPal internal ID. Used for correlation purposes."
+          },
+          "links": {
+            "type": "array",
+            "description": "An array of request-related [HATEOAS links](https://en.wikipedia.org/wiki/HATEOAS).",
+            "maxItems": 10000,
+            "items": {
+              "$ref": "#/components/schemas/error_link_description"
+            }
+          }
+        }
+      },
+      "error_500": {
+        "title": "Internal Server Error",
+        "type": "object",
+        "description": "This is either a system or application error, and generally indicates that although the client appeared to provide a correct request, something unexpected has gone wrong on the server.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "INTERNAL_SERVER_ERROR"
+            ]
+          },
+          "message": {
+            "type": "string",
+            "enum": [
+              "An internal server error occurred."
+            ]
+          },
+          "debug_id": {
+            "type": "string",
+            "description": "The PayPal internal ID. Used for correlation purposes."
+          },
+          "links": {
+            "type": "array",
+            "description": "An array of request-related [HATEOAS links](https://en.wikipedia.org/wiki/HATEOAS).",
+            "maxItems": 10000,
+            "items": {
+              "$ref": "#/components/schemas/error_link_description"
+            }
+          }
+        },
+        "example": {
+          "name": "INTERNAL_SERVER_ERROR",
+          "message": "An internal server error occurred.",
+          "debug_id": "90957fca61718",
+          "links": [
+            {
+              "href": "https://developer.paypal.com/api/orders/v2/#error-INTERNAL_SERVER_ERROR",
+              "rel": "information_link"
+            }
+          ]
+        }
+      },
+      "error_503": {
+        "title": "Service Unavailable Error",
+        "type": "object",
+        "description": "The server is temporarily unable to handle the request, for example, because of planned maintenance or downtime.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "SERVICE_UNAVAILABLE"
+            ]
+          },
+          "message": {
+            "type": "string",
+            "enum": [
+              "Service Unavailable."
+            ]
+          },
+          "debug_id": {
+            "type": "string",
+            "description": "The PayPal internal ID. Used for correlation purposes."
+          },
+          "links": {
+            "type": "array",
+            "description": "An array of request-related [HATEOAS links](https://en.wikipedia.org/wiki/HATEOAS).",
+            "maxItems": 10000,
+            "items": {
+              "$ref": "#/components/schemas/error_link_description"
+            }
+          }
+        },
+        "example": {
+          "name": "SERVICE_UNAVAILABLE",
+          "message": "Service Unavailable.",
+          "debug_id": "90957fca61718",
+          "information_link": "https://developer.paypal.com/docs/api/orders/v2/#error-SERVICE_UNAVAILABLE"
+        }
+      },
+      "error_default": {
+        "description": "The default error response.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/error_400"
+          },
+          {
+            "$ref": "#/components/schemas/error_401"
+          },
+          {
+            "$ref": "#/components/schemas/error_403"
+          },
+          {
+            "$ref": "#/components/schemas/error_404"
+          },
+          {
+            "$ref": "#/components/schemas/error_409"
+          },
+          {
+            "$ref": "#/components/schemas/error_415"
+          },
+          {
+            "$ref": "#/components/schemas/error_422"
+          },
+          {
+            "$ref": "#/components/schemas/error_500"
+          },
+          {
+            "$ref": "#/components/schemas/error_503"
+          }
+        ]
+      },
+      "error_details": {
+        "title": "Error Details",
+        "type": "object",
+        "description": "The error details. Required for client-side `4XX` errors.",
+        "required": [
+          "issue"
+        ],
+        "properties": {
+          "field": {
+            "type": "string",
+            "description": "The field that caused the error. If this field is in the body, set this value to the field's JSON pointer value. Required for client-side errors."
+          },
+          "value": {
+            "type": "string",
+            "description": "The value of the field that caused the error."
+          },
+          "location": {
+            "$ref": "#/components/schemas/error_location"
+          },
+          "issue": {
+            "type": "string",
+            "description": "The unique, fine-grained application-level error code."
+          },
+          "description": {
+            "type": "string",
+            "description": "The human-readable description for an issue. The description can change over the lifetime of an API, so clients must not depend on this value."
+          }
+        }
+      },
+      "error_link_description": {
+        "title": "Link Description",
+        "type": "object",
+        "description": "The request-related [HATEOAS link](/api/rest/responses/#hateoas-links) information.",
+        "required": [
+          "href",
+          "rel"
+        ],
+        "properties": {
+          "href": {
+            "type": "string",
+            "description": "The complete target URL. To make the related call, combine the method with this [URI Template-formatted](https://tools.ietf.org/html/rfc6570) link. For pre-processing, include the `$`, `(`, and `)` characters. The `href` is the key HATEOAS component that links a completed call with a subsequent call.",
+            "maxLength": 20000,
+            "minLength": 0,
+            "pattern": "^.*$"
+          },
+          "rel": {
+            "type": "string",
+            "description": "The [link relation type](https://tools.ietf.org/html/rfc5988#section-4), which serves as an ID for a link that unambiguously describes the semantics of the link. See [Link Relations](https://www.iana.org/assignments/link-relations/link-relations.xhtml).",
+            "maxLength": 100,
+            "minLength": 0,
+            "pattern": "^.*$"
+          },
+          "method": {
+            "type": "string",
+            "description": "The HTTP method required to make the related call.",
+            "maxLength": 6,
+            "minLength": 3,
+            "pattern": "^[A-Z]*$",
+            "enum": [
+              "GET",
+              "POST",
+              "PUT",
+              "DELETE",
+              "PATCH"
+            ]
+          }
+        }
+      },
+      "error_location": {
+        "type": "string",
+        "description": "The location of the field that caused the error. Value is `body`, `path`, or `query`.",
+        "default": "body",
+        "enum": [
+          "body",
+          "path",
+          "query"
+        ]
+      },
+      "failed_payment_details": {
+        "title": "Failed Payment Details",
+        "description": "The details for the failed payment of the subscription.",
+        "type": "object",
+        "properties": {
+          "amount": {
+            "description": "The failed payment amount.",
+            "readOnly": true,
+            "$ref": "#/components/schemas/money"
+          },
+          "time": {
+            "description": "The date and time when the failed payment was made, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+            "readOnly": true,
+            "$ref": "#/components/schemas/date_time"
+          },
+          "reason_code": {
+            "type": "string",
+            "description": "The reason code for the payment failure.",
+            "minLength": 1,
+            "maxLength": 120,
+            "pattern": "^[A-Z_]+$",
+            "x-enumDescriptions": [
+              {
+                "value": "PAYMENT_DENIED",
+                "description": "PayPal declined the payment due to one or more customer issues."
+              },
+              {
+                "value": "INTERNAL_SERVER_ERROR",
+                "description": "An internal server error has occurred."
+              },
+              {
+                "value": "PAYEE_ACCOUNT_RESTRICTED",
+                "description": "The payee account is not in good standing and cannot receive payments."
+              },
+              {
+                "value": "PAYER_ACCOUNT_RESTRICTED",
+                "description": "The payer account is not in good standing and cannot make payments."
+              },
+              {
+                "value": "PAYER_CANNOT_PAY",
+                "description": "Payer cannot pay for this transaction."
+              },
+              {
+                "value": "SENDING_LIMIT_EXCEEDED",
+                "description": "The transaction exceeds the payer's sending limit."
+              },
+              {
+                "value": "TRANSACTION_RECEIVING_LIMIT_EXCEEDED",
+                "description": "The transaction exceeds the receiver's receiving limit."
+              },
+              {
+                "value": "CURRENCY_MISMATCH",
+                "description": "The transaction is declined due to a currency mismatch."
+              }
+            ],
+            "readOnly": true,
+            "enum": [
+              "PAYMENT_DENIED",
+              "INTERNAL_SERVER_ERROR",
+              "PAYEE_ACCOUNT_RESTRICTED",
+              "PAYER_ACCOUNT_RESTRICTED",
+              "PAYER_CANNOT_PAY",
+              "SENDING_LIMIT_EXCEEDED",
+              "TRANSACTION_RECEIVING_LIMIT_EXCEEDED",
+              "CURRENCY_MISMATCH"
+            ]
+          },
+          "next_payment_retry_time": {
+            "description": "The time when the retry attempt for the failed payment occurs, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+            "readOnly": true,
+            "$ref": "#/components/schemas/date_time"
+          }
+        },
+        "required": [
+          "amount",
+          "time"
+        ]
+      },
+      "frequency": {
+        "title": "Billing Cycle Frequency",
+        "description": "The frequency of the billing cycle.",
+        "type": "object",
+        "properties": {
+          "interval_unit": {
+            "type": "string",
+            "description": "The interval at which the subscription is charged or billed.",
+            "minLength": 1,
+            "maxLength": 24,
+            "pattern": "^[A-Z_]+$",
+            "x-enumDescriptions": [
+              {
+                "value": "DAY",
+                "description": "A daily billing cycle."
+              },
+              {
+                "value": "WEEK",
+                "description": "A weekly billing cycle."
+              },
+              {
+                "value": "MONTH",
+                "description": "A monthly billing cycle."
+              },
+              {
+                "value": "YEAR",
+                "description": "A yearly billing cycle."
+              }
+            ],
+            "enum": [
+              "DAY",
+              "WEEK",
+              "MONTH",
+              "YEAR"
+            ]
+          },
+          "interval_count": {
+            "type": "integer",
+            "description": "The number of intervals after which a subscriber is billed. For example, if the `interval_unit` is `DAY` with an `interval_count` of  `2`, the subscription is billed once every two days. The following table lists the maximum allowed values for the `interval_count` for each `interval_unit`:<table><thead><tr><th><code>Interval unit</code></th><th>Maximum interval count</th></tr></thead><tbody><tr><td><code>DAY</code></td><td align=\"right\">365</td></tr><tr><td><code>WEEK</code></td><td align=\"right\">52</td></tr><tr><td><code>MONTH</code></td><td align=\"right\">12</td></tr><tr><td><code>YEAR</code></td><td align=\"right\">1</td></tr></tbody></table>",
+            "default": 1,
+            "maximum": 365.0,
+            "minimum": 1.0
+          }
+        },
+        "required": [
+          "interval_unit"
+        ]
+      },
+      "language": {
+        "type": "string",
+        "description": "The [language tag](https://tools.ietf.org/html/bcp47#section-2) for the language in which to localize the error-related strings, such as messages, issues, and suggested actions. The tag is made up of the [ISO 639-2 language code](https://www.loc.gov/standards/iso639-2/php/code_list.php), the optional [ISO-15924 script tag](https://www.unicode.org/iso15924/codelists.html), and the [ISO-3166 alpha-2 country code](/api/rest/reference/country-codes/) or [M49 region code](https://unstats.un.org/unsd/methodology/m49/).",
+        "format": "ppaas_common_language_v3",
+        "maxLength": 10,
+        "minLength": 2,
+        "pattern": "^[a-z]{2}(?:-[A-Z][a-z]{3})?(?:-(?:[A-Z]{2}|[0-9]{3}))?$"
+      },
+      "last_payment_details": {
+        "title": "Last Payment Details",
+        "type": "object",
+        "description": "The details for the last payment.",
+        "required": [
+          "amount",
+          "time"
+        ],
+        "allOf": [
+          {
+            "properties": {
+              "amount": {
+                "readonly": true,
+                "description": "The last payment amount.",
+                "$ref": "#/components/schemas/money"
+              },
+              "time": {
+                "readonly": true,
+                "description": "The date and time when the last payment was made, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+                "$ref": "#/components/schemas/date_time"
+              }
+            }
+          }
+        ]
+      },
+      "liability_shift": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 255,
+        "pattern": "^[0-9A-Z_]+$",
+        "description": "Liability shift indicator. The outcome of the issuer's authentication.",
+        "x-enumDescriptions": [
+          {
+            "value": "NO",
+            "description": "Liability is with the merchant."
+          },
+          {
+            "value": "POSSIBLE",
+            "description": "Liability may shift to the card issuer."
+          },
+          {
+            "value": "UNKNOWN",
+            "description": "The authentication system is not available."
+          }
+        ],
+        "enum": [
+          "NO",
+          "POSSIBLE",
+          "UNKNOWN"
+        ]
+      },
+      "link_description": {
+        "title": "Link Description",
+        "type": "object",
+        "description": "The request-related [HATEOAS link](/api/rest/responses/#hateoas-links) information.",
+        "required": [
+          "href",
+          "rel"
+        ],
+        "properties": {
+          "href": {
+            "type": "string",
+            "description": "The complete target URL. To make the related call, combine the method with this [URI Template-formatted](https://tools.ietf.org/html/rfc6570) link. For pre-processing, include the `$`, `(`, and `)` characters. The `href` is the key HATEOAS component that links a completed call with a subsequent call."
+          },
+          "rel": {
+            "type": "string",
+            "description": "The [link relation type](https://tools.ietf.org/html/rfc5988#section-4), which serves as an ID for a link that unambiguously describes the semantics of the link. See [Link Relations](https://www.iana.org/assignments/link-relations/link-relations.xhtml)."
+          },
+          "method": {
+            "type": "string",
+            "description": "The HTTP method required to make the related call.",
+            "enum": [
+              "GET",
+              "POST",
+              "PUT",
+              "DELETE",
+              "HEAD",
+              "CONNECT",
+              "OPTIONS",
+              "PATCH"
+            ]
+          }
+        }
+      },
+      "link_description_list": {
+        "type": "array",
+        "description": "An array of request-related [HATEOAS links](/docs/api/reference/api-responses/#hateoas-links).",
+        "maxItems": 10,
+        "minItems": 1,
+        "items": {
+          "$ref": "#/components/schemas/link_description"
+        },
+        "readOnly": true
+      },
+      "merchant_inventory": {},
+      "merchant_partner_customer_id": {
+        "type": "string",
+        "description": "The unique ID for a customer generated by PayPal.",
+        "maxLength": 22,
+        "minLength": 1,
+        "pattern": "^[0-9a-zA-Z_-]+$"
+      },
+      "money": {
+        "title": "Money",
+        "type": "object",
+        "description": "The currency and amount for a financial transaction, such as a balance or payment due.",
+        "required": [
+          "currency_code",
+          "value"
+        ],
+        "properties": {
+          "currency_code": {
+            "$ref": "#/components/schemas/currency_code"
+          },
+          "value": {
+            "type": "string",
+            "description": "The value, which might be:<ul><li>An integer for currencies like `JPY` that are not typically fractional.</li><li>A decimal fraction for currencies like `TND` that are subdivided into thousandths.</li></ul>For the required number of decimal places for a currency code, see [Currency Codes](/api/rest/reference/currency-codes/).",
+            "maxLength": 32,
+            "pattern": "^((-?[0-9]+)|(-?([0-9]+)?[.][0-9]+))$"
+          }
+        }
+      },
+      "name": {
+        "title": "Name",
+        "type": "object",
+        "description": "The name of the party.",
+        "properties": {
+          "prefix": {
+            "type": "string",
+            "description": "The prefix, or title, to the party's name.",
+            "maxLength": 140
+          },
+          "given_name": {
+            "type": "string",
+            "description": "When the party is a person, the party's given, or first, name.",
+            "maxLength": 140
+          },
+          "surname": {
+            "type": "string",
+            "description": "When the party is a person, the party's surname or family name. Also known as the last name. Required when the party is a person. Use also to store multiple surnames including the matronymic, or mother's, surname.",
+            "maxLength": 140
+          },
+          "middle_name": {
+            "type": "string",
+            "description": "When the party is a person, the party's middle name. Use also to store multiple middle names including the patronymic, or father's, middle name.",
+            "maxLength": 140
+          },
+          "suffix": {
+            "type": "string",
+            "description": "The suffix for the party's name.",
+            "maxLength": 140
+          },
+          "full_name": {
+            "type": "string",
+            "description": "When the party is a person, the party's full name.",
+            "maxLength": 300
+          }
+        }
+      },
+      "pares_status": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 255,
+        "pattern": "^[0-9A-Z_]+$",
+        "description": "Transactions status result identifier. The outcome of the issuer's authentication.",
+        "x-enumDescriptions": [
+          {
+            "value": "Y",
+            "description": "Successful authentication."
+          },
+          {
+            "value": "N",
+            "description": "Failed authentication / account not verified / transaction denied."
+          },
+          {
+            "value": "U",
+            "description": "Unable to complete authentication."
+          },
+          {
+            "value": "A",
+            "description": "Successful attempts transaction."
+          },
+          {
+            "value": "C",
+            "description": "Challenge required for authentication."
+          },
+          {
+            "value": "R",
+            "description": "Authentication rejected (merchant must not submit for authorization)."
+          },
+          {
+            "value": "D",
+            "description": "Challenge required; decoupled authentication confirmed."
+          },
+          {
+            "value": "I",
+            "description": "Informational only; 3DS requestor challenge preference acknowledged."
+          }
+        ],
+        "enum": [
+          "Y",
+          "N",
+          "U",
+          "A",
+          "C",
+          "R",
+          "D",
+          "I"
+        ]
+      },
+      "patch": {
+        "type": "object",
+        "title": "Patch",
+        "description": "The JSON patch object to apply partial updates to resources.",
+        "properties": {
+          "op": {
+            "type": "string",
+            "description": "The operation.",
+            "x-enumDescriptions": [
+              {
+                "value": "add",
+                "description": "Depending on the target location reference, completes one of these functions:<ul><li><strong>The target location is an array index</strong>. Inserts a new value into the array at the specified index.</li><li><strong>The target location is an object parameter that does not already exist</strong>. Adds a new parameter to the object.</li><li><strong>The target location is an object parameter that does exist</strong>. Replaces that parameter's value.</li></ul>The <code>value</code> parameter defines the value to add. For more information, see <a href=\"https://tools.ietf.org/html/rfc6902#section-4.1\">4.1. add</a>."
+              },
+              {
+                "value": "remove",
+                "description": "Removes the value at the target location. For the operation to succeed, the target location must exist. For more information, see <a href=\"https://tools.ietf.org/html/rfc6902#section-4.2\">4.2. remove</a>."
+              },
+              {
+                "value": "replace",
+                "description": "Replaces the value at the target location with a new value. The operation object must contain a <code>value</code> parameter that defines the replacement value. For the operation to succeed, the target location must exist. For more information, see <a href=\"https://tools.ietf.org/html/rfc6902#section-4.3\">4.3. replace</a>."
+              },
+              {
+                "value": "move",
+                "description": "Removes the value at a specified location and adds it to the target location. The operation object must contain a <code>from</code> parameter, which is a string that contains a JSON pointer value that references the location in the target document from which to move the value. For the operation to succeed, the <code>from</code> location must exist. For more information, see <a href=\"https://tools.ietf.org/html/rfc6902#section-4.4\">4.4. move</a>."
+              },
+              {
+                "value": "copy",
+                "description": "Copies the value at a specified location to the target location. The operation object must contain a <code>from</code> parameter, which is a string that contains a JSON pointer value that references the location in the target document from which to copy the value. For the operation to succeed, the <code>from</code> location must exist. For more information, see <a href=\"https://tools.ietf.org/html/rfc6902#section-4.5\">4.5. copy</a>."
+              },
+              {
+                "value": "test",
+                "description": "Tests that a value at the target location is equal to a specified value. The operation object must contain a <code>value</code> parameter that defines the value to compare to the target location's value. For the operation to succeed, the target location must be equal to the <code>value</code> value. For test, <code>equal</code> indicates that the value at the target location and the value that <code>value</code> defines are of the same JSON type. The data type of the value determines how equality is defined:<table><thead align=\"left\"><tr><th>Type</th><th>Considered equal if both values</th></tr></thead><tbody align=\"left\"><tr><td><strong>strings</strong></td><td>Contain the same number of Unicode characters and their code points are byte-by-byte equal.</td></tr><tr><td><strong>numbers</strong></td><td>Are numerically equal.</td></tr><tr><td><strong>arrays</strong></td><td>Contain the same number of values, and each value is equal to the value at the corresponding position in the other array, by using these type-specific rules.</td></tr><tr><td><strong>objects</strong></td><td>Contain the same number of parameters, and each parameter is equal to a parameter in the other object, by comparing their keys (as strings) and their values (by using these type-specific rules).</td></tr><tr><td><strong>literals (<code>false</code>, <code>true</code>, and <code>null</code>)</strong></td><td>Are the same. The comparison is a logical comparison. For example, whitespace between the parameter values of an array is not significant. Also, ordering of the serialization of object parameters is not significant.</td></tr></tbody></table>For more information, see <a href=\"https://tools.ietf.org/html/rfc6902#section-4.6\">4.6. test</a>."
+              }
+            ],
+            "enum": [
+              "add",
+              "remove",
+              "replace",
+              "move",
+              "copy",
+              "test"
+            ]
+          },
+          "path": {
+            "type": "string",
+            "description": "The <a href=\"https://tools.ietf.org/html/rfc6901\">JSON Pointer</a> to the target document location at which to complete the operation."
+          },
+          "value": {
+            "title": "Patch Value",
+            "description": "The value to apply. The <code>remove</code>, <code>copy</code>, and <code>move</code> operations do not require a value. Since <a href=\"https://www.rfc-editor.org/rfc/rfc69021\">JSON Patch</a> allows any type for <code>value</code>, the <code>type</code> property is not specified."
+          },
+          "from": {
+            "type": "string",
+            "description": "The <a href=\"https://tools.ietf.org/html/rfc6901\">JSON Pointer</a> to the target document location from which to move the value. Required for the <code>move</code> operation."
+          }
+        },
+        "required": [
+          "op"
+        ]
+      },
+      "patch_request": {
+        "title": "Patch Request",
+        "type": "array",
+        "description": "An array of JSON patch objects to apply partial updates to resources.",
+        "items": {
+          "$ref": "#/components/schemas/patch"
+        }
+      },
+      "payee_payment_method_preference": {
+        "type": "string",
+        "description": "The merchant-preferred payment methods.",
+        "minLength": 1,
+        "maxLength": 255,
+        "pattern": "^[0-9A-Z_]+$",
+        "default": "UNRESTRICTED",
+        "x-enumDescriptions": [
+          {
+            "value": "UNRESTRICTED",
+            "description": "Accepts any type of payment from the customer.",
+            "default": true
+          },
+          {
+            "value": "IMMEDIATE_PAYMENT_REQUIRED",
+            "description": "Accepts only immediate payment from the customer. For example, credit card, PayPal balance, or instant ACH. Ensures that at the time of capture, the payment does not have the `pending` status."
+          }
+        ],
+        "enum": [
+          "UNRESTRICTED",
+          "IMMEDIATE_PAYMENT_REQUIRED"
+        ]
+      },
+      "payer_base": {
+        "title": "Payer Base",
+        "type": "object",
+        "description": "The customer who approves and pays for the order. The customer is also known as the payer.",
+        "properties": {
+          "email_address": {
+            "description": "The email address of the payer.",
+            "$ref": "#/components/schemas/email"
+          },
+          "payer_id": {
+            "readonly": true,
+            "description": "The PayPal-assigned ID for the payer.",
+            "$ref": "#/components/schemas/account_id"
+          }
+        }
+      },
+      "payment_preferences": {
+        "title": "Payment Preferences",
+        "description": "The payment preferences for a subscription.",
+        "type": "object",
+        "properties": {
+          "auto_bill_outstanding": {
+            "type": "boolean",
+            "description": "Indicates whether to automatically bill the outstanding amount in the next billing cycle.",
+            "default": true
+          },
+          "setup_fee": {
+            "description": "The initial set-up fee for the service.",
+            "$ref": "#/components/schemas/money"
+          },
+          "setup_fee_failure_action": {
+            "type": "string",
+            "description": "The action to take on the subscription if the initial payment for the setup fails.",
+            "minLength": 1,
+            "maxLength": 24,
+            "pattern": "^[A-Z_]+$",
+            "default": "CANCEL",
+            "x-enumDescriptions": [
+              {
+                "value": "CONTINUE",
+                "description": "Continues the subscription if the initial payment for the setup fails."
+              },
+              {
+                "value": "CANCEL",
+                "description": "Cancels the subscription if the initial payment for the setup fails."
+              }
+            ],
+            "enum": [
+              "CONTINUE",
+              "CANCEL"
+            ]
+          },
+          "payment_failure_threshold": {
+            "type": "integer",
+            "description": "The maximum number of payment failures before a subscription is suspended. For example, if `payment_failure_threshold` is `2`, the subscription automatically updates to the `SUSPEND` state if two consecutive payments fail.",
+            "default": 0,
+            "maximum": 999.0,
+            "minimum": 0.0
+          }
+        }
+      },
+      "payment_preferences_override": {
+        "title": "Payment Preferences Override",
+        "description": "The payment preferences to override at subscription level.",
+        "type": "object",
+        "properties": {
+          "auto_bill_outstanding": {
+            "type": "boolean",
+            "description": "Indicates whether to automatically bill the outstanding amount in the next billing cycle."
+          },
+          "setup_fee": {
+            "description": "The initial set-up fee for the service.",
+            "$ref": "#/components/schemas/money"
+          },
+          "setup_fee_failure_action": {
+            "type": "string",
+            "description": "The action to take on the subscription if the initial payment for the setup fails.",
+            "minLength": 1,
+            "maxLength": 24,
+            "pattern": "^[A-Z_]+$",
+            "x-enumDescriptions": [
+              {
+                "value": "CONTINUE",
+                "description": "Continues the subscription if the initial payment for the setup fails."
+              },
+              {
+                "value": "CANCEL",
+                "description": "Cancels the subscription if the initial payment for the setup fails."
+              }
+            ],
+            "enum": [
+              "CONTINUE",
+              "CANCEL"
+            ]
+          },
+          "payment_failure_threshold": {
+            "type": "integer",
+            "description": "The maximum number of payment failures before a subscription is suspended. For example, if `payment_failure_threshold` is `2`, the subscription automatically updates to the `SUSPEND` state if two consecutive payments fail.",
+            "maximum": 999.0,
+            "minimum": 0.0
+          }
+        }
+      },
+      "payment_source": {
+        "title": "Payment Source",
+        "type": "object",
+        "description": "The payment source definition. To be eligible to create subscription using debit or credit card, you will need to sign up here (https://www.paypal.com/bizsignup/entry/product/ppcp). Please note, its available only for non-3DS cards and for merchants in US and AU regions.",
+        "properties": {
+          "card": {
+            "title": "Card",
+            "type": "object",
+            "description": "The payment card to use to fund a payment. Can be a credit or debit card.",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The card holder's name as it appears on the card.",
+                "maxLength": 300,
+                "minLength": 1,
+                "pattern": "^.{1,300}$"
+              },
+              "number": {
+                "type": "string",
+                "description": "The primary account number (PAN) for the payment card.",
+                "maxLength": 19,
+                "minLength": 13,
+                "pattern": "^[0-9]{13,19}$"
+              },
+              "expiry": {
+                "description": "The card expiration year and month, in [Internet date format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+                "$ref": "#/components/schemas/date_year_month"
+              },
+              "security_code": {
+                "type": "string",
+                "description": "The three- or four-digit security code of the card. Also known as the CVV, CVC, CVN, CVE, or CID. This parameter cannot be present in the request when `payment_initiator=MERCHANT`.",
+                "maxLength": 4,
+                "minLength": 3,
+                "pattern": "^[0-9]{3,4}$"
+              },
+              "type": {
+                "description": "The payment card type.",
+                "$ref": "#/components/schemas/card_type"
+              },
+              "brand": {
+                "description": "The card brand or network. Typically used in the response.",
+                "$ref": "#/components/schemas/card_brand"
+              },
+              "billing_address": {
+                "title": "Portable Postal Address (Medium-Grained)",
+                "type": "object",
+                "description": "The portable international postal address. Maps to [AddressValidationMetadata](https://github.com/googlei18n/libaddressinput/wiki/AddressValidationMetadata) and HTML 5.1 [Autofilling form controls: the autocomplete attribute](https://www.w3.org/TR/html51/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).",
+                "required": [
+                  "country_code"
+                ],
+                "properties": {
+                  "address_line_1": {
+                    "type": "string",
+                    "description": "The first line of the address, such as number and street, for example, `173 Drury Lane`. Needed for data entry, and Compliance and Risk checks. This field needs to pass the full address.",
+                    "maxLength": 300
+                  },
+                  "address_line_2": {
+                    "type": "string",
+                    "description": "The second line of the address, for example, a suite or apartment number.",
+                    "maxLength": 300
+                  },
+                  "admin_area_2": {
+                    "type": "string",
+                    "description": "A city, town, or village. Smaller than `admin_area_level_1`.",
+                    "maxLength": 120
+                  },
+                  "admin_area_1": {
+                    "type": "string",
+                    "description": "The highest-level sub-division in a country, which is usually a province, state, or ISO-3166-2 subdivision. This data is formatted for postal delivery, for example, `CA` and not `California`. Value, by country, is:<ul><li>UK. A county.</li><li>US. A state.</li><li>Canada. A province.</li><li>Japan. A prefecture.</li><li>Switzerland. A *kanton*.</li></ul>",
+                    "maxLength": 300
+                  },
+                  "postal_code": {
+                    "type": "string",
+                    "description": "The postal code, which is the ZIP code or equivalent. Typically required for countries with a postal code or an equivalent. See [postal code](https://en.wikipedia.org/wiki/Postal_code).",
+                    "maxLength": 60
+                  },
+                  "country_code": {
+                    "$ref": "#/components/schemas/country_code"
+                  }
+                }
+              },
+              "attributes": {
+                "description": "Additional attributes associated with the use of this card.",
+                "$ref": "#/components/schemas/card_attributes"
+              }
+            }
+          }
+        }
+      },
+      "payment_source_response": {
+        "title": "Payment Source Response",
+        "type": "object",
+        "description": "The payment source used to fund the payment.",
+        "properties": {
+          "card": {
+            "$ref": "#/components/schemas/card_response_with_billing_address"
+          }
+        }
+      },
+      "percentage": {
+        "type": "string",
+        "description": "The percentage, as a fixed-point, signed decimal number. For example, define a 19.99% interest rate as `19.99`.",
+        "format": "ppaas_common_percentage_v2",
+        "pattern": "^((-?[0-9]+)|(-?([0-9]+)?[.][0-9]+))$"
+      },
+      "phone_type": {
+        "title": "Phone Type",
+        "type": "string",
+        "description": "The phone type.",
+        "enum": [
+          "FAX",
+          "HOME",
+          "MOBILE",
+          "OTHER",
+          "PAGER"
+        ]
+      },
+      "phone_with_type": {
+        "title": "Phone With Type",
+        "type": "object",
+        "description": "The phone information.",
+        "required": [
+          "phone_number"
+        ],
+        "properties": {
+          "phone_type": {
+            "$ref": "#/components/schemas/phone_type"
+          },
+          "phone_number": {
+            "title": "Phone",
+            "type": "object",
+            "description": "The phone number, in its canonical international [E.164 numbering plan format](https://www.itu.int/rec/T-REC-E.164/en).",
+            "required": [
+              "national_number"
+            ],
+            "properties": {
+              "national_number": {
+                "type": "string",
+                "description": "The national number, in its canonical international [E.164 numbering plan format](https://www.itu.int/rec/T-REC-E.164/en). The combined length of the country calling code (CC) and the national number must not be greater than 15 digits. The national number consists of a national destination code (NDC) and subscriber number (SN).",
+                "maxLength": 14,
+                "minLength": 1,
+                "pattern": "^[0-9]{1,14}?$"
+              }
+            }
+          }
+        }
+      },
+      "plan": {
+        "title": "Plan",
+        "description": "The plan details.",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique PayPal-generated ID for the plan.",
+            "maxLength": 26,
+            "minLength": 26,
+            "pattern": "^P-[A-Z0-9]*$",
+            "readOnly": true
+          },
+          "product_id": {
+            "type": "string",
+            "description": "The ID for the product.",
+            "maxLength": 22,
+            "minLength": 22,
+            "pattern": "^PROD-[A-Z0-9]*$"
+          },
+          "name": {
+            "type": "string",
+            "description": "The plan name.",
+            "maxLength": 127,
+            "minLength": 1,
+            "pattern": "^.*$"
+          },
+          "status": {
+            "type": "string",
+            "description": "The plan status.",
+            "minLength": 1,
+            "maxLength": 24,
+            "pattern": "^[A-Z_]+$",
+            "x-enumDescriptions": [
+              {
+                "value": "CREATED",
+                "description": "The plan was created. You cannot create subscriptions for a plan in this state."
+              },
+              {
+                "value": "INACTIVE",
+                "description": "The plan is inactive."
+              },
+              {
+                "value": "ACTIVE",
+                "description": "The plan is active. You can only create subscriptions for a plan in this state."
+              }
+            ],
+            "enum": [
+              "CREATED",
+              "INACTIVE",
+              "ACTIVE"
+            ]
+          },
+          "description": {
+            "type": "string",
+            "description": "The detailed description of the plan.",
+            "maxLength": 127,
+            "minLength": 1,
+            "pattern": "^.*$"
+          },
+          "billing_cycles": {
+            "$ref": "#/components/schemas/billing_cycle_list"
+          },
+          "payment_preferences": {
+            "$ref": "#/components/schemas/payment_preferences"
+          },
+          "taxes": {
+            "$ref": "#/components/schemas/taxes"
+          },
+          "quantity_supported": {
+            "type": "boolean",
+            "description": "Indicates whether you can subscribe to this plan by providing a quantity for the goods or service.",
+            "default": false
+          },
+          "create_time": {
+            "description": "The date and time when the plan was created, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+            "readOnly": true,
+            "$ref": "#/components/schemas/date_time"
+          },
+          "update_time": {
+            "description": "The date and time when the plan was last updated, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+            "readOnly": true,
+            "$ref": "#/components/schemas/date_time"
+          },
+          "links": {
+            "$ref": "#/components/schemas/link_description_list"
+          }
+        }
+      },
+      "plan_collection": {
+        "title": "Plan Collection",
+        "type": "object",
+        "description": "The list of plans with details.",
+        "properties": {
+          "plans": {
+            "$ref": "#/components/schemas/plan_list"
+          },
+          "total_items": {
+            "type": "integer",
+            "description": "The total number of items.",
+            "maximum": 500000000.0,
+            "minimum": 0.0
+          },
+          "total_pages": {
+            "type": "integer",
+            "description": "The total number of pages.",
+            "maximum": 100000000.0,
+            "minimum": 0.0
+          },
+          "links": {
+            "$ref": "#/components/schemas/link_description_list"
+          }
+        }
+      },
+      "plan_list": {
+        "type": "array",
+        "description": "An array of plans.",
+        "maxItems": 32767,
+        "items": {
+          "$ref": "#/components/schemas/plan"
+        }
+      },
+      "plan_override": {
+        "title": "Plan Override",
+        "type": "object",
+        "description": "An inline plan object to customise the subscription. You can override plan level default attributes by providing customised values for the subscription in this object.",
+        "properties": {
+          "billing_cycles": {
+            "$ref": "#/components/schemas/billing_cycle_override_list"
+          },
+          "payment_preferences": {
+            "$ref": "#/components/schemas/payment_preferences_override"
+          },
+          "taxes": {
+            "$ref": "#/components/schemas/taxes_override"
+          }
+        }
+      },
+      "plan_request_POST": {
+        "title": "Create Plan Request",
+        "description": "The create plan request details.",
+        "type": "object",
+        "properties": {
+          "product_id": {
+            "type": "string",
+            "description": "The ID of the product created through Catalog Products API.",
+            "maxLength": 22,
+            "minLength": 22,
+            "pattern": "^PROD-[A-Z0-9]*$"
+          },
+          "name": {
+            "type": "string",
+            "description": "The plan name.",
+            "maxLength": 127,
+            "minLength": 1,
+            "pattern": "^.*$"
+          },
+          "status": {
+            "type": "string",
+            "description": "The initial state of the plan. Allowed input values are CREATED and ACTIVE.",
+            "minLength": 1,
+            "maxLength": 24,
+            "pattern": "^[A-Z_]+$",
+            "default": "ACTIVE",
+            "x-enumDescriptions": [
+              {
+                "value": "CREATED",
+                "description": "The plan was created. You cannot create subscriptions for a plan in this state."
+              },
+              {
+                "value": "INACTIVE",
+                "description": "The plan is inactive."
+              },
+              {
+                "value": "ACTIVE",
+                "description": "The plan is active. You can only create subscriptions for a plan in this state."
+              }
+            ],
+            "enum": [
+              "CREATED",
+              "INACTIVE",
+              "ACTIVE"
+            ]
+          },
+          "description": {
+            "type": "string",
+            "description": "The detailed description of the plan.",
+            "maxLength": 127,
+            "minLength": 1,
+            "pattern": "^.*$"
+          },
+          "billing_cycles": {
+            "$ref": "#/components/schemas/billing_cycle_list"
+          },
+          "payment_preferences": {
+            "$ref": "#/components/schemas/payment_preferences"
+          },
+          "taxes": {
+            "$ref": "#/components/schemas/taxes"
+          },
+          "quantity_supported": {
+            "type": "boolean",
+            "description": "Indicates whether you can subscribe to this plan by providing a quantity for the goods or service.",
+            "default": false
+          }
+        },
+        "required": [
+          "name",
+          "billing_cycles",
+          "payment_preferences",
+          "product_id"
+        ]
+      },
+      "plans.activate-422": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "USER_ACCOUNT_CLOSED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "USER_ACCOUNT_CLOSED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "User account locked or closed."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "PLAN_STATUS_INVALID",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "PLAN_STATUS_INVALID"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Invalid plan status for activate action; plan status should be either created or inactive."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "plans.create-400": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "INVALID_PARAMETER_SYNTAX",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PARAMETER_SYNTAX"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field does not conform to the expected format."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PARAMETER_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PARAMETER_VALUE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field is invalid."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_REQUIRED_PARAMETER",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "MISSING_REQUIRED_PARAMETER"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "A required field is missing."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_STRING_MIN_LENGTH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_STRING_MIN_LENGTH"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field is too short."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_STRING_MAX_LENGTH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_STRING_MAX_LENGTH"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field is too long."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_INTEGER_MIN_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_INTEGER_MIN_VALUE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The integer value of a field is too small."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_INTEGER_MAX_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_INTEGER_MAX_VALUE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The integer value of a field is too large."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "plans.deactivate-422": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "USER_ACCOUNT_CLOSED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "USER_ACCOUNT_CLOSED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "User account locked or closed."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "PLAN_STATUS_INVALID",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "PLAN_STATUS_INVALID"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Invalid plan status for deactivate action; plan status should be active."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "plans.patch-400": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "UNSUPPORTED_PATCH_OPERATION",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "UNSUPPORTED_PATCH_OPERATION"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The specified patch operation not supported for this field."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PATCH_PATH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PATCH_PATH"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The specified field cannot be patched."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PATCH_PATH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PATCH_PATH"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Multiple operations on the same field are not allowed."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PARAMETER_SYNTAX",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PARAMETER_SYNTAX"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field does not conform to the expected format."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PARAMETER_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PARAMETER_VALUE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field is invalid."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PARAMETER_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PARAMETER_VALUE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The field is not eligible for '$value' patch operation."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "plans.patch-422": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "USER_ACCOUNT_CLOSED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "USER_ACCOUNT_CLOSED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "User account locked or closed."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "PLAN_STATUS_INACTIVE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "PLAN_STATUS_INACTIVE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Status update is the only patchable filed on an inactive plan."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "plans.update-pricing-schemes-400": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "INVALID_PARAMETER_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PARAMETER_VALUE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field is invalid."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_REQUIRED_PARAMETER",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "MISSING_REQUIRED_PARAMETER"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "A required field is missing."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "plans.update-pricing-schemes-422": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "CURRENCY_MISMATCH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "CURRENCY_MISMATCH"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The currency code is different from the plan's currency code."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_BILLING_CYCLE_SEQUENCE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_BILLING_CYCLE_SEQUENCE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The provided billing cycle sequence is not available."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_SCHEME",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PRICING_SCHEME"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The new pricing scheme should be of the same type as that of the old one."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_TIER_AMOUNT",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PRICING_TIER_AMOUNT"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Free tiers are not supported."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_PRICING_SCHEME_TIERS",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "MISSING_PRICING_SCHEME_TIERS"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Tier(s) are missing for some quantities."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "OVERLAPPING_PRICING_SCHEME_TIERS",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "OVERLAPPING_PRICING_SCHEME_TIERS"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The specified quantity overlaps with multiple pricing tiers."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_MODEL",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PRICING_MODEL"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The specified pricing model is not supported for trial billing cycle."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "FIXED_PRICE_NOT_SUPPORTED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "FIXED_PRICE_NOT_SUPPORTED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Fixed price is not supported for tiered pricing schemes."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_TIER_QUANTITY",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PRICING_TIER_QUANTITY"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Tier starting quantity must be less than ending quantity."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "PRICING_SCHEME_UPDATE_NOT_ALLOWED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "PRICING_SCHEME_UPDATE_NOT_ALLOWED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Pricing scheme update is not allowed for the plan."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "pricing_scheme": {
+        "title": "Pricing Scheme",
+        "description": "The pricing scheme details.",
+        "type": "object",
+        "properties": {
+          "version": {
+            "type": "integer",
+            "description": "The version of the pricing scheme.",
+            "maximum": 999.0,
+            "minimum": 0.0,
+            "readOnly": true
+          },
+          "fixed_price": {
+            "description": "The fixed amount to charge for the subscription. The changes to fixed amount are applicable to both existing and future subscriptions. For existing subscriptions, payments within 10 days of price change are not affected.",
+            "$ref": "#/components/schemas/money"
+          },
+          "pricing_model": {
+            "type": "string",
+            "description": "The pricing model for tiered plan. The `tiers` parameter is required.",
+            "minLength": 1,
+            "maxLength": 24,
+            "pattern": "^[A-Z_]+$",
+            "x-enumDescriptions": [
+              {
+                "value": "VOLUME",
+                "description": "A volume pricing model."
+              },
+              {
+                "value": "TIERED",
+                "description": "A tiered pricing model."
+              }
+            ],
+            "enum": [
+              "VOLUME",
+              "TIERED"
+            ]
+          },
+          "tiers": {
+            "$ref": "#/components/schemas/pricing_tier_list"
+          },
+          "create_time": {
+            "description": "The date and time when this pricing scheme was created, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+            "readOnly": true,
+            "$ref": "#/components/schemas/date_time"
+          },
+          "update_time": {
+            "description": "The date and time when this pricing scheme was last updated, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+            "readOnly": true,
+            "$ref": "#/components/schemas/date_time"
+          }
+        }
+      },
+      "pricing_tier": {
+        "title": "Pricing Tier",
+        "type": "object",
+        "description": "The pricing tier details.",
+        "required": [
+          "starting_quantity",
+          "amount"
+        ],
+        "properties": {
+          "starting_quantity": {
+            "type": "string",
+            "description": "The starting quantity for the tier.",
+            "maxLength": 32,
+            "minLength": 1,
+            "pattern": "^([0-9]+|([0-9]+)?[.][0-9]+)$"
+          },
+          "ending_quantity": {
+            "type": "string",
+            "description": "The ending quantity for the tier. Optional for the last tier.",
+            "maxLength": 32,
+            "minLength": 1,
+            "pattern": "^([0-9]+|([0-9]+)?[.][0-9]+)$"
+          },
+          "amount": {
+            "description": "The pricing amount for the tier.",
+            "$ref": "#/components/schemas/money"
+          }
+        }
+      },
+      "pricing_tier_list": {
+        "type": "array",
+        "description": "An array of pricing tiers which are used for billing volume/tiered plans. pricing_model field has to be specified.",
+        "maxItems": 32,
+        "minItems": 1,
+        "items": {
+          "$ref": "#/components/schemas/pricing_tier"
+        }
+      },
+      "products": {
+        "type": "string",
+        "description": "This value provides the category of the BIN.",
+        "maxLength": 255,
+        "minLength": 1
+      },
+      "products_list": {
+        "type": "array",
+        "description": "The type of card product assigned to the BIN by the issuer. These values are defined by the issuer and may change over time. Some examples include: PREPAID_GIFT, CONSUMER, CORPORATE.",
+        "maxItems": 256,
+        "minItems": 1,
+        "items": {
+          "$ref": "#/components/schemas/products"
+        }
+      },
+      "shipping_detail": {
+        "type": "object",
+        "description": "The shipping details.",
+        "title": "Shipping Details",
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "object",
+            "description": "The name of the party.",
+            "properties": {
+              "full_name": {
+                "type": "string",
+                "description": "When the party is a person, the party's full name.",
+                "maxLength": 300
+              }
+            }
+          },
+          "options": {
+            "$ref": "#/components/schemas/shipping_option_list"
+          },
+          "address": {
+            "title": "Portable Postal Address (Medium-Grained)",
+            "type": "object",
+            "description": "The portable international postal address. Maps to [AddressValidationMetadata](https://github.com/googlei18n/libaddressinput/wiki/AddressValidationMetadata) and HTML 5.1 [Autofilling form controls: the autocomplete attribute](https://www.w3.org/TR/html51/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).",
+            "required": [
+              "country_code"
+            ],
+            "properties": {
+              "address_line_1": {
+                "type": "string",
+                "description": "The first line of the address, such as number and street, for example, `173 Drury Lane`. Needed for data entry, and Compliance and Risk checks. This field needs to pass the full address.",
+                "maxLength": 300
+              },
+              "address_line_2": {
+                "type": "string",
+                "description": "The second line of the address, for example, a suite or apartment number.",
+                "maxLength": 300
+              },
+              "admin_area_2": {
+                "type": "string",
+                "description": "A city, town, or village. Smaller than `admin_area_level_1`.",
+                "maxLength": 120
+              },
+              "admin_area_1": {
+                "type": "string",
+                "description": "The highest-level sub-division in a country, which is usually a province, state, or ISO-3166-2 subdivision. This data is formatted for postal delivery, for example, `CA` and not `California`. Value, by country, is:<ul><li>UK. A county.</li><li>US. A state.</li><li>Canada. A province.</li><li>Japan. A prefecture.</li><li>Switzerland. A *kanton*.</li></ul>",
+                "maxLength": 300
+              },
+              "postal_code": {
+                "type": "string",
+                "description": "The postal code, which is the ZIP code or equivalent. Typically required for countries with a postal code or an equivalent. See [postal code](https://en.wikipedia.org/wiki/Postal_code).",
+                "maxLength": 60
+              },
+              "country_code": {
+                "$ref": "#/components/schemas/country_code"
+              }
+            }
+          }
+        }
+      },
+      "shipping_option": {
+        "title": "Shipping Option",
+        "type": "object",
+        "description": "The options that the payee or merchant offers to the payer to ship or pick up their items.",
+        "required": [
+          "id",
+          "label",
+          "selected"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "A unique ID that identifies a payer-selected shipping option.",
+            "maxLength": 127
+          },
+          "label": {
+            "type": "string",
+            "description": "A description that the payer sees, which helps them choose an appropriate shipping option. For example, `Free Shipping`, `USPS Priority Shipping`, `Expédition prioritaire USPS`, or `USPS yōuxiān fā huò`. Localize this description to the payer's locale.",
+            "maxLength": 127
+          },
+          "type": {
+            "description": "A classification for the method of purchase fulfillment.",
+            "$ref": "#/components/schemas/shipping_type"
+          },
+          "amount": {
+            "description": "The shipping cost for the selected option.",
+            "$ref": "#/components/schemas/money"
+          },
+          "selected": {
+            "type": "boolean",
+            "description": "If the API request sets `selected = true`, it represents the shipping option that the payee or merchant expects to be pre-selected for the payer when they first view the `shipping.options` in the PayPal Checkout experience. As part of the response if a `shipping.option` contains `selected=true`, it represents the shipping option that the payer selected during the course of checkout with PayPal. Only one `shipping.option` can be set to `selected=true`."
+          }
+        }
+      },
+      "shipping_option_list": {
+        "type": "array",
+        "description": "An array of shipping options that the payee or merchant offers to the payer to ship or pick up their items.",
+        "maxItems": 10,
+        "items": {
+          "$ref": "#/components/schemas/shipping_option"
+        }
+      },
+      "shipping_type": {
+        "type": "string",
+        "title": "Shipping Type",
+        "description": "A classification for the method of purchase fulfillment.",
+        "x-enumDescriptions": [
+          {
+            "value": "SHIPPING",
+            "description": "The payer intends to receive the items at a specified address.",
+            "default": true
+          },
+          {
+            "value": "PICKUP",
+            "description": "DEPRECATED. To ensure that seller protection is correctly assigned, please use 'PICKUP_IN_STORE' or 'PICKUP_FROM_PERSON' instead. Currently, this field indicates that the payer intends to pick up the items at a specified address (ie. a store address). "
+          },
+          {
+            "value": "PICKUP_IN_STORE",
+            "description": "The payer intends to pick up the item(s) from the payee's physical store. Also termed as BOPIS, \"Buy Online, Pick-up in Store\". Seller protection is provided with this option."
+          },
+          {
+            "value": "PICKUP_FROM_PERSON",
+            "description": "The payer intends to pick up the item(s) from the payee in person. Also termed as BOPIP, \"Buy Online, Pick-up in Person\". Seller protection is not available, since the payer is receiving the item from the payee in person, and can validate the item prior to payment."
+          }
+        ],
+        "enum": [
+          "SHIPPING",
+          "PICKUP",
+          "PICKUP_IN_STORE",
+          "PICKUP_FROM_PERSON"
+        ]
+      },
+      "store_in_vault_instruction": {
+        "type": "string",
+        "description": "Defines how and when the payment source gets vaulted.",
+        "minLength": 1,
+        "maxLength": 255,
+        "pattern": "^[0-9A-Z_]+$",
+        "x-enumDescriptions": [
+          {
+            "value": "ON_SUCCESS",
+            "description": "Defines that the payment_source will be vaulted only when at least one authorization or capture using that payment_source is successful."
+          }
+        ],
+        "enum": [
+          "ON_SUCCESS"
+        ]
+      },
+      "subscriber": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/payer_base"
+          },
+          {
+            "properties": {
+              "name": {
+                "title": "Name",
+                "type": "object",
+                "description": "The name of the party.",
+                "properties": {
+                  "given_name": {
+                    "type": "string",
+                    "description": "When the party is a person, the party's given, or first, name.",
+                    "maxLength": 140
+                  },
+                  "surname": {
+                    "type": "string",
+                    "description": "When the party is a person, the party's surname or family name. Also known as the last name. Required when the party is a person. Use also to store multiple surnames including the matronymic, or mother's, surname.",
+                    "maxLength": 140
+                  }
+                }
+              },
+              "phone": {
+                "description": "The phone number of the customer. Available only when you enable the **Contact Telephone Number** option in the <a href=\"https://www.paypal.com/cgi-bin/customerprofileweb?cmd=_profile-website-payments\">**Profile & Settings**</a> for the merchant's PayPal account. The `phone.phone_number` supports only `national_number`.",
+                "$ref": "#/components/schemas/phone_with_type"
+              }
+            }
+          },
+          {
+            "title": "Payer",
+            "type": "object",
+            "description": "The customer who approves and pays for the order. The customer is also known as the payer.",
+            "format": "payer_v1"
+          },
+          {
+            "properties": {
+              "shipping_address": {
+                "$ref": "#/components/schemas/shipping_detail"
+              },
+              "payment_source": {
+                "$ref": "#/components/schemas/payment_source_response"
+              }
+            }
+          },
+          {
+            "title": "Subscriber Response Information",
+            "type": "object",
+            "description": "The subscriber response information."
+          }
+        ]
+      },
+      "subscriber_request": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/payer_base"
+          },
+          {
+            "properties": {
+              "name": {
+                "title": "Name",
+                "type": "object",
+                "description": "The name of the party.",
+                "properties": {
+                  "given_name": {
+                    "type": "string",
+                    "description": "When the party is a person, the party's given, or first, name.",
+                    "maxLength": 140
+                  },
+                  "surname": {
+                    "type": "string",
+                    "description": "When the party is a person, the party's surname or family name. Also known as the last name. Required when the party is a person. Use also to store multiple surnames including the matronymic, or mother's, surname.",
+                    "maxLength": 140
+                  }
+                }
+              },
+              "phone": {
+                "description": "The phone number of the customer. Available only when you enable the **Contact Telephone Number** option in the <a href=\"https://www.paypal.com/cgi-bin/customerprofileweb?cmd=_profile-website-payments\">**Profile & Settings**</a> for the merchant's PayPal account. The `phone.phone_number` supports only `national_number`.",
+                "$ref": "#/components/schemas/phone_with_type"
+              }
+            }
+          },
+          {
+            "title": "Payer",
+            "type": "object",
+            "description": "The customer who approves and pays for the order. The customer is also known as the payer.",
+            "format": "payer_v1"
+          },
+          {
+            "properties": {
+              "shipping_address": {
+                "$ref": "#/components/schemas/shipping_detail"
+              },
+              "payment_source": {
+                "$ref": "#/components/schemas/payment_source"
+              }
+            }
+          },
+          {
+            "title": "Subscriber Request Information",
+            "type": "object",
+            "description": "The subscriber request information ."
+          }
+        ]
+      },
+      "subscription": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/subscription_status"
+          },
+          {},
+          {
+            "properties": {
+              "id": {
+                "type": "string",
+                "readonly": true,
+                "description": "The PayPal-generated ID for the subscription.",
+                "maxLength": 50,
+                "minLength": 3
+              },
+              "plan_id": {
+                "type": "string",
+                "description": "The ID of the plan.",
+                "maxLength": 50,
+                "minLength": 3
+              },
+              "start_time": {
+                "$ref": "#/components/schemas/date_time"
+              },
+              "quantity": {
+                "type": "string",
+                "description": "The quantity of the product in the subscription.",
+                "maxLength": 32,
+                "minLength": 1,
+                "pattern": "^([0-9]+|([0-9]+)?[.][0-9]+)$"
+              },
+              "shipping_amount": {
+                "$ref": "#/components/schemas/money"
+              },
+              "subscriber": {
+                "$ref": "#/components/schemas/subscriber"
+              },
+              "billing_info": {
+                "readonly": true,
+                "$ref": "#/components/schemas/subscription_billing_info"
+              },
+              "create_time": {
+                "readonly": true,
+                "$ref": "#/components/schemas/date_time"
+              },
+              "update_time": {
+                "readonly": true,
+                "$ref": "#/components/schemas/date_time"
+              },
+              "custom_id": {
+                "type": "string",
+                "description": "The custom id for the subscription. Can be invoice id.",
+                "maxLength": 127,
+                "minLength": 1,
+                "pattern": "^[\\x20-\\x7E]+"
+              },
+              "plan_overridden": {
+                "type": "boolean",
+                "readonly": true,
+                "description": "Indicates whether the subscription has overridden any plan attributes."
+              },
+              "plan": {
+                "title": "Plan",
+                "type": "object",
+                "description": "The plan details.",
+                "properties": {
+                  "product_id": {
+                    "type": "string",
+                    "description": "The ID for the product.",
+                    "maxLength": 22,
+                    "minLength": 22,
+                    "pattern": "^PROD-[A-Z0-9]*$"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "The plan name.",
+                    "maxLength": 127,
+                    "minLength": 1,
+                    "pattern": "^.*$"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "The detailed description of the plan.",
+                    "maxLength": 127,
+                    "minLength": 1,
+                    "pattern": "^.*$"
+                  },
+                  "billing_cycles": {
+                    "$ref": "#/components/schemas/billing_cycle_list"
+                  },
+                  "payment_preferences": {
+                    "$ref": "#/components/schemas/payment_preferences"
+                  },
+                  "taxes": {
+                    "$ref": "#/components/schemas/taxes"
+                  },
+                  "quantity_supported": {
+                    "type": "boolean",
+                    "description": "Indicates whether you can subscribe to this plan by providing a quantity for the goods or service.",
+                    "default": false
+                  }
+                }
+              },
+              "links": {
+                "$ref": "#/components/schemas/link_description_list"
+              }
+            }
+          },
+          {
+            "title": "Subscription",
+            "type": "object",
+            "description": "The subscription details."
+          }
+        ]
+      },
+      "subscription_activate_request": {
+        "title": "Activate Subscription Request",
+        "type": "object",
+        "description": "The activate subscription request details.",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "description": "The reason for activation of a subscription. Required to reactivate the subscription.",
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^.*$"
+          }
+        }
+      },
+      "subscription_billing_info": {
+        "title": "Subscription Billing Information",
+        "type": "object",
+        "description": "The billing details for the subscription. If the subscription was or is active, these fields are populated.",
+        "required": [
+          "outstanding_balance",
+          "failed_payments_count"
+        ],
+        "properties": {
+          "outstanding_balance": {
+            "description": "The total pending bill amount, to be paid by the subscriber.",
+            "$ref": "#/components/schemas/money"
+          },
+          "cycle_executions": {
+            "$ref": "#/components/schemas/cycle_execution_list"
+          },
+          "last_payment": {
+            "readonly": true,
+            "description": "The details for the last payment of the subscription.",
+            "$ref": "#/components/schemas/last_payment_details"
+          },
+          "next_billing_time": {
+            "readonly": true,
+            "description": "The next date and time for billing this subscription, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+            "$ref": "#/components/schemas/date_time"
+          },
+          "final_payment_time": {
+            "readonly": true,
+            "description": "The date and time when the final billing cycle occurs, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+            "$ref": "#/components/schemas/date_time"
+          },
+          "failed_payments_count": {
+            "type": "integer",
+            "readonly": true,
+            "description": "The number of consecutive payment failures. Resets to `0` after a successful payment. If this reaches the `payment_failure_threshold` value, the subscription updates to the `SUSPENDED` state.",
+            "maximum": 999.0,
+            "minimum": 0.0
+          },
+          "last_failed_payment": {
+            "readonly": true,
+            "description": "The details for the last failed payment of the subscription.",
+            "$ref": "#/components/schemas/failed_payment_details"
+          }
+        }
+      },
+      "subscription_cancel_request": {
+        "title": "Cancel Subscription Request",
+        "type": "object",
+        "description": "The cancel subscription request details.",
+        "required": [
+          "reason"
+        ],
+        "properties": {
+          "reason": {
+            "type": "string",
+            "description": "The reason for the cancellation of a subscription.",
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^.*$"
+          }
+        }
+      },
+      "subscription_capture_request": {
+        "title": "Charge Amount from Subscriber",
+        "description": "The charge amount from the subscriber.",
+        "type": "object",
+        "properties": {
+          "note": {
+            "type": "string",
+            "description": "The reason or note for the subscription charge.",
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^.*$"
+          },
+          "capture_type": {
+            "type": "string",
+            "description": "The type of capture.",
+            "minLength": 1,
+            "maxLength": 24,
+            "pattern": "^[A-Z_]+$",
+            "x-enumDescriptions": [
+              {
+                "value": "OUTSTANDING_BALANCE",
+                "description": "The outstanding balance that the subscriber must clear."
+              }
+            ],
+            "enum": [
+              "OUTSTANDING_BALANCE"
+            ]
+          },
+          "amount": {
+            "$ref": "#/components/schemas/money",
+            "description": "The amount of the outstanding balance. This value cannot be greater than the current outstanding balance amount."
+          }
+        },
+        "required": [
+          "note",
+          "capture_type",
+          "amount"
+        ]
+      },
+      "subscription_request_post": {
+        "title": "Create Subscription Request",
+        "type": "object",
+        "description": "The create subscription request details.",
+        "required": [
+          "plan_id"
+        ],
+        "properties": {
+          "plan_id": {
+            "type": "string",
+            "description": "The ID of the plan.",
+            "maxLength": 26,
+            "minLength": 26,
+            "pattern": "^P-[A-Z0-9]*$"
+          },
+          "start_time": {
+            "description": "The date and time when the subscription started, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+            "default": "Current time",
+            "$ref": "#/components/schemas/date_time"
+          },
+          "quantity": {
+            "type": "string",
+            "description": "The quantity of the product in the subscription.",
+            "maxLength": 32,
+            "minLength": 1,
+            "pattern": "^([0-9]+|([0-9]+)?[.][0-9]+)$"
+          },
+          "shipping_amount": {
+            "description": "The shipping charges.",
+            "$ref": "#/components/schemas/money"
+          },
+          "subscriber": {
+            "$ref": "#/components/schemas/subscriber_request"
+          },
+          "auto_renewal": {
+            "type": "boolean",
+            "description": "DEPRECATED. Indicates whether the subscription auto-renews after the billing cycles complete.",
+            "default": false,
+            "deprecated": true
+          },
+          "application_context": {
+            "$ref": "#/components/schemas/application_context"
+          },
+          "custom_id": {
+            "type": "string",
+            "description": "The custom id for the subscription. Can be invoice id.",
+            "maxLength": 127,
+            "minLength": 1,
+            "pattern": "^[\\x20-\\x7E]+"
+          },
+          "plan": {
+            "description": "An inline plan object to customise the subscription. You can override plan level default attributes by providing customised values for the subscription in this object.",
+            "$ref": "#/components/schemas/plan_override"
+          },
+          "merchant_inventory": {
+            "description": "Merchant's inventory identifier details for the WPS hosted button.",
+            "$ref": "#/components/schemas/merchant_inventory"
+          }
+        }
+      },
+      "subscription_revise_request": {
+        "title": "Subscription Modify Plan Request",
+        "description": "The request to update the quantity of the product or service in a subscription. You can also use this method to switch the plan and update the `shipping_amount` and `shipping_address` values for the subscription. This type of update requires the buyer's consent.",
+        "type": "object",
+        "properties": {
+          "plan_id": {
+            "type": "string",
+            "description": "The unique PayPal-generated ID for the plan.",
+            "maxLength": 26,
+            "minLength": 26,
+            "pattern": "^P-[A-Z0-9]*$"
+          },
+          "quantity": {
+            "type": "string",
+            "description": "The quantity of the product or service in the subscription.",
+            "maxLength": 32,
+            "minLength": 1,
+            "pattern": "^([0-9]+|([0-9]+)?[.][0-9]+)$"
+          },
+          "shipping_amount": {
+            "description": "The shipping charges.",
+            "$ref": "#/components/schemas/money"
+          },
+          "shipping_address": {
+            "description": "The shipping address of the subscriber.",
+            "$ref": "#/components/schemas/shipping_detail"
+          },
+          "application_context": {
+            "title": "Application Context",
+            "description": "The application context, which customizes the payer experience during the subscription approval process with PayPal.",
+            "type": "object",
+            "properties": {
+              "brand_name": {
+                "type": "string",
+                "description": "The label that overrides the business name in the PayPal account on the PayPal site.",
+                "maxLength": 127,
+                "minLength": 1,
+                "pattern": "^.*$"
+              },
+              "locale": {
+                "description": "The BCP 47-formatted locale of pages that the PayPal payment experience shows. PayPal supports a five-character code. For example, `da-DK`, `he-IL`, `id-ID`, `ja-JP`, `no-NO`, `pt-BR`, `ru-RU`, `sv-SE`, `th-TH`, `zh-CN`, `zh-HK`, or `zh-TW`.",
+                "$ref": "#/components/schemas/language"
+              },
+              "shipping_preference": {
+                "type": "string",
+                "description": "The location from which the shipping address is derived.",
+                "minLength": 1,
+                "maxLength": 24,
+                "pattern": "^[A-Z_]+$",
+                "default": "GET_FROM_FILE",
+                "x-enumDescriptions": [
+                  {
+                    "value": "GET_FROM_FILE",
+                    "description": "Get the customer-provided shipping address on the PayPal site.",
+                    "default": true
+                  },
+                  {
+                    "value": "NO_SHIPPING",
+                    "description": "Redacts the shipping address from the PayPal site. Recommended for digital goods."
+                  },
+                  {
+                    "value": "SET_PROVIDED_ADDRESS",
+                    "description": "Get the merchant-provided address. The customer cannot change this address on the PayPal site. If merchant does not pass an address, customer can choose the address on PayPal pages."
+                  }
+                ],
+                "enum": [
+                  "GET_FROM_FILE",
+                  "NO_SHIPPING",
+                  "SET_PROVIDED_ADDRESS"
+                ]
+              },
+              "payment_method": {
+                "title": "Payment Method",
+                "type": "object",
+                "description": "The customer and merchant payment preferences.",
+                "properties": {
+                  "payee_preferred": {
+                    "$ref": "#/components/schemas/payee_payment_method_preference"
+                  }
+                }
+              },
+              "return_url": {
+                "type": "string",
+                "description": "The URL where the customer is redirected after the customer approves the payment.",
+                "format": "uri",
+                "maxLength": 4000,
+                "minLength": 10
+              },
+              "cancel_url": {
+                "type": "string",
+                "description": "The URL where the customer is redirected after the customer cancels the payment.",
+                "format": "uri",
+                "maxLength": 4000,
+                "minLength": 10
+              }
+            },
+            "required": [
+              "return_url",
+              "cancel_url"
+            ]
+          },
+          "plan": {
+            "description": "An inline plan object to customise the subscription. You can override plan level default attributes by providing customised values for the subscription in this object. Any existing overrides will not be carried forward during subscription revise.",
+            "$ref": "#/components/schemas/plan_override"
+          }
+        }
+      },
+      "subscription_revise_response": {
+        "title": "Update Product Quantity in Subscription Response",
+        "type": "object",
+        "description": "The response to a request to update the quantity of the product or service in a subscription. You can also use this method to switch the plan and update the `shipping_amount` and `shipping_address` values for the subscription. This type of update requires the buyer's consent.",
+        "properties": {
+          "plan_id": {
+            "type": "string",
+            "description": "The unique PayPal-generated ID for the plan.",
+            "maxLength": 26,
+            "minLength": 26,
+            "pattern": "^P-[A-Z0-9]*$"
+          },
+          "quantity": {
+            "type": "string",
+            "description": "The quantity of the product or service in the subscription.",
+            "maxLength": 32,
+            "minLength": 1,
+            "pattern": "^([0-9]+|([0-9]+)?[.][0-9]+)$"
+          },
+          "shipping_amount": {
+            "description": "The shipping charges.",
+            "$ref": "#/components/schemas/money"
+          },
+          "shipping_address": {
+            "description": "The shipping address of the subscriber.",
+            "$ref": "#/components/schemas/shipping_detail"
+          },
+          "plan": {
+            "description": "An inline plan object to customise the subscription. You can override plan level default attributes by providing customised values for the subscription in this object. Any existing overrides will not be carried forward during subscription revise.",
+            "$ref": "#/components/schemas/plan_override"
+          },
+          "plan_overridden": {
+            "type": "boolean",
+            "readonly": true,
+            "description": "Indicates whether the subscription has overridden any plan attributes."
+          },
+          "links": {
+            "$ref": "#/components/schemas/subscription_revise_response_definitions-link_description_list"
+          }
+        }
+      },
+      "subscription_revise_response_definitions-link_description_list": {
+        "type": "array",
+        "description": "An array of request-related [HATEOAS links](/docs/api/reference/api-responses/#hateoas-links).",
+        "items": {
+          "$ref": "#/components/schemas/link_description"
+        },
+        "readOnly": true
+      },
+      "subscription_status": {
+        "title": "Subscription Status",
+        "description": "The subscription status details.",
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "The status of the subscription.",
+            "minLength": 1,
+            "maxLength": 24,
+            "pattern": "^[A-Z_]+$",
+            "x-enumDescriptions": [
+              {
+                "value": "APPROVAL_PENDING",
+                "description": "The subscription is created but not yet approved by the buyer."
+              },
+              {
+                "value": "APPROVED",
+                "description": "The buyer has approved the subscription."
+              },
+              {
+                "value": "ACTIVE",
+                "description": "The subscription is active."
+              },
+              {
+                "value": "SUSPENDED",
+                "description": "The subscription is suspended."
+              },
+              {
+                "value": "CANCELLED",
+                "description": "The subscription is cancelled."
+              },
+              {
+                "value": "EXPIRED",
+                "description": "The subscription is expired."
+              }
+            ],
+            "enum": [
+              "APPROVAL_PENDING",
+              "APPROVED",
+              "ACTIVE",
+              "SUSPENDED",
+              "CANCELLED",
+              "EXPIRED"
+            ]
+          },
+          "status_change_note": {
+            "type": "string",
+            "description": "The reason or notes for the status of the subscription.",
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^.*$"
+          },
+          "status_update_time": {
+            "readOnly": true,
+            "$ref": "#/components/schemas/date_time"
+          }
+        }
+      },
+      "subscription_suspend_request": {
+        "title": "Suspend Subscription",
+        "type": "object",
+        "description": "The suspend subscription request details.",
+        "required": [
+          "reason"
+        ],
+        "properties": {
+          "reason": {
+            "type": "string",
+            "description": "The reason for suspension of the Subscription.",
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^.*$"
+          }
+        }
+      },
+      "subscriptions.activate-400": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "INVALID_STRING_MAX_LENGTH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_STRING_MAX_LENGTH"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field is too long."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.activate-422": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "USER_ACCOUNT_CLOSED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "USER_ACCOUNT_CLOSED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "User account locked or closed."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "SUBSCRIPTION_STATUS_INVALID",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "SUBSCRIPTION_STATUS_INVALID"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Invalid subscription status for activate action; subscription status should be suspended."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "SUBSCRIPTION_CANNOT_BE_ACTIVATED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "SUBSCRIPTION_CANNOT_BE_ACTIVATED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Subscription cannot be activated after payment failure threshold has reached."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "SUBSCRIPTION_CANNOT_BE_ACTIVATED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "SUBSCRIPTION_CANNOT_BE_ACTIVATED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "This subscription should be activated by the system."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "SUBSCRIPTION_CANNOT_BE_ACTIVATED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "SUBSCRIPTION_CANNOT_BE_ACTIVATED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "This subscription should be activated by the merchant."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.cancel-400": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "INVALID_STRING_MAX_LENGTH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_STRING_MAX_LENGTH"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field is too long."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.cancel-422": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "USER_ACCOUNT_CLOSED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "USER_ACCOUNT_CLOSED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "User account locked or closed."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "SUBSCRIPTION_STATUS_INVALID",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "SUBSCRIPTION_STATUS_INVALID"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Invalid subscription status for cancel action; subscription status should be active or suspended."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.capture-400": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "MISSING_REQUEST_BODY",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "MISSING_REQUEST_BODY"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Request body is missing."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PARAMETER_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PARAMETER_VALUE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field is invalid."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_STRING_MAX_LENGTH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_STRING_MAX_LENGTH"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field is too long."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_REQUIRED_PARAMETER",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "MISSING_REQUIRED_PARAMETER"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "A required field is missing."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.capture-422": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "USER_ACCOUNT_CLOSED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "USER_ACCOUNT_CLOSED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "User account locked or closed."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "SUBSCRIBER_ACCOUNT_LOCKED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "SUBSCRIBER_ACCOUNT_LOCKED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Subscriber Account Locked."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "SUBSCRIBER_ACCOUNT_CLOSED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "SUBSCRIBER_ACCOUNT_CLOSED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Subscriber Account Closed."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "SUBSCRIBER_ACCOUNT_RESTRICTED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "SUBSCRIBER_ACCOUNT_RESTRICTED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Subscriber Account Restricted."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "SUBSCRIPTION_STATUS_INVALID",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "SUBSCRIPTION_STATUS_INVALID"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Invalid subscription status for capture action; subscription status should be active or suspended or expired."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "ZERO_OUTSTANDING_BALANCE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "ZERO_OUTSTANDING_BALANCE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Current outstanding balance should be greater than zero."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "CURRENCY_MISMATCH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "CURRENCY_MISMATCH"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The currency code is different from the subscription's currency code."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "AMOUNT_GREATER_THAN_OUTSTANDING_BALANCE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "AMOUNT_GREATER_THAN_OUTSTANDING_BALANCE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The capture amount can not be greater than the current outstanding balance."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.create-400": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "INVALID_PARAMETER_SYNTAX",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PARAMETER_SYNTAX"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field does not conform to the expected format."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_STRING_MAX_LENGTH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_STRING_MAX_LENGTH"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field is too long."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PARAMETER_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PARAMETER_VALUE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field is invalid."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_INTEGER_MIN_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_INTEGER_MIN_VALUE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The integer value of a field is too small."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_INTEGER_MAX_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_INTEGER_MAX_VALUE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The integer value of a field is too large."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PARAMETER_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PARAMETER_VALUE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Start time must be a valid future date and time."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_REQUEST_BODY",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "MISSING_REQUEST_BODY"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Request body is missing."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_REQUIRED_PARAMETER",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "MISSING_REQUIRED_PARAMETER"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "A required field is missing."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_STRING_MAX_LENGTH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_STRING_MAX_LENGTH"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field is too long."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.create-422": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "USER_ACCOUNT_CLOSED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "USER_ACCOUNT_CLOSED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "User account locked or closed."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "PLAN_STATUS_INVALID",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "PLAN_STATUS_INVALID"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Invalid plan status for subscription creation; plan status should be active."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "SUBSCRIPTION_CANNOT_HAVE_QUANTITY",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "SUBSCRIPTION_CANNOT_HAVE_QUANTITY"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Subscription can't have quantity as the plan does not support quantity."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "CARD_SUBSCRIPTIONS_NOT_ENABLED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "CARD_SUBSCRIPTIONS_NOT_ENABLED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The account is not setup to be able to process subscriptions funded by card payments. Please contact PayPal customer support."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "3DS_CARDS_NOT_SUPPORTED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "3DS_CARDS_NOT_SUPPORTED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Cards that require 3DS authentication not supported."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_BILLING_CYCLE_SEQUENCE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_BILLING_CYCLE_SEQUENCE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The provided billing cycle sequence is not available."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_SCHEME",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PRICING_SCHEME"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The override plan pricing scheme should be of the same type as that of the original plan."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_TIER_AMOUNT",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PRICING_TIER_AMOUNT"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Free tiers are not supported."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_PRICING_SCHEME_TIERS",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "MISSING_PRICING_SCHEME_TIERS"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Tier(s) are missing for some quantities."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "OVERLAPPING_PRICING_SCHEME_TIERS",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "OVERLAPPING_PRICING_SCHEME_TIERS"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The specified quantity overlaps with multiple pricing tiers."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_MODEL",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PRICING_MODEL"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The specified pricing model is not supported for trial billing cycle."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "FIXED_PRICE_NOT_SUPPORTED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "FIXED_PRICE_NOT_SUPPORTED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Fixed price is not supported for tiered pricing schemes."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_TIER_QUANTITY",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PRICING_TIER_QUANTITY"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Tier starting quantity must be less than ending quantity."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "CURRENCY_MISMATCH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "CURRENCY_MISMATCH"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The currency code is different from the plan's currency code."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.patch-400": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "UNSUPPORTED_PATCH_OPERATION",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "UNSUPPORTED_PATCH_OPERATION"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The specified patch operation not supported for this field."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PATCH_PATH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PATCH_PATH"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The specified field cannot be patched."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PATCH_PATH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PATCH_PATH"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Multiple operations on the same field are not allowed."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PARAMETER_SYNTAX",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PARAMETER_SYNTAX"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field does not conform to the expected format."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PARAMETER_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PARAMETER_VALUE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field is invalid."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_STRING_MAX_LENGTH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_STRING_MAX_LENGTH"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field is too long."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_STRING_MIN_LENGTH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_STRING_MIN_LENGTH"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field is too short."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_INTEGER_MIN_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_INTEGER_MIN_VALUE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The integer value of a field is too small."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_INTEGER_MAX_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_INTEGER_MAX_VALUE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The integer value of a field is too large."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_REQUEST_BODY",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "MISSING_REQUEST_BODY"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Request body is missing."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_REQUIRED_PARAMETER",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "MISSING_REQUIRED_PARAMETER"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "A required field is missing."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.patch-422": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "USER_ACCOUNT_CLOSED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "USER_ACCOUNT_CLOSED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "User account locked or closed."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "SUBSCRIPTION_STATUS_INVALID",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "SUBSCRIPTION_STATUS_INVALID"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Invalid subscription status for patch action; subscription status should be either active or suspended."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "CARD_SUBSCRIPTIONS_NOT_ENABLED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "CARD_SUBSCRIPTIONS_NOT_ENABLED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The account is not setup to be able to process subscriptions funded by card payments. Please contact PayPal customer support."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "3DS_CARDS_NOT_SUPPORTED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "3DS_CARDS_NOT_SUPPORTED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Cards that require 3DS authentication not supported."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "BILLING_CYCLE_EXECUTION_COMPLETED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "BILLING_CYCLE_EXECUTION_COMPLETED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Update cannot be performed on a billing cycle that has completed execution."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "AMOUNT_GREATER_THAN_OUTSTANDING_BALANCE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "AMOUNT_GREATER_THAN_OUTSTANDING_BALANCE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The new outstanding balance cannot be greater than the current outstanding balance."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_BILLING_TOTAL_CYCLES",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_BILLING_TOTAL_CYCLES"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The total cycles cannot be less than the number of billing cycles completed."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_TIER_AMOUNT",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PRICING_TIER_AMOUNT"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Free tiers are not supported."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_PRICING_SCHEME_TIERS",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "MISSING_PRICING_SCHEME_TIERS"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Tier(s) are missing for some quantities."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "OVERLAPPING_PRICING_SCHEME_TIERS",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "OVERLAPPING_PRICING_SCHEME_TIERS"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The specified quantity overlaps with multiple pricing tiers."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_MODEL",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PRICING_MODEL"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The specified pricing model is not supported for trial billing cycle."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "FIXED_PRICE_NOT_SUPPORTED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "FIXED_PRICE_NOT_SUPPORTED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Fixed price is not supported for tiered pricing schemes."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_TIER_QUANTITY",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PRICING_TIER_QUANTITY"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Tier starting quantity must be less than ending quantity."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_START_TIME",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_START_TIME"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The start time cannot be updated for a subscription that has been activated."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "CURRENCY_MISMATCH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "CURRENCY_MISMATCH"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The currency code is different from the subscription's currency code."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.revise-400": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "INVALID_PARAMETER_SYNTAX",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PARAMETER_SYNTAX"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field does not conform to the expected format."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PARAMETER_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PARAMETER_VALUE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field is invalid."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_INTEGER_MIN_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_INTEGER_MIN_VALUE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The integer value of a field is too small."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_INTEGER_MAX_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_INTEGER_MAX_VALUE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The integer value of a field is too large."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_REQUEST_BODY",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "MISSING_REQUEST_BODY"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Request body is missing."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_REQUIRED_PARAMETER",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "MISSING_REQUIRED_PARAMETER"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "A required field is missing."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.revise-404": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "INVALID_RESOURCE_ID",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_RESOURCE_ID"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Requested resource ID was not found."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.revise-422": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "USER_ACCOUNT_CLOSED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "USER_ACCOUNT_CLOSED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "User account locked or closed."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "PLAN_PRODUCT_NOT_COMPATIBLE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "PLAN_PRODUCT_NOT_COMPATIBLE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The old and the new plans should be for the same product."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_BILLING_CYCLE_SEQUENCE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_BILLING_CYCLE_SEQUENCE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The provided billing cycle sequence is not available."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_SCHEME",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PRICING_SCHEME"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The override plan pricing scheme should be of the same type as that of the original plan."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_TIER_AMOUNT",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PRICING_TIER_AMOUNT"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Free tiers are not supported."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_PRICING_SCHEME_TIERS",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "MISSING_PRICING_SCHEME_TIERS"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Tier(s) are missing for some quantities."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "OVERLAPPING_PRICING_SCHEME_TIERS",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "OVERLAPPING_PRICING_SCHEME_TIERS"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The specified quantity overlaps with multiple pricing tiers."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_MODEL",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PRICING_MODEL"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The specified pricing model is not supported for trial billing cycle."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "FIXED_PRICE_NOT_SUPPORTED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "FIXED_PRICE_NOT_SUPPORTED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Fixed price is not supported for tiered pricing schemes."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_TIER_QUANTITY",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PRICING_TIER_QUANTITY"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Tier starting quantity must be less than ending quantity."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "CURRENCY_MISMATCH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "CURRENCY_MISMATCH"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The currency code is different from the plan's currency code."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.suspend-400": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "INVALID_STRING_MAX_LENGTH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_STRING_MAX_LENGTH"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field is too long."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.suspend-422": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "USER_ACCOUNT_CLOSED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "USER_ACCOUNT_CLOSED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "User account locked or closed."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "SUBSCRIPTION_STATUS_INVALID",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "SUBSCRIPTION_STATUS_INVALID"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Invalid subscription status for suspend action; subscription status should be active."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.transactions-400": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "INVALID_PARAMETER_SYNTAX",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PARAMETER_SYNTAX"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field does not conform to the expected format."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PARAMETER_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "INVALID_PARAMETER_VALUE"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field is invalid."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_REQUIRED_PARAMETER",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "MISSING_REQUIRED_PARAMETER"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "A required field is missing."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "taxes": {
+        "title": "Taxes",
+        "type": "object",
+        "description": "The tax details.",
+        "required": [
+          "percentage"
+        ],
+        "properties": {
+          "percentage": {
+            "description": "The tax percentage on the billing amount.",
+            "$ref": "#/components/schemas/percentage"
+          },
+          "inclusive": {
+            "type": "boolean",
+            "description": "Indicates whether the tax was already included in the billing amount.",
+            "default": true
+          }
+        }
+      },
+      "taxes_override": {
+        "title": "Taxes Override",
+        "type": "object",
+        "description": "The tax details.",
+        "properties": {
+          "percentage": {
+            "description": "The tax percentage on the billing amount.",
+            "$ref": "#/components/schemas/percentage"
+          },
+          "inclusive": {
+            "type": "boolean",
+            "description": "Indicates whether the tax was already included in the billing amount."
+          }
+        }
+      },
+      "three_d_secure_authentication_response": {
+        "title": "3D Secure Authentication Response",
+        "type": "object",
+        "description": "Results of 3D Secure Authentication.",
+        "properties": {
+          "authentication_status": {
+            "description": "The outcome of the issuer's authentication.",
+            "$ref": "#/components/schemas/pares_status"
+          },
+          "enrollment_status": {
+            "description": "Status of authentication eligibility.",
+            "$ref": "#/components/schemas/enrolled"
+          }
+        }
+      },
+      "transaction": {
+        "type": "object",
+        "title": "Transaction Details",
+        "description": "The transaction details.",
+        "properties": {
+          "status": {
+            "title": "Capture Status",
+            "description": "The status of the captured payment.",
+            "type": "string",
+            "x-enumDescriptions": [
+              {
+                "value": "COMPLETED",
+                "description": "The funds for this captured payment were credited to the payee's PayPal account."
+              },
+              {
+                "value": "DECLINED",
+                "description": "The funds could not be captured."
+              },
+              {
+                "value": "PARTIALLY_REFUNDED",
+                "description": "An amount less than this captured payment's amount was partially refunded to the payer."
+              },
+              {
+                "value": "PENDING",
+                "description": "The funds for this captured payment was not yet credited to the payee's PayPal account. For more information, see <code>status.details</code>."
+              },
+              {
+                "value": "REFUNDED",
+                "description": "An amount greater than or equal to this captured payment's amount was refunded to the payer."
+              },
+              {
+                "value": "FAILED",
+                "description": "There was an error while capturing payment."
+              }
+            ],
+            "readOnly": true,
+            "enum": [
+              "COMPLETED",
+              "DECLINED",
+              "PARTIALLY_REFUNDED",
+              "PENDING",
+              "REFUNDED",
+              "FAILED"
+            ]
+          },
+          "id": {
+            "type": "string",
+            "description": "The PayPal-generated transaction ID.",
+            "maxLength": 50,
+            "minLength": 3,
+            "readOnly": true
+          },
+          "amount_with_breakdown": {
+            "$ref": "#/components/schemas/amount_with_breakdown"
+          },
+          "payer_name": {
+            "description": "The name of the customer.",
+            "readOnly": true,
+            "$ref": "#/components/schemas/name"
+          },
+          "payer_email": {
+            "description": "The email ID of the customer.",
+            "readOnly": true,
+            "$ref": "#/components/schemas/email_address"
+          },
+          "time": {
+            "description": "The date and time when the transaction was processed, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+            "readOnly": true,
+            "$ref": "#/components/schemas/date_time"
+          }
+        },
+        "required": [
+          "id",
+          "amount_with_breakdown",
+          "time"
+        ]
+      },
+      "transaction_list": {
+        "type": "array",
+        "description": "An array of transactions.",
+        "maxItems": 32767,
+        "items": {
+          "$ref": "#/components/schemas/transaction"
+        }
+      },
+      "transactions_list": {
+        "title": "List Transactions",
+        "type": "object",
+        "description": "The list transactions for a subscription request details.",
+        "properties": {
+          "transactions": {
+            "$ref": "#/components/schemas/transaction_list"
+          },
+          "total_items": {
+            "type": "integer",
+            "description": "The total number of items.",
+            "maximum": 500000000.0,
+            "minimum": 0.0
+          },
+          "total_pages": {
+            "type": "integer",
+            "description": "The total number of pages.",
+            "maximum": 100000000.0,
+            "minimum": 0.0
+          },
+          "links": {
+            "$ref": "#/components/schemas/link_description_list"
+          }
+        }
+      },
+      "update_pricing_scheme_request": {
+        "title": "Update Pricing Scheme",
+        "type": "object",
+        "description": "The update pricing scheme request details.",
+        "required": [
+          "billing_cycle_sequence",
+          "pricing_scheme"
+        ],
+        "properties": {
+          "billing_cycle_sequence": {
+            "type": "integer",
+            "description": "The billing cycle sequence.",
+            "maximum": 99.0,
+            "minimum": 1.0
+          },
+          "pricing_scheme": {
+            "$ref": "#/components/schemas/pricing_scheme"
+          }
+        }
+      },
+      "update_pricing_scheme_request_list": {
+        "type": "array",
+        "description": "An array of pricing schemes.",
+        "maxItems": 99,
+        "minItems": 1,
+        "items": {
+          "$ref": "#/components/schemas/update_pricing_scheme_request"
+        }
+      },
+      "update_pricing_schemes_list_request": {
+        "title": "Update Pricing Scheme Request",
+        "type": "object",
+        "description": "The update pricing scheme request details.",
+        "required": [
+          "pricing_schemes"
+        ],
+        "properties": {
+          "pricing_schemes": {
+            "$ref": "#/components/schemas/update_pricing_scheme_request_list"
+          }
+        }
+      },
+      "vault_instruction_base": {
+        "title": "Vault Instruction Base",
+        "type": "object",
+        "description": "Basic vault instruction specification that can be extended by specific payment sources that supports vaulting.",
+        "properties": {
+          "store_in_vault": {
+            "$ref": "#/components/schemas/store_in_vault_instruction"
+          }
+        }
+      },
+      "vault_response": {
+        "type": "object",
+        "title": "Vault Response",
+        "description": "The details about a saved payment source.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The PayPal-generated ID for the saved payment source.",
+            "maxLength": 255,
+            "minLength": 1
+          },
+          "status": {
+            "title": "Vault Status",
+            "type": "string",
+            "description": "The vault status.",
+            "minLength": 1,
+            "maxLength": 255,
+            "pattern": "^[0-9A-Z_]+$",
+            "x-enumDescriptions": [
+              {
+                "value": "VAULTED",
+                "description": "The payment source has been saved in your customer's vault. This vault status reflects `/v3/vault` status."
+              },
+              {
+                "value": "CREATED",
+                "description": "DEPRECATED. The payment source has been saved in your customer's vault. This status applies to deprecated integration patterns and will not be returned for v3/vault integrations."
+              },
+              {
+                "value": "APPROVED",
+                "description": "Customer has approved the action of saving the specified payment_source into their vault. Use v3/vault/payment-tokens with given setup_token to save the payment source in the vault"
+              }
+            ],
+            "deprecated": true,
+            "enum": [
+              "VAULTED",
+              "CREATED",
+              "APPROVED"
+            ]
+          },
+          "customer": {
+            "title": "Customer Information",
+            "type": "object",
+            "description": "The details about a customer in PayPal's system of record.",
+            "properties": {
+              "id": {
+                "$ref": "#/components/schemas/merchant_partner_customer_id"
+              }
+            }
+          },
+          "links": {
+            "$ref": "#/components/schemas/definitions-link_description_list"
+          }
+        }
+      }
+    },
+    "parameters": {
+      "prefer": {
+        "name": "Prefer",
+        "in": "header",
+        "description": "The preferred server response upon successful completion of the request. Value is:<ul><li><code>return=minimal</code>. The server returns a minimal response to optimize communication between the API caller and the server. A minimal response includes the <code>id</code>, <code>status</code> and HATEOAS links.</li><li><code>return=representation</code>. The server returns a complete resource representation, including the current state of the resource.</li></ul>",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "default": "return=minimal"
+        }
+      },
+      "paypal_request_id": {
+        "name": "PayPal-Request-Id",
+        "in": "header",
+        "description": "The server stores keys for 72 hours.",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "product_id": {
+        "name": "product_id",
+        "in": "query",
+        "description": "Filters the response by a Product ID.",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "maxLength": 50,
+          "minLength": 6
+        }
+      },
+      "page_size": {
+        "name": "page_size",
+        "in": "query",
+        "description": "The number of items to return in the response.",
+        "schema": {
+          "type": "integer",
+          "default": 10,
+          "maximum": 20.0,
+          "minimum": 1.0
+        }
+      },
+      "page": {
+        "name": "page",
+        "in": "query",
+        "description": "A non-zero integer which is the start index of the entire list of items to return in the response. The combination of `page=1` and `page_size=20` returns the first 20 items. The combination of `page=2` and `page_size=20` returns the next 20 items.",
+        "schema": {
+          "type": "integer",
+          "default": 1,
+          "maximum": 100000.0,
+          "minimum": 1.0
+        }
+      },
+      "total_required": {
+        "name": "total_required",
+        "in": "query",
+        "description": "Indicates whether to show the total count in the response.",
+        "schema": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "id": {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "The ID of the subscription.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "fields": {
+        "name": "fields",
+        "in": "query",
+        "description": "List of fields that are to be returned in the response. Possible value for fields are last_failed_payment and plan.",
+        "schema": {
+          "type": "string",
+          "maxLength": 100,
+          "minLength": 1
+        }
+      },
+      "start_time": {
+        "name": "start_time",
+        "in": "query",
+        "required": true,
+        "description": "The start time of the range of transactions to list.",
+        "schema": {
+          "type": "string",
+          "maxLength": 64,
+          "minLength": 20,
+          "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])[T,t]([0-1][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)([.][0-9]+)?([Zz]|[+-][0-9]{2}:[0-9]{2})$"
+        }
+      },
+      "end_time": {
+        "name": "end_time",
+        "in": "query",
+        "required": true,
+        "description": "The end time of the range of transactions to list.",
+        "schema": {
+          "type": "string",
+          "maxLength": 64,
+          "minLength": 20,
+          "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])[T,t]([0-1][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)([.][0-9]+)?([Zz]|[+-][0-9]{2}:[0-9]{2})$"
+        }
+      }
+    }
+  }
+}

--- a/src/NJsonSchema.Tests/Deserialization/TestData/paypal_billing_subscriptions_v1.json
+++ b/src/NJsonSchema.Tests/Deserialization/TestData/paypal_billing_subscriptions_v1.json
@@ -1,0 +1,8199 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Subscriptions",
+    "description": "You can use billing plans and subscriptions to create subscriptions that process recurring PayPal payments for physical or digital goods, or services. A plan includes pricing and billing cycle information that defines the amount and frequency of charge for a subscription. You can also define a fixed plan, such as a $5 basic plan or a volume- or graduated-based plan with pricing tiers based on the quantity purchased. For more information, see <a href=\"/docs/subscriptions/\">Subscriptions Overview</a>.",
+    "version": "1.8",
+    "contact": {}
+  },
+  "servers": [
+    {
+      "url": "https://api-m.sandbox.paypal.com",
+      "description": "PayPal Sandbox Environment"
+    },
+    {
+      "url": "https://api-m.paypal.com",
+      "description": "PayPal Live Environment"
+    }
+  ],
+  "tags": [
+    {
+      "name": "plans",
+      "description": "Use the `/billing/plans` resource to create and manage plans."
+    },
+    {
+      "name": "subscriptions",
+      "description": "Use the `/billing/subscriptions` resource to create and manage subscriptions."
+    },
+    {
+      "name": "subscriptions-buyer-consent",
+      "description": "Use the `/billing/subscriptions/approval-tokens` resource for subscriptions buyer consent flow."
+    }
+  ],
+  "externalDocs": {
+    "url": "https://developer.paypal.com/docs/api/subscriptions/v1/"
+  },
+  "paths": {
+    "/v1/billing/plans": {
+      "post": {
+        "summary": "Create plan",
+        "description": "Creates a plan that defines pricing and billing cycle details for subscriptions.",
+        "operationId": "plans.create",
+        "responses": {
+          "200": {
+            "description": "A successful request returns the HTTP `200 OK` status code and a JSON response body that shows billing plan details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/plan"
+                },
+                "examples": {
+                  "plan": {
+                    "value": {
+                      "id": "P-5ML4271244454362WXNWU5NQ",
+                      "product_id": "PROD-XXCD1234QWER65782",
+                      "name": "Video Streaming Service Plan",
+                      "description": "Video Streaming Service basic plan",
+                      "status": "ACTIVE",
+                      "billing_cycles": [
+                        {
+                          "frequency": {
+                            "interval_unit": "MONTH",
+                            "interval_count": 1
+                          },
+                          "tenure_type": "TRIAL",
+                          "sequence": 1,
+                          "total_cycles": 2,
+                          "pricing_scheme": {
+                            "fixed_price": {
+                              "value": "3",
+                              "currency_code": "USD"
+                            },
+                            "version": 1,
+                            "create_time": "2020-05-27T12:13:51Z",
+                            "update_time": "2020-05-27T12:13:51Z"
+                          }
+                        },
+                        {
+                          "frequency": {
+                            "interval_unit": "MONTH",
+                            "interval_count": 1
+                          },
+                          "tenure_type": "TRIAL",
+                          "sequence": 2,
+                          "total_cycles": 3,
+                          "pricing_scheme": {
+                            "fixed_price": {
+                              "currency_code": "USD",
+                              "value": "6"
+                            },
+                            "version": 1,
+                            "create_time": "2020-05-27T12:13:51Z",
+                            "update_time": "2020-05-27T12:13:51Z"
+                          }
+                        },
+                        {
+                          "frequency": {
+                            "interval_unit": "MONTH",
+                            "interval_count": 1
+                          },
+                          "tenure_type": "REGULAR",
+                          "sequence": 3,
+                          "total_cycles": 12,
+                          "pricing_scheme": {
+                            "fixed_price": {
+                              "currency_code": "USD",
+                              "value": "10"
+                            },
+                            "version": 1,
+                            "create_time": "2020-05-27T12:13:51Z",
+                            "update_time": "2020-05-27T12:13:51Z"
+                          }
+                        }
+                      ],
+                      "payment_preferences": {
+                        "auto_bill_outstanding": true,
+                        "setup_fee": {
+                          "value": "10",
+                          "currency_code": "USD"
+                        },
+                        "setup_fee_failure_action": "CONTINUE",
+                        "payment_failure_threshold": 3
+                      },
+                      "taxes": {
+                        "percentage": "10",
+                        "inclusive": false
+                      },
+                      "create_time": "2020-05-27T12:13:51Z",
+                      "update_time": "2020-05-27T12:13:51Z",
+                      "links": [
+                        {
+                          "href": "https://api-m.paypal.com/v1/billing/plans/P-5ML4271244454362WXNWU5NQ",
+                          "rel": "self",
+                          "method": "GET"
+                        },
+                        {
+                          "href": "https://api-m.paypal.com/v1/billing/plans/P-5ML4271244454362WXNWU5NQ",
+                          "rel": "edit",
+                          "method": "PATCH"
+                        },
+                        {
+                          "href": "https://api-m.paypal.com/v1/billing/plans/P-5ML4271244454362WXNWU5NQ/deactivate",
+                          "rel": "deactivate",
+                          "method": "POST"
+                        },
+                        {
+                          "href": "https://api-m.paypal.com/v1/billing/plans/P-5ML4271244454362WXNWU5NQ/update-pricing-schemes",
+                          "rel": "edit",
+                          "method": "POST"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "A successful request returns the HTTP `201 Created` status code and a JSON response body that shows billing plan details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/plan"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request. Request is not well-formed, syntactically incorrect, or violates schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_400"
+                    },
+                    {
+                      "$ref": "#/components/schemas/plans.create-400"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The requested action could not be performed, semantically incorrect, or failed business validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_422"
+                    },
+                    {
+                      "$ref": "#/components/schemas/422"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/prefer"
+          },
+          {
+            "$ref": "#/components/parameters/paypal_request_id"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/plan_request_POST"
+              },
+              "examples": {
+                "plan_request_post": {
+                  "value": {
+                    "product_id": "PROD-XXCD1234QWER65782",
+                    "name": "Video Streaming Service Plan",
+                    "description": "Video Streaming Service basic plan",
+                    "status": "ACTIVE",
+                    "billing_cycles": [
+                      {
+                        "frequency": {
+                          "interval_unit": "MONTH",
+                          "interval_count": 1
+                        },
+                        "tenure_type": "TRIAL",
+                        "sequence": 1,
+                        "total_cycles": 2,
+                        "pricing_scheme": {
+                          "fixed_price": {
+                            "value": "3",
+                            "currency_code": "USD"
+                          }
+                        }
+                      },
+                      {
+                        "frequency": {
+                          "interval_unit": "MONTH",
+                          "interval_count": 1
+                        },
+                        "tenure_type": "TRIAL",
+                        "sequence": 2,
+                        "total_cycles": 3,
+                        "pricing_scheme": {
+                          "fixed_price": {
+                            "value": "6",
+                            "currency_code": "USD"
+                          }
+                        }
+                      },
+                      {
+                        "frequency": {
+                          "interval_unit": "MONTH",
+                          "interval_count": 1
+                        },
+                        "tenure_type": "REGULAR",
+                        "sequence": 3,
+                        "total_cycles": 12,
+                        "pricing_scheme": {
+                          "fixed_price": {
+                            "value": "10",
+                            "currency_code": "USD"
+                          }
+                        }
+                      }
+                    ],
+                    "payment_preferences": {
+                      "auto_bill_outstanding": true,
+                      "setup_fee": {
+                        "value": "10",
+                        "currency_code": "USD"
+                      },
+                      "setup_fee_failure_action": "CONTINUE",
+                      "payment_failure_threshold": 3
+                    },
+                    "taxes": {
+                      "percentage": "10",
+                      "inclusive": false
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Oauth2": ["https://uri.paypal.com/services/subscriptions"]
+          }
+        ],
+        "tags": ["plans"]
+      },
+      "get": {
+        "summary": "List plans",
+        "description": "Lists billing plans.",
+        "operationId": "plans.list",
+        "responses": {
+          "200": {
+            "description": "A successful request returns the HTTP `200 OK` status code and a JSON response body that lists billing plans.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/plan_collection"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Request is not well-formed, syntactically incorrect, or violates schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_400"
+                    },
+                    {
+                      "$ref": "#/components/schemas/400"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The specified resource does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_404"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/prefer"
+          },
+          {
+            "$ref": "#/components/parameters/product_id"
+          },
+          {
+            "$ref": "#/components/parameters/page_size"
+          },
+          {
+            "$ref": "#/components/parameters/page"
+          },
+          {
+            "$ref": "#/components/parameters/total_required"
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": ["https://uri.paypal.com/services/subscriptions"]
+          }
+        ],
+        "tags": ["plans"]
+      }
+    },
+    "/v1/billing/plans/{id}": {
+      "get": {
+        "summary": "Show plan details",
+        "description": "Shows details for a plan, by ID.",
+        "operationId": "plans.get",
+        "responses": {
+          "200": {
+            "description": "A successful request returns the HTTP `200 OK` status code and a JSON response body that shows plan details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/plan"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The specified resource does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_404"
+                    },
+                    {
+                      "$ref": "#/components/schemas/404"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": ["https://uri.paypal.com/services/subscriptions"]
+          }
+        ],
+        "tags": ["plans"]
+      },
+      "patch": {
+        "summary": "Update plan",
+        "description": "Updates a plan with the `CREATED` or `ACTIVE` status. For an `INACTIVE` plan, you can make only status updates.<br/>You can patch these attributes and objects:<table><thead><tr><th>Attribute or object</th><th>Operations</th></tr></thead><tbody><tr><td><code>description</code></td><td>replace</td></tr><tr><td><code>payment_preferences.auto_bill_outstanding</code></td><td>replace</td></tr><tr><td><code>taxes.percentage</code></td><td>replace</td></tr><tr><td><code>payment_preferences.payment_failure_threshold</code></td><td>replace</td></tr><tr><td><code>payment_preferences.setup_fee</code></td><td>replace</td></tr><tr><td><code>payment_preferences.setup_fee_failure_action</code></td><td>replace</td></tr><tr><td><code>name</code></td><td>replace</td></tr></tbody></table>",
+        "operationId": "plans.patch",
+        "responses": {
+          "204": {
+            "description": "A successful request returns the HTTP `204 No Content` status code with no JSON response body."
+          },
+          "400": {
+            "description": "Request is not well-formed, syntactically incorrect, or violates schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_400"
+                    },
+                    {
+                      "$ref": "#/components/schemas/plans.patch-400"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The specified resource does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_404"
+                    },
+                    {
+                      "$ref": "#/components/schemas/404"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The requested action could not be performed, semantically incorrect, or failed business validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_422"
+                    },
+                    {
+                      "$ref": "#/components/schemas/plans.patch-422"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/patch_request"
+        },
+        "security": [
+          {
+            "Oauth2": ["https://uri.paypal.com/services/subscriptions"]
+          }
+        ],
+        "tags": ["plans"]
+      }
+    },
+    "/v1/billing/plans/{id}/activate": {
+      "post": {
+        "summary": "Activate plan",
+        "description": "Activates a plan, by ID.",
+        "operationId": "plans.activate",
+        "responses": {
+          "204": {
+            "description": "A successful request returns the HTTP `204 No Content` status code with no JSON response body."
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The specified resource does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_404"
+                    },
+                    {
+                      "$ref": "#/components/schemas/404"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The requested action could not be performed, semantically incorrect, or failed business validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_422"
+                    },
+                    {
+                      "$ref": "#/components/schemas/plans.activate-422"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": ["https://uri.paypal.com/services/subscriptions"]
+          }
+        ],
+        "tags": ["plans"]
+      }
+    },
+    "/v1/billing/plans/{id}/deactivate": {
+      "post": {
+        "summary": "Deactivate plan",
+        "description": "Deactivates a plan, by ID.",
+        "operationId": "plans.deactivate",
+        "responses": {
+          "204": {
+            "description": "A successful request returns the HTTP `204 No Content` status code with no JSON response body."
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The specified resource does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_404"
+                    },
+                    {
+                      "$ref": "#/components/schemas/404"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The requested action could not be performed, semantically incorrect, or failed business validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_422"
+                    },
+                    {
+                      "$ref": "#/components/schemas/plans.deactivate-422"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": ["https://uri.paypal.com/services/subscriptions"]
+          }
+        ],
+        "tags": ["plans"]
+      }
+    },
+    "/v1/billing/plans/{id}/update-pricing-schemes": {
+      "post": {
+        "summary": "Update pricing",
+        "description": "Updates pricing for a plan. For example, you can update a regular billing cycle from $5 per month to $7 per month.",
+        "operationId": "plans.update-pricing-schemes",
+        "responses": {
+          "204": {
+            "description": "A successful request returns the HTTP `204 No Content` status code with no JSON response body."
+          },
+          "400": {
+            "description": "Bad Request. Request is not well-formed, syntactically incorrect, or violates schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_400"
+                    },
+                    {
+                      "$ref": "#/components/schemas/plans.update-pricing-schemes-400"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The specified resource does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_404"
+                    },
+                    {
+                      "$ref": "#/components/schemas/404"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The requested action could not be performed, semantically incorrect, or failed business validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_422"
+                    },
+                    {
+                      "$ref": "#/components/schemas/plans.update-pricing-schemes-422"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/update_pricing_schemes_list_request"
+              },
+              "examples": {
+                "update_pricing_schemes_list_request": {
+                  "value": {
+                    "pricing_schemes": [
+                      {
+                        "billing_cycle_sequence": 1,
+                        "pricing_scheme": {
+                          "fixed_price": {
+                            "value": "50",
+                            "currency_code": "USD"
+                          }
+                        }
+                      },
+                      {
+                        "billing_cycle_sequence": 2,
+                        "pricing_scheme": {
+                          "fixed_price": {
+                            "value": "100",
+                            "currency_code": "USD"
+                          },
+                          "pricing_model": "VOLUME",
+                          "tiers": [
+                            {
+                              "starting_quantity": "1",
+                              "ending_quantity": "1000",
+                              "amount": {
+                                "value": "150",
+                                "currency_code": "USD"
+                              }
+                            },
+                            {
+                              "starting_quantity": "1001",
+                              "amount": {
+                                "value": "250",
+                                "currency_code": "USD"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Oauth2": ["https://uri.paypal.com/services/subscriptions"]
+          }
+        ],
+        "tags": ["plans"]
+      }
+    },
+    "/v1/billing/subscriptions": {
+      "post": {
+        "summary": "Create subscription",
+        "description": "Creates a subscription.",
+        "operationId": "subscriptions.create",
+        "responses": {
+          "200": {
+            "description": "A successful request returns the HTTP `200 OK` status code and a JSON response body that shows subscription details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/subscription"
+                },
+                "examples": {
+                  "subscription": {
+                    "value": {
+                      "id": "I-BW452GLLEP1G",
+                      "status": "APPROVAL_PENDING",
+                      "status_update_time": "2018-12-10T21:20:49Z",
+                      "plan_id": "P-5ML4271244454362WXNWU5NQ",
+                      "plan_overridden": false,
+                      "start_time": "2018-11-01T00:00:00Z",
+                      "quantity": "20",
+                      "shipping_amount": {
+                        "currency_code": "USD",
+                        "value": "10.00"
+                      },
+                      "subscriber": {
+                        "name": {
+                          "given_name": "John",
+                          "surname": "Doe"
+                        },
+                        "email_address": "customer@example.com",
+                        "payer_id": "2J6QB8YJQSJRJ",
+                        "shipping_address": {
+                          "name": {
+                            "full_name": "John Doe"
+                          },
+                          "address": {
+                            "address_line_1": "2211 N First Street",
+                            "address_line_2": "Building 17",
+                            "admin_area_2": "San Jose",
+                            "admin_area_1": "CA",
+                            "postal_code": "95131",
+                            "country_code": "US"
+                          }
+                        }
+                      },
+                      "create_time": "2018-12-10T21:20:49Z",
+                      "links": [
+                        {
+                          "href": "https://www.paypal.com/webapps/billing/subscriptions?ba_token=BA-2M539689T3856352J",
+                          "rel": "approve",
+                          "method": "GET"
+                        },
+                        {
+                          "href": "https://api-m.paypal.com/v1/billing/subscriptions/I-BW452GLLEP1G",
+                          "rel": "edit",
+                          "method": "PATCH"
+                        },
+                        {
+                          "href": "https://api-m.paypal.com/v1/billing/subscriptions/I-BW452GLLEP1G",
+                          "rel": "self",
+                          "method": "GET"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "A successful request returns the HTTP `201 Created` status code and a JSON response body that shows subscription details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/subscription"
+                },
+                "examples": {
+                  "subscription": {
+                    "value": {
+                      "id": "I-BW452GLLEP1G",
+                      "status": "APPROVAL_PENDING",
+                      "status_update_time": "2018-12-10T21:20:49Z",
+                      "plan_id": "P-5ML4271244454362WXNWU5NQ",
+                      "plan_overridden": false,
+                      "start_time": "2018-11-01T00:00:00Z",
+                      "quantity": "20",
+                      "shipping_amount": {
+                        "currency_code": "USD",
+                        "value": "10.00"
+                      },
+                      "subscriber": {
+                        "name": {
+                          "given_name": "John",
+                          "surname": "Doe"
+                        },
+                        "email_address": "customer@example.com",
+                        "payer_id": "2J6QB8YJQSJRJ",
+                        "shipping_address": {
+                          "name": {
+                            "full_name": "John Doe"
+                          },
+                          "address": {
+                            "address_line_1": "2211 N First Street",
+                            "address_line_2": "Building 17",
+                            "admin_area_2": "San Jose",
+                            "admin_area_1": "CA",
+                            "postal_code": "95131",
+                            "country_code": "US"
+                          }
+                        }
+                      },
+                      "create_time": "2018-12-10T21:20:49Z",
+                      "links": [
+                        {
+                          "href": "https://www.paypal.com/webapps/billing/subscriptions?ba_token=BA-2M539689T3856352J",
+                          "rel": "approve",
+                          "method": "GET"
+                        },
+                        {
+                          "href": "https://api-m.paypal.com/v1/billing/subscriptions/I-BW452GLLEP1G",
+                          "rel": "edit",
+                          "method": "PATCH"
+                        },
+                        {
+                          "href": "https://api-m.paypal.com/v1/billing/subscriptions/I-BW452GLLEP1G",
+                          "rel": "self",
+                          "method": "GET"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request. Request is not well-formed, syntactically incorrect, or violates schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_400"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.create-400"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The requested action could not be performed, semantically incorrect, or failed business validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_422"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.create-422"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/prefer"
+          },
+          {
+            "$ref": "#/components/parameters/paypal_request_id"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/subscription_request_post"
+              },
+              "examples": {
+                "subscription_request_post": {
+                  "value": {
+                    "plan_id": "P-5ML4271244454362WXNWU5NQ",
+                    "start_time": "2018-11-01T00:00:00Z",
+                    "quantity": "20",
+                    "shipping_amount": {
+                      "currency_code": "USD",
+                      "value": "10.00"
+                    },
+                    "subscriber": {
+                      "name": {
+                        "given_name": "John",
+                        "surname": "Doe"
+                      },
+                      "email_address": "customer@example.com",
+                      "shipping_address": {
+                        "name": {
+                          "full_name": "John Doe"
+                        },
+                        "address": {
+                          "address_line_1": "2211 N First Street",
+                          "address_line_2": "Building 17",
+                          "admin_area_2": "San Jose",
+                          "admin_area_1": "CA",
+                          "postal_code": "95131",
+                          "country_code": "US"
+                        }
+                      }
+                    },
+                    "application_context": {
+                      "brand_name": "walmart",
+                      "locale": "en-US",
+                      "shipping_preference": "SET_PROVIDED_ADDRESS",
+                      "user_action": "SUBSCRIBE_NOW",
+                      "payment_method": {
+                        "payer_selected": "PAYPAL",
+                        "payee_preferred": "IMMEDIATE_PAYMENT_REQUIRED"
+                      },
+                      "return_url": "https://example.com/returnUrl",
+                      "cancel_url": "https://example.com/cancelUrl"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Oauth2": ["https://uri.paypal.com/services/subscriptions"]
+          }
+        ],
+        "tags": ["subscriptions"]
+      }
+    },
+    "/v1/billing/subscriptions/{id}": {
+      "get": {
+        "summary": "Show subscription details",
+        "description": "Shows details for a subscription, by ID.",
+        "operationId": "subscriptions.get",
+        "responses": {
+          "200": {
+            "description": "A successful request returns the HTTP `200 OK` status code and a JSON response body that shows subscription details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/subscription"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The specified resource does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_404"
+                    },
+                    {
+                      "$ref": "#/components/schemas/404"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          },
+          {
+            "$ref": "#/components/parameters/fields"
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": ["https://uri.paypal.com/services/subscriptions"]
+          }
+        ],
+        "tags": ["subscriptions"]
+      },
+      "patch": {
+        "summary": "Update subscription",
+        "description": "Updates a subscription which could be in <code>ACTIVE</code> or <code>SUSPENDED</code> status. You can override plan level default attributes by providing customised values for plan path in the patch request.<br /> <ul> <li>You cannot update attributes that have already completed (Example - trial cycles can’t be updated if completed).</li> <li>Once overridden, changes to plan resource will not impact subscription.</li> <li>Any price update will not impact billing cycles within next 10 days (Applicable only for subscriptions funded by PayPal account).</li> </ul> Following are the fields eligible for patch.<table><thead><tr><th>Attribute or object</th><th>Operations</th></tr></thead><tbody><tr><td><code>billing_info.outstanding_balance</code></td><td>replace</td></tr><tr><td><code>custom_id</code></td><td>add,replace</td></tr><tr><td><code>plan.billing_cycles[@sequence==n].<br/>pricing_scheme.fixed_price</code></td><td>add,replace</td></tr><tr><td><code>plan.billing_cycles[@sequence==n].<br/>pricing_scheme.tiers</code></td><td>replace</td></tr><tr><td><code>plan.billing_cycles[@sequence==n].<br/>total_cycles</code></td><td>replace</td></tr><tr><td><code>plan.payment_preferences.<br/>auto_bill_outstanding</code></td><td>replace</td></tr><tr><td><code>plan.payment_preferences.<br/>payment_failure_threshold</code></td><td>replace</td></tr><tr><td><code>plan.taxes.inclusive</code></td><td>add,replace</td></tr><tr><td><code>plan.taxes.percentage</code></td><td>add,replace</td></tr><tr><td><code>shipping_amount</code></td><td>add,replace</td></tr><tr><td><code>start_time</code></td><td>replace</td></tr><tr><td><code>subscriber.shipping_address</code></td><td>add,replace</td></tr><tr><td><code>subscriber.payment_source (for subscriptions funded<br/>by card payments)</code></td><td>replace</td></tr></tbody></table>",
+        "operationId": "subscriptions.patch",
+        "responses": {
+          "204": {
+            "description": "A successful request returns the HTTP `204 No Content` status code with no JSON response body."
+          },
+          "400": {
+            "description": "Request is not well-formed, syntactically incorrect, or violates schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_400"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.patch-400"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The specified resource does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_404"
+                    },
+                    {
+                      "$ref": "#/components/schemas/404"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The requested action could not be performed, semantically incorrect, or failed business validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_422"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.patch-422"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/patch_request"
+        },
+        "security": [
+          {
+            "Oauth2": ["https://uri.paypal.com/services/subscriptions"]
+          }
+        ],
+        "tags": ["subscriptions"]
+      }
+    },
+    "/v1/billing/subscriptions/{id}/revise": {
+      "post": {
+        "summary": "Revise plan or quantity of subscription",
+        "description": "Updates the quantity of the product or service in a subscription. You can also use this method to switch the plan and update the `shipping_amount`, `shipping_address` values for the subscription. This type of update requires the buyer's consent.",
+        "operationId": "subscriptions.revise",
+        "responses": {
+          "200": {
+            "description": "A successful request returns the HTTP `200 OK` status code and a JSON response body that shows subscription details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/subscription_revise_response"
+                },
+                "examples": {
+                  "subscription_revise_response": {
+                    "value": {
+                      "plan_id": "P-5ML4271244454362WXNWU5NQ",
+                      "plan_overridden": false,
+                      "shipping_amount": {
+                        "currency_code": "USD",
+                        "value": "10.00"
+                      },
+                      "shipping_address": {
+                        "name": {
+                          "full_name": "John Doe"
+                        },
+                        "address": {
+                          "address_line_1": "2211 N First Street",
+                          "address_line_2": "Building 17",
+                          "admin_area_2": "San Jose",
+                          "admin_area_1": "CA",
+                          "postal_code": "95131",
+                          "country_code": "US"
+                        }
+                      },
+                      "links": [
+                        {
+                          "href": "https://www.paypal.com/webapps/billing/subscriptions/update?ba_token=BA-2M539689T3856352J",
+                          "rel": "approve",
+                          "method": "GET"
+                        },
+                        {
+                          "href": "https://api-m.paypal.com/v1/billing/subscriptions/I-BW452GLLEP1G",
+                          "rel": "edit",
+                          "method": "PATCH"
+                        },
+                        {
+                          "href": "https://api-m.paypal.com/v1/billing/subscriptions/I-BW452GLLEP1G",
+                          "rel": "self",
+                          "method": "GET"
+                        },
+                        {
+                          "href": "https://api-m.paypal.com/v1/billing/subscriptions/I-BW452GLLEP1G/cancel",
+                          "rel": "cancel",
+                          "method": "POST"
+                        },
+                        {
+                          "href": "https://api-m.paypal.com/v1/billing/subscriptions/I-BW452GLLEP1G/suspend",
+                          "rel": "suspend",
+                          "method": "POST"
+                        },
+                        {
+                          "href": "https://api-m.paypal.com/v1/billing/subscriptions/I-BW452GLLEP1G/capture",
+                          "rel": "capture",
+                          "method": "POST"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request. Request is not well-formed, syntactically incorrect, or violates schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_400"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.revise-400"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The specified resource does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_404"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.revise-404"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The requested action could not be performed, semantically incorrect, or failed business validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_422"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.revise-422"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/subscription_revise_request"
+              },
+              "examples": {
+                "subscription_revise_request": {
+                  "value": {
+                    "plan_id": "P-5ML4271244454362WXNWU5NQ",
+                    "shipping_amount": {
+                      "currency_code": "USD",
+                      "value": "10.00"
+                    },
+                    "shipping_address": {
+                      "name": {
+                        "full_name": "John Doe"
+                      },
+                      "address": {
+                        "address_line_1": "2211 N First Street",
+                        "address_line_2": "Building 17",
+                        "admin_area_2": "San Jose",
+                        "admin_area_1": "CA",
+                        "postal_code": "95131",
+                        "country_code": "US"
+                      }
+                    },
+                    "application_context": {
+                      "brand_name": "walmart",
+                      "locale": "en-US",
+                      "shipping_preference": "SET_PROVIDED_ADDRESS",
+                      "payment_method": {
+                        "payer_selected": "PAYPAL",
+                        "payee_preferred": "IMMEDIATE_PAYMENT_REQUIRED"
+                      },
+                      "return_url": "https://example.com/returnUrl",
+                      "cancel_url": "https://example.com/cancelUrl"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Oauth2": ["https://uri.paypal.com/services/subscriptions"]
+          }
+        ],
+        "tags": ["subscriptions"]
+      }
+    },
+    "/v1/billing/subscriptions/{id}/suspend": {
+      "post": {
+        "summary": "Suspend subscription",
+        "description": "Suspends the subscription.",
+        "operationId": "subscriptions.suspend",
+        "responses": {
+          "204": {
+            "description": "A successful request returns the HTTP `204 No Content` status code with no JSON response body."
+          },
+          "400": {
+            "description": "Bad Request. Request is not well-formed, syntactically incorrect, or violates schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_400"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.suspend-400"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The specified resource does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_404"
+                    },
+                    {
+                      "$ref": "#/components/schemas/404"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The requested action could not be performed, semantically incorrect, or failed business validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_422"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.suspend-422"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/subscription_suspend_request"
+              },
+              "examples": {
+                "subscription_suspend_request": {
+                  "value": {
+                    "reason": "Item out of stock"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Oauth2": ["https://uri.paypal.com/services/subscriptions"]
+          }
+        ],
+        "tags": ["subscriptions"]
+      }
+    },
+    "/v1/billing/subscriptions/{id}/cancel": {
+      "post": {
+        "summary": "Cancel subscription",
+        "description": "Cancels the subscription.",
+        "operationId": "subscriptions.cancel",
+        "responses": {
+          "204": {
+            "description": "A successful request returns the HTTP `204 No Content` status code with no JSON response body."
+          },
+          "400": {
+            "description": "Bad Request. Request is not well-formed, syntactically incorrect, or violates schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_400"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.cancel-400"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The specified resource does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_404"
+                    },
+                    {
+                      "$ref": "#/components/schemas/404"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The requested action could not be performed, semantically incorrect, or failed business validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_422"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.cancel-422"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/subscription_cancel_request"
+              },
+              "examples": {
+                "subscription_cancel_request": {
+                  "value": {
+                    "reason": "Not satisfied with the service"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Oauth2": ["https://uri.paypal.com/services/subscriptions"]
+          }
+        ],
+        "tags": ["subscriptions"]
+      }
+    },
+    "/v1/billing/subscriptions/{id}/activate": {
+      "post": {
+        "summary": "Activate subscription",
+        "description": "Activates the subscription.",
+        "operationId": "subscriptions.activate",
+        "responses": {
+          "204": {
+            "description": "A successful request returns the HTTP `204 No Content` status code with no JSON response body."
+          },
+          "400": {
+            "description": "Bad Request. Request is not well-formed, syntactically incorrect, or violates schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_400"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.activate-400"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The specified resource does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_404"
+                    },
+                    {
+                      "$ref": "#/components/schemas/404"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The requested action could not be performed, semantically incorrect, or failed business validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_422"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.activate-422"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/subscription_activate_request"
+              },
+              "examples": {
+                "subscription_activate_request": {
+                  "value": {
+                    "reason": "Reactivating the subscription"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Oauth2": ["https://uri.paypal.com/services/subscriptions"]
+          }
+        ],
+        "tags": ["subscriptions"]
+      }
+    },
+    "/v1/billing/subscriptions/{id}/capture": {
+      "post": {
+        "summary": "Capture authorized payment on subscription",
+        "description": "Captures an authorized payment from the subscriber on the subscription.",
+        "operationId": "subscriptions.capture",
+        "responses": {
+          "200": {
+            "description": "A successful request returns the HTTP `200 OK` status code and a JSON response body that shows subscription details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/transaction"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Request Accepted."
+          },
+          "400": {
+            "description": "Bad Request. Request is not well-formed, syntactically incorrect, or violates schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_400"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.capture-400"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The specified resource does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_404"
+                    },
+                    {
+                      "$ref": "#/components/schemas/404"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The requested action could not be performed, semantically incorrect, or failed business validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_422"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.capture-422"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/paypal_request_id"
+          },
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/subscription_capture_request"
+              },
+              "examples": {
+                "subscription_capture_request": {
+                  "value": {
+                    "note": "Charging as the balance reached the limit",
+                    "capture_type": "OUTSTANDING_BALANCE",
+                    "amount": {
+                      "currency_code": "USD",
+                      "value": "100"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Oauth2": ["https://uri.paypal.com/services/subscriptions"]
+          }
+        ],
+        "tags": ["subscriptions"]
+      }
+    },
+    "/v1/billing/subscriptions/{id}/transactions": {
+      "get": {
+        "summary": "List transactions for subscription",
+        "description": "Lists transactions for a subscription.",
+        "operationId": "subscriptions.transactions",
+        "responses": {
+          "200": {
+            "description": "A successful request returns the HTTP `200 OK` status code and a JSON response body that shows subscription details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/transactions_list"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request. Request is not well-formed, syntactically incorrect, or violates schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_400"
+                    },
+                    {
+                      "$ref": "#/components/schemas/subscriptions.transactions-400"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed due to missing authorization header, or invalid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_401"
+                    },
+                    {
+                      "$ref": "#/components/schemas/401"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authorization failed due to insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_403"
+                    },
+                    {
+                      "$ref": "#/components/schemas/403"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The specified resource does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/error_404"
+                    },
+                    {
+                      "$ref": "#/components/schemas/404"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_500"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          },
+          {
+            "$ref": "#/components/parameters/start_time"
+          },
+          {
+            "$ref": "#/components/parameters/end_time"
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": ["https://uri.paypal.com/services/subscriptions"]
+          }
+        ],
+        "tags": ["subscriptions"]
+      }
+    }
+  },
+  "components": {
+    "requestBodies": {
+      "patch_request": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/patch_request"
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "Oauth2": {
+        "type": "oauth2",
+        "description": "Oauth 2.0 authentication",
+        "flows": {
+          "clientCredentials": {
+            "tokenUrl": "/v1/oauth2/token",
+            "scopes": {
+              "https://uri.paypal.com/services/subscriptions": "Manage plan & subscription"
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "default": {
+        "description": "The default response.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/error_default"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "400": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "INVALID_PARAMETER_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PARAMETER_VALUE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["The value of a field is invalid."]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "401": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "INVALID_ACCOUNT_STATUS",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_ACCOUNT_STATUS"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["Account validations failed for the user."]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "403": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "PERMISSION_DENIED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["PERMISSION_DENIED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "You do not have permission to access or perform operations on this resource."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "404": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "INVALID_RESOURCE_ID",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_RESOURCE_ID"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Specified resource ID does not exist. Please check the resource ID and try again."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "422": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "USER_ACCOUNT_CLOSED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["USER_ACCOUNT_CLOSED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["User account locked or closed."]
+                    }
+                  }
+                },
+                {
+                  "title": "CURRENCY_MISMATCH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["CURRENCY_MISMATCH"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "All currency codes in the request should be of similar value."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "MULTIPLE_FREE_TRIAL_BILLING_CYCLES_NOT_SUPPORTED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "MULTIPLE_FREE_TRIAL_BILLING_CYCLES_NOT_SUPPORTED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["Only one free trial billing cycle is allowed."]
+                    }
+                  }
+                },
+                {
+                  "title": "MORE_THAN_TWO_TRIAL_BILLING_CYCLE_NOT_SUPPORTED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": [
+                        "MORE_THAN_TWO_TRIAL_BILLING_CYCLE_NOT_SUPPORTED"
+                      ]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["Only two trial billing cycles are allowed."]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_REGULAR_BILLING_CYCLE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["MISSING_REGULAR_BILLING_CYCLE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Plan should have at least one regular billing cycle."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "MULTIPLE_REGULAR_BILLING_CYCLES_NOT_SUPPORTED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["MULTIPLE_REGULAR_BILLING_CYCLES_NOT_SUPPORTED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["Only one regular billing cycle is allowed."]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_BILLING_CYCLE_SEQUENCE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_BILLING_CYCLE_SEQUENCE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Billing cycle sequence should start with `1` and be consecutive."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_BILLING_CYCLE_SEQUENCE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_BILLING_CYCLE_SEQUENCE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Trial Billing cycle should precede regular billing cycle."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_TRIAL_BILLING_TOTAL_CYCLES",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_TRIAL_BILLING_TOTAL_CYCLES"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Total cycles for trial billing must be greater than '0'."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_TIER_AMOUNT",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PRICING_TIER_AMOUNT"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["Free tiers are not supported."]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_PRICING_SCHEME_TIERS",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["MISSING_PRICING_SCHEME_TIERS"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["Tier(s) are missing for some quantities."]
+                    }
+                  }
+                },
+                {
+                  "title": "OVERLAPPING_PRICING_SCHEME_TIERS",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["OVERLAPPING_PRICING_SCHEME_TIERS"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The specified quantity overlaps with multiple pricing tiers."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_MODEL",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PRICING_MODEL"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The specified pricing model is not supported for trial billing cycle."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "FIXED_PRICE_NOT_SUPPORTED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["FIXED_PRICE_NOT_SUPPORTED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Fixed price is not supported for tiered pricing schemes."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_TIER_QUANTITY",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PRICING_TIER_QUANTITY"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Tier starting quantity must be less than ending quantity."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_QUANTITY_SUPPORTED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_QUANTITY_SUPPORTED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Quantity is always supported for volume and tiered plans."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "CURRENCY_NOT_SUPPORTED_FOR_RECEIVER",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["CURRENCY_NOT_SUPPORTED_FOR_RECEIVER"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "This currency cannot be accepted for this recipient’s account."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_METADATA_CUSTOM_NOTE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_METADATA_CUSTOM_NOTE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Merchant custom note cannot exceed 255 characters."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_METADATA_INVOICE_ID",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_METADATA_INVOICE_ID"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["Invoice id cannot exceed 127 characters."]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "account_id": {
+        "type": "string",
+        "title": "PayPal Account Identifier",
+        "description": "The account identifier for a PayPal account.",
+        "format": "ppaas_payer_id_v3",
+        "minLength": 13,
+        "maxLength": 13,
+        "pattern": "^[2-9A-HJ-NP-Z]{13}$"
+      },
+      "amount_with_breakdown": {
+        "type": "object",
+        "title": "Amount with Breakdown",
+        "description": "The breakdown details for the amount. Includes the gross, tax, fee, and shipping amounts.",
+        "properties": {
+          "gross_amount": {
+            "description": "The amount for this transaction.",
+            "readOnly": true,
+            "$ref": "#/components/schemas/money"
+          },
+          "total_item_amount": {
+            "description": "The item total for the transaction.",
+            "readOnly": true,
+            "$ref": "#/components/schemas/money"
+          },
+          "fee_amount": {
+            "description": "The fee details for the transaction.",
+            "readOnly": true,
+            "$ref": "#/components/schemas/money"
+          },
+          "shipping_amount": {
+            "description": "The shipping amount for the transaction.",
+            "readOnly": true,
+            "$ref": "#/components/schemas/money"
+          },
+          "tax_amount": {
+            "description": "The tax amount for the transaction.",
+            "readOnly": true,
+            "$ref": "#/components/schemas/money"
+          },
+          "net_amount": {
+            "description": "The net amount that the payee receives for this transaction in their PayPal account. The net amount is computed as <code>gross_amount</code> minus the <code>paypal_fee</code>.",
+            "readOnly": true,
+            "$ref": "#/components/schemas/money"
+          }
+        },
+        "required": ["gross_amount"]
+      },
+      "application_context": {
+        "title": "Application Context",
+        "description": "The application context, which customizes the payer experience during the subscription approval process with PayPal.",
+        "type": "object",
+        "properties": {
+          "brand_name": {
+            "type": "string",
+            "description": "The label that overrides the business name in the PayPal account on the PayPal site.",
+            "minLength": 1,
+            "maxLength": 127,
+            "pattern": "^.*$"
+          },
+          "locale": {
+            "description": "The BCP 47-formatted locale of pages that the PayPal payment experience shows. PayPal supports a five-character code. For example, `da-DK`, `he-IL`, `id-ID`, `ja-JP`, `no-NO`, `pt-BR`, `ru-RU`, `sv-SE`, `th-TH`, `zh-CN`, `zh-HK`, or `zh-TW`.",
+            "$ref": "#/components/schemas/language"
+          },
+          "shipping_preference": {
+            "type": "string",
+            "description": "The location from which the shipping address is derived.",
+            "minLength": 1,
+            "maxLength": 24,
+            "pattern": "^[A-Z_]+$",
+            "default": "GET_FROM_FILE",
+            "x-enumDescriptions": [
+              {
+                "value": "GET_FROM_FILE",
+                "description": "Get the customer-provided shipping address on the PayPal site.",
+                "default": true
+              },
+              {
+                "value": "NO_SHIPPING",
+                "description": "Redacts the shipping address from the PayPal site. Recommended for digital goods."
+              },
+              {
+                "value": "SET_PROVIDED_ADDRESS",
+                "description": "Get the merchant-provided address. The customer cannot change this address on the PayPal site. If merchant does not pass an address, customer can choose the address on PayPal pages."
+              }
+            ],
+            "enum": ["GET_FROM_FILE", "NO_SHIPPING", "SET_PROVIDED_ADDRESS"]
+          },
+          "user_action": {
+            "type": "string",
+            "description": "Configures the label name to `Continue` or `Subscribe Now` for subscription consent experience.",
+            "minLength": 1,
+            "maxLength": 24,
+            "pattern": "^[A-Z_]+$",
+            "default": "SUBSCRIBE_NOW",
+            "x-enumDescriptions": [
+              {
+                "value": "CONTINUE",
+                "description": "After you redirect the customer to the PayPal subscription consent page, a <strong>Continue</strong> button appears. Use this option when you want to control the activation of the subscription and do not want PayPal to activate the subscription.",
+                "default": true
+              },
+              {
+                "value": "SUBSCRIBE_NOW",
+                "description": "After you redirect the customer to the PayPal subscription consent page, a <strong>Subscribe Now</strong> button appears. Use this option when you want PayPal to activate the subscription."
+              }
+            ],
+            "enum": ["CONTINUE", "SUBSCRIBE_NOW"]
+          },
+          "payment_method": {
+            "description": "The customer and merchant payment preferences.",
+            "type": "object",
+            "title": "Payment Method",
+            "properties": {
+              "payee_preferred": {
+                "$ref": "#/components/schemas/payee_payment_method_preference"
+              }
+            }
+          },
+          "return_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL where the customer is redirected after the customer approves the payment.",
+            "minLength": 10,
+            "maxLength": 4000
+          },
+          "cancel_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL where the customer is redirected after the customer cancels the payment.",
+            "minLength": 10,
+            "maxLength": 4000
+          }
+        },
+        "required": ["return_url", "cancel_url"]
+      },
+      "authentication_response": {
+        "type": "object",
+        "title": "Authentication Response",
+        "description": "Results of Authentication such as 3D Secure.",
+        "properties": {
+          "liability_shift": {
+            "$ref": "#/components/schemas/liability_shift"
+          },
+          "three_d_secure": {
+            "$ref": "#/components/schemas/three_d_secure_authentication_response"
+          }
+        }
+      },
+      "billing_cycle": {
+        "title": "Billing Cycle",
+        "description": "The billing cycle details.",
+        "type": "object",
+        "properties": {
+          "pricing_scheme": {
+            "description": "The active pricing scheme for this billing cycle. A free trial billing cycle does not require a pricing scheme.",
+            "$ref": "#/components/schemas/pricing_scheme"
+          },
+          "frequency": {
+            "description": "The frequency details for this billing cycle.",
+            "$ref": "#/components/schemas/frequency"
+          },
+          "tenure_type": {
+            "type": "string",
+            "description": "The tenure type of the billing cycle. In case of a plan having trial cycle, only 2 trial cycles are allowed per plan.",
+            "minLength": 1,
+            "maxLength": 24,
+            "pattern": "^[A-Z_]+$",
+            "x-enumDescriptions": [
+              {
+                "value": "REGULAR",
+                "description": "A regular billing cycle."
+              },
+              {
+                "value": "TRIAL",
+                "description": "A trial billing cycle."
+              }
+            ],
+            "enum": ["REGULAR", "TRIAL"]
+          },
+          "sequence": {
+            "type": "integer",
+            "description": "The order in which this cycle is to run among other billing cycles. For example, a trial billing cycle has a `sequence` of `1` while a regular billing cycle has a `sequence` of `2`, so that trial cycle runs before the regular cycle.",
+            "minimum": 1,
+            "maximum": 99
+          },
+          "total_cycles": {
+            "type": "integer",
+            "description": "The number of times this billing cycle gets executed. Trial billing cycles can only be executed a finite number of times (value between <code>1</code> and <code>999</code> for <code>total_cycles</code>). Regular billing cycles can be executed infinite times (value of <code>0</code> for <code>total_cycles</code>) or a finite number of times (value between <code>1</code> and <code>999</code> for <code>total_cycles</code>).",
+            "minimum": 0,
+            "maximum": 999,
+            "default": 1
+          }
+        },
+        "required": ["frequency", "tenure_type", "sequence"]
+      },
+      "billing_cycle_list": {
+        "type": "array",
+        "description": "An array of billing cycles for trial billing and regular billing. A plan can have at most two trial cycles and only one regular cycle.",
+        "minItems": 1,
+        "maxItems": 12,
+        "items": {
+          "$ref": "#/components/schemas/billing_cycle"
+        }
+      },
+      "billing_cycle_override": {
+        "title": "Billing Cycle Override",
+        "description": "The billing cycle details to override at subscription level. The subscription billing cycle definition has to adhere to the plan billing cycle definition.",
+        "type": "object",
+        "properties": {
+          "pricing_scheme": {
+            "description": "The active pricing scheme for this billing cycle. A free trial billing cycle does not require a pricing scheme.",
+            "$ref": "#/components/schemas/pricing_scheme"
+          },
+          "sequence": {
+            "type": "integer",
+            "description": "The order in which this cycle is to run among other billing cycles. For example, a trial billing cycle has a `sequence` of `1` while a regular billing cycle has a `sequence` of `2`, so that trial cycle runs before the regular cycle.",
+            "minimum": 1,
+            "maximum": 99
+          },
+          "total_cycles": {
+            "type": "integer",
+            "description": "The number of times this billing cycle gets executed. Trial billing cycles can only be executed a finite number of times (value between <code>1</code> and <code>999</code> for <code>total_cycles</code>). Regular billing cycles can be executed infinite times (value of <code>0</code> for <code>total_cycles</code>) or a finite number of times (value between <code>1</code> and <code>999</code> for <code>total_cycles</code>).",
+            "minimum": 0,
+            "maximum": 999
+          }
+        },
+        "required": ["sequence"]
+      },
+      "billing_cycle_override_list": {
+        "type": "array",
+        "description": "An array of billing cycles for trial billing and regular billing. The subscription billing cycle definition has to adhere to the plan billing cycle definition.",
+        "minItems": 1,
+        "maxItems": 12,
+        "items": {
+          "$ref": "#/components/schemas/billing_cycle_override"
+        }
+      },
+      "bin_details": {
+        "type": "object",
+        "title": "Bin Details",
+        "description": "Bank Identification Number (BIN) details used to fund a payment.",
+        "properties": {
+          "bin": {
+            "type": "string",
+            "description": "The Bank Identification Number (BIN) signifies the number that is being used to identify the granular level details (except the PII information) of the card.",
+            "pattern": "^[0-9]+$",
+            "maxLength": 25,
+            "minLength": 1
+          },
+          "issuing_bank": {
+            "type": "string",
+            "description": "The issuer of the card instrument.",
+            "minLength": 1,
+            "maxLength": 64
+          },
+          "bin_country_code": {
+            "description": "The [two-character ISO-3166-1 country code](/docs/integration/direct/rest/country-codes/) of the bank.",
+            "$ref": "#/components/schemas/country_code-2"
+          },
+          "products": {
+            "$ref": "#/components/schemas/products_list"
+          }
+        }
+      },
+      "card_attributes": {
+        "type": "object",
+        "title": "Card Attributes",
+        "description": "Additional attributes associated with the use of this card.",
+        "properties": {
+          "customer": {
+            "$ref": "#/components/schemas/customer"
+          },
+          "vault": {
+            "description": "Instruction to vault the card based on the specified strategy.",
+            "$ref": "#/components/schemas/vault_instruction_base"
+          },
+          "verification": {
+            "description": "Instruction to optionally verify the card based on the specified strategy.",
+            "$ref": "#/components/schemas/card_verification"
+          }
+        }
+      },
+      "card_attributes_response": {
+        "type": "object",
+        "title": "Card Attributes Response",
+        "description": "Additional attributes associated with the use of this card.",
+        "properties": {
+          "vault": {
+            "$ref": "#/components/schemas/vault_response"
+          }
+        }
+      },
+      "card_brand": {
+        "type": "string",
+        "title": "Card Brand",
+        "description": "The card network or brand. Applies to credit, debit, gift, and payment cards.",
+        "minLength": 1,
+        "maxLength": 255,
+        "pattern": "^[A-Z_]+$",
+        "x-enumDescriptions": [
+          {
+            "value": "VISA",
+            "description": "Visa card."
+          },
+          {
+            "value": "MASTERCARD",
+            "description": "Mastecard card."
+          },
+          {
+            "value": "DISCOVER",
+            "description": "Discover card."
+          },
+          {
+            "value": "AMEX",
+            "description": "American Express card."
+          },
+          {
+            "value": "SOLO",
+            "description": "Solo debit card."
+          },
+          {
+            "value": "JCB",
+            "description": "Japan Credit Bureau card."
+          },
+          {
+            "value": "STAR",
+            "description": "Military Star card."
+          },
+          {
+            "value": "DELTA",
+            "description": "Delta Airlines card."
+          },
+          {
+            "value": "SWITCH",
+            "description": "Switch credit card."
+          },
+          {
+            "value": "MAESTRO",
+            "description": "Maestro credit card."
+          },
+          {
+            "value": "CB_NATIONALE",
+            "description": "Carte Bancaire (CB) credit card."
+          },
+          {
+            "value": "CONFIGOGA",
+            "description": "Configoga credit card."
+          },
+          {
+            "value": "CONFIDIS",
+            "description": "Confidis credit card."
+          },
+          {
+            "value": "ELECTRON",
+            "description": "Visa Electron credit card."
+          },
+          {
+            "value": "CETELEM",
+            "description": "Cetelem credit card."
+          },
+          {
+            "value": "CHINA_UNION_PAY",
+            "description": "China union pay credit card."
+          },
+          {
+            "value": "DINERS",
+            "description": "The Diners Club International banking and payment services capability network owned by Discover Financial Services (DFS), one of the most recognized brands in US financial services."
+          },
+          {
+            "value": "ELO",
+            "description": "The Brazilian Elo card payment network."
+          },
+          {
+            "value": "HIPER",
+            "description": "The Hiper - Ingenico ePayment network."
+          },
+          {
+            "value": "HIPERCARD",
+            "description": "The Brazilian Hipercard payment network that's widely accepted in the retail market."
+          },
+          {
+            "value": "RUPAY",
+            "description": "The RuPay payment network."
+          },
+          {
+            "value": "GE",
+            "description": "The GE Credit Union 3Point card payment network."
+          },
+          {
+            "value": "SYNCHRONY",
+            "description": "The Synchrony Financial (SYF) payment network."
+          },
+          {
+            "value": "UNKNOWN",
+            "description": "UNKNOWN payment network."
+          }
+        ],
+        "enum": [
+          "VISA",
+          "MASTERCARD",
+          "DISCOVER",
+          "AMEX",
+          "SOLO",
+          "JCB",
+          "STAR",
+          "DELTA",
+          "SWITCH",
+          "MAESTRO",
+          "CB_NATIONALE",
+          "CONFIGOGA",
+          "CONFIDIS",
+          "ELECTRON",
+          "CETELEM",
+          "CHINA_UNION_PAY",
+          "DINERS",
+          "ELO",
+          "HIPER",
+          "HIPERCARD",
+          "RUPAY",
+          "GE",
+          "SYNCHRONY",
+          "UNKNOWN"
+        ]
+      },
+      "card_brand_list": {
+        "type": "array",
+        "description": "Array of brands or networks associated with the card.",
+        "readOnly": true,
+        "minItems": 1,
+        "maxItems": 256,
+        "items": {
+          "$ref": "#/components/schemas/card_brand"
+        }
+      },
+      "card_from_request": {
+        "type": "object",
+        "title": "Card from Request",
+        "description": "Representation of card details as received in the request.",
+        "properties": {
+          "expiry": {
+            "description": "The card expiration year and month, in [Internet date format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+            "$ref": "#/components/schemas/date_year_month"
+          },
+          "last_digits": {
+            "type": "string",
+            "description": "The last digits of the payment card.",
+            "pattern": "[0-9]{2,}",
+            "minLength": 2,
+            "maxLength": 4,
+            "readOnly": true
+          }
+        }
+      },
+      "card_response": {
+        "type": "object",
+        "title": "Card Response",
+        "description": "The payment card to use to fund a payment. Card can be a credit or debit card.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The card holder's name as it appears on the card.",
+            "minLength": 2,
+            "maxLength": 300
+          },
+          "last_digits": {
+            "type": "string",
+            "description": "The last digits of the payment card.",
+            "pattern": "[0-9]{2,}",
+            "readOnly": true
+          },
+          "brand": {
+            "description": "The card brand or network. Typically used in the response.",
+            "readOnly": true,
+            "$ref": "#/components/schemas/card_brand"
+          },
+          "available_networks": {
+            "$ref": "#/components/schemas/card_brand_list"
+          },
+          "type": {
+            "description": "The payment card type.",
+            "$ref": "#/components/schemas/card_type"
+          },
+          "authentication_result": {
+            "$ref": "#/components/schemas/authentication_response"
+          },
+          "attributes": {
+            "$ref": "#/components/schemas/card_attributes_response"
+          },
+          "from_request": {
+            "$ref": "#/components/schemas/card_from_request"
+          },
+          "expiry": {
+            "description": "The card expiration year and month, in [Internet date format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+            "$ref": "#/components/schemas/date_year_month"
+          },
+          "bin_details": {
+            "description": "Bank Identification Number (BIN) details used to fund a payment.",
+            "$ref": "#/components/schemas/bin_details"
+          }
+        }
+      },
+      "card_response_with_billing_address": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/card_response"
+          },
+          {
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The card holder's name as it appears on the card.",
+                "minLength": 2,
+                "maxLength": 300
+              },
+              "billing_address": {
+                "description": "The portable international postal address. Maps to [AddressValidationMetadata](https://github.com/googlei18n/libaddressinput/wiki/AddressValidationMetadata) and HTML 5.1 [Autofilling form controls: the autocomplete attribute](https://www.w3.org/TR/html51/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).",
+                "type": "object",
+                "title": "Portable Postal Address (Medium-Grained)",
+                "properties": {
+                  "address_line_1": {
+                    "type": "string",
+                    "description": "The first line of the address, such as number and street, for example, `173 Drury Lane`. Needed for data entry, and Compliance and Risk checks. This field needs to pass the full address.",
+                    "maxLength": 300
+                  },
+                  "address_line_2": {
+                    "type": "string",
+                    "description": "The second line of the address, for example, a suite or apartment number.",
+                    "maxLength": 300
+                  },
+                  "admin_area_2": {
+                    "type": "string",
+                    "description": "A city, town, or village. Smaller than `admin_area_level_1`.",
+                    "maxLength": 120
+                  },
+                  "admin_area_1": {
+                    "type": "string",
+                    "description": "The highest-level sub-division in a country, which is usually a province, state, or ISO-3166-2 subdivision. This data is formatted for postal delivery, for example, `CA` and not `California`. Value, by country, is:<ul><li>UK. A county.</li><li>US. A state.</li><li>Canada. A province.</li><li>Japan. A prefecture.</li><li>Switzerland. A *kanton*.</li></ul>",
+                    "maxLength": 300
+                  },
+                  "postal_code": {
+                    "type": "string",
+                    "description": "The postal code, which is the ZIP code or equivalent. Typically required for countries with a postal code or an equivalent. See [postal code](https://en.wikipedia.org/wiki/Postal_code).",
+                    "maxLength": 60
+                  },
+                  "country_code": {
+                    "$ref": "#/components/schemas/country_code"
+                  }
+                },
+                "required": ["country_code"]
+              },
+              "expiry": {
+                "description": "The card expiration year and month, in [Internet date format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+                "$ref": "#/components/schemas/date_year_month"
+              },
+              "currency_code": {
+                "description": "Currency code of the given instrument",
+                "$ref": "#/components/schemas/currency_code"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "title": "Card Response with billing address and name",
+            "description": "The payment card used to fund the payment. Card can be a credit or debit card."
+          }
+        ]
+      },
+      "card_type": {
+        "type": "string",
+        "title": "Card Type",
+        "description": "Type of card. i.e Credit, Debit and so on.",
+        "minLength": 1,
+        "maxLength": 255,
+        "pattern": "^[A-Z_]+$",
+        "x-enumDescriptions": [
+          {
+            "value": "CREDIT",
+            "description": "A credit card."
+          },
+          {
+            "value": "DEBIT",
+            "description": "A debit card."
+          },
+          {
+            "value": "PREPAID",
+            "description": "A Prepaid card."
+          },
+          {
+            "value": "STORE",
+            "description": "A store card."
+          },
+          {
+            "value": "UNKNOWN",
+            "description": "Card type cannot be determined."
+          }
+        ],
+        "enum": ["CREDIT", "DEBIT", "PREPAID", "STORE", "UNKNOWN"]
+      },
+      "card_verification": {
+        "type": "object",
+        "title": "Card Verification",
+        "description": "The API caller can opt in to verify the card through PayPal offered verification services (e.g. Smart Dollar Auth, 3DS).",
+        "properties": {
+          "method": {
+            "description": "The method used for card verification.",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "pattern": "^[0-9A-Z_]+$",
+            "default": "SCA_WHEN_REQUIRED",
+            "x-enumDescriptions": [
+              {
+                "value": "SCA_ALWAYS",
+                "description": "Selecting this option will attempt to force a strong customer authentication for the authorization/transaction. In countries where SCA has been defined and implemented it will result in a contingency and HATEOAS link being returned.  The API caller should redirect the payer to that link so that they can authenticate themselves against their issuing bank or other entity. As noted, the HATEOAS link is only available in all regions where strong authentication is supported, (e.g. in European countries where 3DS is live). Merchants can use this setting as an additional layer of security if they choose to. In all cases, when an authorization is requested the AVS/CVV results will be returned in the response."
+              },
+              {
+                "value": "SCA_WHEN_REQUIRED",
+                "description": "This is the default. When an authorization or transaction is attempted this option will return a contingency and HATEOAS link only when local regulations require strong customer authentication, (e.g. 3DS in countries and use cases where it is mandated). The API caller should redirect the payer to the link so that they can authenticate themselves. In all cases, when an authorization is requested the AVS/CVV results will be returned in the response."
+              },
+              {
+                "value": "3D_SECURE",
+                "description": "The contingency surfaced as an additional security layer that helps prevent unauthorized card-not-present transactions and protects the merchant from exposure to fraud.",
+                "deprecated": true
+              },
+              {
+                "value": "AVS_CVV",
+                "description": "Places a temporary hold on the card to ensure its validity. This process protects the merchant from exposure to fraud. This verification method will confirm that the address information or CVV included matches what the issuing bank has on file for the associated card, ensuring that only authorized card users are able to make purchases from you.",
+                "deprecated": true
+              }
+            ],
+            "enum": ["SCA_ALWAYS", "SCA_WHEN_REQUIRED", "3D_SECURE", "AVS_CVV"]
+          }
+        }
+      },
+      "country_code": {
+        "type": "string",
+        "description": "The [2-character ISO 3166-1 code](/api/rest/reference/country-codes/) that identifies the country or region.<blockquote><strong>Note:</strong> The country code for Great Britain is <code>GB</code> and not <code>UK</code> as used in the top-level domain names for that country. Use the `C2` country code for China worldwide for comparable uncontrolled price (CUP) method, bank card, and cross-border transactions.</blockquote>",
+        "format": "ppaas_common_country_code_v2",
+        "maxLength": 2,
+        "minLength": 2,
+        "pattern": "^([A-Z]{2}|C2)$"
+      },
+      "country_code-2": {
+        "type": "string",
+        "description": "The [two-character ISO 3166-1 code](/api/rest/reference/country-codes/) that identifies the country or region.<blockquote><strong>Note:</strong> The country code for Great Britain is <code>GB</code> and not <code>UK</code> as used in the top-level domain names for that country. Use the `C2` country code for China worldwide for comparable uncontrolled price (CUP) method, bank card, and cross-border transactions.</blockquote>",
+        "format": "ppaas_common_country_code_v2",
+        "maxLength": 2,
+        "minLength": 2,
+        "pattern": "^([A-Z]{2}|C2)$"
+      },
+      "currency_code": {
+        "description": "The [three-character ISO-4217 currency code](/api/rest/reference/currency-codes/) that identifies the currency.",
+        "type": "string",
+        "format": "ppaas_common_currency_code_v2",
+        "minLength": 3,
+        "maxLength": 3
+      },
+      "customer": {
+        "type": "object",
+        "title": "Customer Information",
+        "description": "The details about a customer in PayPal's system of record.",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/merchant_partner_customer_id"
+          },
+          "email_address": {
+            "description": "Email address of the buyer as provided to the merchant or on file with the merchant. Email Address is required if you are processing the transaction using PayPal Guest Processing which is offered to select partners and merchants. For all other use cases we do not expect partners/merchant to send email_address of their customer.",
+            "$ref": "#/components/schemas/email"
+          },
+          "phone": {
+            "description": "The phone number of the buyer as provided to the merchant or on file with the merchant. The `phone.phone_number` supports only `national_number`.",
+            "$ref": "#/components/schemas/phone_with_type"
+          }
+        }
+      },
+      "cycle_execution": {
+        "title": "Billing Cycle Execution Details",
+        "description": "The regular and trial execution details for a billing cycle.",
+        "type": "object",
+        "properties": {
+          "tenure_type": {
+            "type": "string",
+            "description": "The type of the billing cycle.",
+            "minLength": 1,
+            "maxLength": 24,
+            "pattern": "^[A-Z_]+$",
+            "x-enumDescriptions": [
+              {
+                "value": "REGULAR",
+                "description": "A regular billing cycle."
+              },
+              {
+                "value": "TRIAL",
+                "description": "A trial billing cycle."
+              }
+            ],
+            "readOnly": true,
+            "enum": ["REGULAR", "TRIAL"]
+          },
+          "sequence": {
+            "type": "integer",
+            "description": "The order in which to run this cycle among other billing cycles.",
+            "minimum": 0,
+            "maximum": 99
+          },
+          "cycles_completed": {
+            "type": "integer",
+            "description": "The number of billing cycles that have completed.",
+            "minimum": 0,
+            "maximum": 9999,
+            "readOnly": true
+          },
+          "cycles_remaining": {
+            "type": "integer",
+            "description": "For a finite billing cycle, cycles_remaining is the number of remaining cycles. For an infinite billing cycle, cycles_remaining is set as 0.",
+            "minimum": 0,
+            "maximum": 9999,
+            "readOnly": true
+          },
+          "current_pricing_scheme_version": {
+            "type": "integer",
+            "description": "The active pricing scheme version for the billing cycle.",
+            "minimum": 1,
+            "maximum": 99,
+            "readOnly": true
+          },
+          "total_cycles": {
+            "type": "integer",
+            "description": "The number of times this billing cycle gets executed. Trial billing cycles can only be executed a finite number of times (value between <code>1</code> and <code>999</code> for <code>total_cycles</code>). Regular billing cycles can be executed infinite times (value of <code>0</code> for <code>total_cycles</code>) or a finite number of times (value between <code>1</code> and <code>999</code> for <code>total_cycles</code>).",
+            "minimum": 0,
+            "maximum": 999,
+            "readOnly": true
+          }
+        },
+        "required": ["tenure_type", "sequence", "cycles_completed"]
+      },
+      "cycle_execution_list": {
+        "type": "array",
+        "description": "The trial and regular billing executions.",
+        "minItems": 0,
+        "maxItems": 3,
+        "items": {
+          "$ref": "#/components/schemas/cycle_execution"
+        },
+        "readOnly": true
+      },
+      "date_time": {
+        "type": "string",
+        "description": "The date and time, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6). Seconds are required while fractional seconds are optional.<blockquote><strong>Note:</strong> The regular expression provides guidance but does not reject all invalid dates.</blockquote>",
+        "format": "ppaas_date_time_v3",
+        "minLength": 20,
+        "maxLength": 64,
+        "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])[T,t]([0-1][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)([.][0-9]+)?([Zz]|[+-][0-9]{2}:[0-9]{2})$"
+      },
+      "date_year_month": {
+        "type": "string",
+        "description": "The year and month, in ISO-8601 `YYYY-MM` date format. See [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+        "minLength": 7,
+        "maxLength": 7,
+        "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])$"
+      },
+      "definitions-link_description_list": {
+        "type": "array",
+        "description": "An array of request-related HATEOAS links.",
+        "readOnly": true,
+        "minItems": 1,
+        "maxItems": 10,
+        "items": {
+          "$ref": "#/components/schemas/link_description"
+        }
+      },
+      "email": {
+        "type": "string",
+        "description": "The internationalized email address.<blockquote><strong>Note:</strong> Up to 64 characters are allowed before and 255 characters are allowed after the <code>@</code> sign. However, the generally accepted maximum length for an email address is 254 characters. The pattern verifies that an unquoted <code>@</code> sign exists.</blockquote>",
+        "format": "merchant_common_email_address_v2",
+        "maxLength": 254,
+        "minLength": 3,
+        "pattern": "(?:[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+)*|(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\\.)+[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?|\\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-zA-Z0-9-]*[a-zA-Z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])"
+      },
+      "email_address": {
+        "type": "string",
+        "description": "The internationalized email address.<blockquote><strong>Note:</strong> Up to 64 characters are allowed before and 255 characters are allowed after the <code>@</code> sign. However, the generally accepted maximum length for an email address is 254 characters. The pattern verifies that an unquoted <code>@</code> sign exists.</blockquote>",
+        "format": "ppaas_common_email_address_v2",
+        "minLength": 3,
+        "maxLength": 254,
+        "pattern": "^(?:[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\\.)+[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[A-Za-z0-9-]*[A-Za-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])$"
+      },
+      "enrolled": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 255,
+        "pattern": "^[0-9A-Z_]+$",
+        "description": "Status of Authentication eligibility.",
+        "x-enumDescriptions": [
+          {
+            "value": "Y",
+            "description": "Yes. The bank is participating in 3-D Secure protocol and will return the ACSUrl."
+          },
+          {
+            "value": "N",
+            "description": "No. The bank is not participating in 3-D Secure protocol."
+          },
+          {
+            "value": "U",
+            "description": "Unavailable. The DS or ACS is not available for authentication at the time of the request."
+          },
+          {
+            "value": "B",
+            "description": "Bypass. The merchant authentication rule is triggered to bypass authentication."
+          }
+        ],
+        "enum": ["Y", "N", "U", "B"]
+      },
+      "error_400": {
+        "type": "object",
+        "title": "Bad Request Error",
+        "description": "Request is not well-formed, syntactically incorrect, or violates schema.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": ["INVALID_REQUEST"]
+          },
+          "message": {
+            "type": "string",
+            "enum": [
+              "Request is not well-formed, syntactically incorrect, or violates schema."
+            ]
+          },
+          "details": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/error_details"
+            }
+          },
+          "debug_id": {
+            "type": "string",
+            "description": "The PayPal internal ID. Used for correlation purposes."
+          },
+          "links": {
+            "description": "An array of request-related [HATEOAS links](https://en.wikipedia.org/wiki/HATEOAS).",
+            "type": "array",
+            "minItems": 0,
+            "maxItems": 10000,
+            "items": {
+              "$ref": "#/components/schemas/error_link_description"
+            }
+          }
+        }
+      },
+      "error_401": {
+        "type": "object",
+        "title": "Unauthorized Error",
+        "description": "Authentication failed due to missing Authorization header, or invalid authentication credentials.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": ["AUTHENTICATION_FAILURE"]
+          },
+          "message": {
+            "type": "string",
+            "enum": [
+              "Authentication failed due to missing authorization header, or invalid authentication credentials."
+            ]
+          },
+          "details": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/error_details"
+            }
+          },
+          "debug_id": {
+            "type": "string",
+            "description": "The PayPal internal ID. Used for correlation purposes."
+          },
+          "links": {
+            "description": "An array of request-related [HATEOAS links](https://en.wikipedia.org/wiki/HATEOAS).",
+            "type": "array",
+            "minItems": 0,
+            "maxItems": 10000,
+            "items": {
+              "$ref": "#/components/schemas/error_link_description"
+            }
+          }
+        }
+      },
+      "error_403": {
+        "type": "object",
+        "title": "Not Authorized Error",
+        "description": "The client is not authorized to access this resource, although it may have valid credentials. ",
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": ["NOT_AUTHORIZED"]
+          },
+          "message": {
+            "type": "string",
+            "enum": ["Authorization failed due to insufficient permissions."]
+          },
+          "details": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/error_details"
+            }
+          },
+          "debug_id": {
+            "type": "string",
+            "description": "The PayPal internal ID. Used for correlation purposes."
+          },
+          "links": {
+            "description": "An array of request-related [HATEOAS links](https://en.wikipedia.org/wiki/HATEOAS).",
+            "type": "array",
+            "minItems": 0,
+            "maxItems": 10000,
+            "items": {
+              "$ref": "#/components/schemas/error_link_description"
+            }
+          }
+        }
+      },
+      "error_404": {
+        "type": "object",
+        "title": "Not found Error",
+        "description": "The server has not found anything matching the request URI. This either means that the URI is incorrect or the resource is not available.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": ["RESOURCE_NOT_FOUND"]
+          },
+          "message": {
+            "type": "string",
+            "enum": ["The specified resource does not exist."]
+          },
+          "details": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/error_details"
+            }
+          },
+          "debug_id": {
+            "type": "string",
+            "description": "The PayPal internal ID. Used for correlation purposes."
+          },
+          "links": {
+            "description": "An array of request-related [HATEOAS links](https://en.wikipedia.org/wiki/HATEOAS).",
+            "type": "array",
+            "minItems": 0,
+            "maxItems": 10000,
+            "items": {
+              "$ref": "#/components/schemas/error_link_description"
+            }
+          }
+        }
+      },
+      "error_409": {
+        "type": "object",
+        "title": "Resource Conflict Error",
+        "description": "The server has detected a conflict while processing this request.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": ["RESOURCE_CONFLICT"]
+          },
+          "message": {
+            "type": "string",
+            "enum": [
+              "The server has detected a conflict while processing this request."
+            ]
+          },
+          "details": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/error_details"
+            }
+          },
+          "debug_id": {
+            "type": "string",
+            "description": "The PayPal internal ID. Used for correlation purposes."
+          },
+          "links": {
+            "description": "An array of request-related [HATEOAS links](https://en.wikipedia.org/wiki/HATEOAS).",
+            "type": "array",
+            "minItems": 0,
+            "maxItems": 10000,
+            "items": {
+              "$ref": "#/components/schemas/error_link_description"
+            }
+          }
+        }
+      },
+      "error_415": {
+        "type": "object",
+        "title": "Unsupported Media Type Error",
+        "description": "The server does not support the request payload's media type.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": ["UNSUPPORTED_MEDIA_TYPE"]
+          },
+          "message": {
+            "type": "string",
+            "enum": [
+              "The server does not support the request payload's media type."
+            ]
+          },
+          "details": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/error_details"
+            }
+          },
+          "debug_id": {
+            "type": "string",
+            "description": "The PayPal internal ID. Used for correlation purposes."
+          },
+          "links": {
+            "description": "An array of request-related [HATEOAS links](https://en.wikipedia.org/wiki/HATEOAS).",
+            "type": "array",
+            "minItems": 0,
+            "maxItems": 10000,
+            "items": {
+              "$ref": "#/components/schemas/error_link_description"
+            }
+          }
+        }
+      },
+      "error_422": {
+        "type": "object",
+        "title": "Unprocessable Entity Error",
+        "description": "The requested action cannot be performed and may require interaction with APIs or processes outside of the current request. This is distinct from a 500 response in that there are no systemic problems limiting the API from performing the request.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": ["UNPROCESSABLE_ENTITY"]
+          },
+          "message": {
+            "type": "string",
+            "enum": [
+              "The requested action could not be performed, semantically incorrect, or failed business validation."
+            ]
+          },
+          "details": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/error_details"
+            }
+          },
+          "debug_id": {
+            "type": "string",
+            "description": "The PayPal internal ID. Used for correlation purposes."
+          },
+          "links": {
+            "description": "An array of request-related [HATEOAS links](https://en.wikipedia.org/wiki/HATEOAS).",
+            "type": "array",
+            "minItems": 0,
+            "maxItems": 10000,
+            "items": {
+              "$ref": "#/components/schemas/error_link_description"
+            }
+          }
+        }
+      },
+      "error_500": {
+        "type": "object",
+        "title": "Internal Server Error",
+        "description": "This is either a system or application error, and generally indicates that although the client appeared to provide a correct request, something unexpected has gone wrong on the server.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": ["INTERNAL_SERVER_ERROR"]
+          },
+          "message": {
+            "type": "string",
+            "enum": ["An internal server error occurred."]
+          },
+          "debug_id": {
+            "type": "string",
+            "description": "The PayPal internal ID. Used for correlation purposes."
+          },
+          "links": {
+            "description": "An array of request-related [HATEOAS links](https://en.wikipedia.org/wiki/HATEOAS).",
+            "type": "array",
+            "minItems": 0,
+            "maxItems": 10000,
+            "items": {
+              "$ref": "#/components/schemas/error_link_description"
+            }
+          }
+        },
+        "example": {
+          "name": "INTERNAL_SERVER_ERROR",
+          "message": "An internal server error occurred.",
+          "debug_id": "90957fca61718",
+          "links": [
+            {
+              "href": "https://developer.paypal.com/api/orders/v2/#error-INTERNAL_SERVER_ERROR",
+              "rel": "information_link"
+            }
+          ]
+        }
+      },
+      "error_503": {
+        "type": "object",
+        "title": "Service Unavailable Error",
+        "description": "The server is temporarily unable to handle the request, for example, because of planned maintenance or downtime.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": ["SERVICE_UNAVAILABLE"]
+          },
+          "message": {
+            "type": "string",
+            "enum": ["Service Unavailable."]
+          },
+          "debug_id": {
+            "type": "string",
+            "description": "The PayPal internal ID. Used for correlation purposes."
+          },
+          "links": {
+            "description": "An array of request-related [HATEOAS links](https://en.wikipedia.org/wiki/HATEOAS).",
+            "type": "array",
+            "minItems": 0,
+            "maxItems": 10000,
+            "items": {
+              "$ref": "#/components/schemas/error_link_description"
+            }
+          }
+        },
+        "example": {
+          "name": "SERVICE_UNAVAILABLE",
+          "message": "Service Unavailable.",
+          "debug_id": "90957fca61718",
+          "information_link": "https://developer.paypal.com/docs/api/orders/v2/#error-SERVICE_UNAVAILABLE"
+        }
+      },
+      "error_default": {
+        "description": "The default error response.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/error_400"
+          },
+          {
+            "$ref": "#/components/schemas/error_401"
+          },
+          {
+            "$ref": "#/components/schemas/error_403"
+          },
+          {
+            "$ref": "#/components/schemas/error_404"
+          },
+          {
+            "$ref": "#/components/schemas/error_409"
+          },
+          {
+            "$ref": "#/components/schemas/error_415"
+          },
+          {
+            "$ref": "#/components/schemas/error_422"
+          },
+          {
+            "$ref": "#/components/schemas/error_500"
+          },
+          {
+            "$ref": "#/components/schemas/error_503"
+          }
+        ]
+      },
+      "error_details": {
+        "title": "Error Details",
+        "type": "object",
+        "description": "The error details. Required for client-side `4XX` errors.",
+        "properties": {
+          "field": {
+            "type": "string",
+            "description": "The field that caused the error. If this field is in the body, set this value to the field's JSON pointer value. Required for client-side errors."
+          },
+          "value": {
+            "type": "string",
+            "description": "The value of the field that caused the error."
+          },
+          "location": {
+            "$ref": "#/components/schemas/error_location"
+          },
+          "issue": {
+            "type": "string",
+            "description": "The unique, fine-grained application-level error code."
+          },
+          "description": {
+            "type": "string",
+            "description": "The human-readable description for an issue. The description can change over the lifetime of an API, so clients must not depend on this value."
+          }
+        },
+        "required": ["issue"]
+      },
+      "error_link_description": {
+        "title": "Link Description",
+        "description": "The request-related [HATEOAS link](/api/rest/responses/#hateoas-links) information.",
+        "type": "object",
+        "required": ["href", "rel"],
+        "properties": {
+          "href": {
+            "description": "The complete target URL. To make the related call, combine the method with this [URI Template-formatted](https://tools.ietf.org/html/rfc6570) link. For pre-processing, include the `$`, `(`, and `)` characters. The `href` is the key HATEOAS component that links a completed call with a subsequent call.",
+            "type": "string",
+            "minLength": 0,
+            "maxLength": 20000,
+            "pattern": "^.*$"
+          },
+          "rel": {
+            "description": "The [link relation type](https://tools.ietf.org/html/rfc5988#section-4), which serves as an ID for a link that unambiguously describes the semantics of the link. See [Link Relations](https://www.iana.org/assignments/link-relations/link-relations.xhtml).",
+            "type": "string",
+            "minLength": 0,
+            "maxLength": 100,
+            "pattern": "^.*$"
+          },
+          "method": {
+            "description": "The HTTP method required to make the related call.",
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 6,
+            "pattern": "^[A-Z]*$",
+            "enum": ["GET", "POST", "PUT", "DELETE", "PATCH"]
+          }
+        }
+      },
+      "error_location": {
+        "type": "string",
+        "description": "The location of the field that caused the error. Value is `body`, `path`, or `query`.",
+        "enum": ["body", "path", "query"],
+        "default": "body"
+      },
+      "failed_payment_details": {
+        "title": "Failed Payment Details",
+        "description": "The details for the failed payment of the subscription.",
+        "type": "object",
+        "properties": {
+          "amount": {
+            "description": "The failed payment amount.",
+            "readOnly": true,
+            "$ref": "#/components/schemas/money"
+          },
+          "time": {
+            "description": "The date and time when the failed payment was made, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+            "readOnly": true,
+            "$ref": "#/components/schemas/date_time"
+          },
+          "reason_code": {
+            "type": "string",
+            "description": "The reason code for the payment failure.",
+            "minLength": 1,
+            "maxLength": 120,
+            "pattern": "^[A-Z_]+$",
+            "x-enumDescriptions": [
+              {
+                "value": "PAYMENT_DENIED",
+                "description": "PayPal declined the payment due to one or more customer issues."
+              },
+              {
+                "value": "INTERNAL_SERVER_ERROR",
+                "description": "An internal server error has occurred."
+              },
+              {
+                "value": "PAYEE_ACCOUNT_RESTRICTED",
+                "description": "The payee account is not in good standing and cannot receive payments."
+              },
+              {
+                "value": "PAYER_ACCOUNT_RESTRICTED",
+                "description": "The payer account is not in good standing and cannot make payments."
+              },
+              {
+                "value": "PAYER_CANNOT_PAY",
+                "description": "Payer cannot pay for this transaction."
+              },
+              {
+                "value": "SENDING_LIMIT_EXCEEDED",
+                "description": "The transaction exceeds the payer's sending limit."
+              },
+              {
+                "value": "TRANSACTION_RECEIVING_LIMIT_EXCEEDED",
+                "description": "The transaction exceeds the receiver's receiving limit."
+              },
+              {
+                "value": "CURRENCY_MISMATCH",
+                "description": "The transaction is declined due to a currency mismatch."
+              }
+            ],
+            "readOnly": true,
+            "enum": [
+              "PAYMENT_DENIED",
+              "INTERNAL_SERVER_ERROR",
+              "PAYEE_ACCOUNT_RESTRICTED",
+              "PAYER_ACCOUNT_RESTRICTED",
+              "PAYER_CANNOT_PAY",
+              "SENDING_LIMIT_EXCEEDED",
+              "TRANSACTION_RECEIVING_LIMIT_EXCEEDED",
+              "CURRENCY_MISMATCH"
+            ]
+          },
+          "next_payment_retry_time": {
+            "description": "The time when the retry attempt for the failed payment occurs, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+            "readOnly": true,
+            "$ref": "#/components/schemas/date_time"
+          }
+        },
+        "required": ["amount", "time"]
+      },
+      "frequency": {
+        "title": "Billing Cycle Frequency",
+        "description": "The frequency of the billing cycle.",
+        "type": "object",
+        "properties": {
+          "interval_unit": {
+            "type": "string",
+            "description": "The interval at which the subscription is charged or billed.",
+            "minLength": 1,
+            "maxLength": 24,
+            "pattern": "^[A-Z_]+$",
+            "x-enumDescriptions": [
+              {
+                "value": "DAY",
+                "description": "A daily billing cycle."
+              },
+              {
+                "value": "WEEK",
+                "description": "A weekly billing cycle."
+              },
+              {
+                "value": "MONTH",
+                "description": "A monthly billing cycle."
+              },
+              {
+                "value": "YEAR",
+                "description": "A yearly billing cycle."
+              }
+            ],
+            "enum": ["DAY", "WEEK", "MONTH", "YEAR"]
+          },
+          "interval_count": {
+            "type": "integer",
+            "description": "The number of intervals after which a subscriber is billed. For example, if the `interval_unit` is `DAY` with an `interval_count` of  `2`, the subscription is billed once every two days. The following table lists the maximum allowed values for the `interval_count` for each `interval_unit`:<table><thead><tr><th><code>Interval unit</code></th><th>Maximum interval count</th></tr></thead><tbody><tr><td><code>DAY</code></td><td align=\"right\">365</td></tr><tr><td><code>WEEK</code></td><td align=\"right\">52</td></tr><tr><td><code>MONTH</code></td><td align=\"right\">12</td></tr><tr><td><code>YEAR</code></td><td align=\"right\">1</td></tr></tbody></table>",
+            "minimum": 1,
+            "maximum": 365,
+            "default": 1
+          }
+        },
+        "required": ["interval_unit"]
+      },
+      "language": {
+        "type": "string",
+        "description": "The [language tag](https://tools.ietf.org/html/bcp47#section-2) for the language in which to localize the error-related strings, such as messages, issues, and suggested actions. The tag is made up of the [ISO 639-2 language code](https://www.loc.gov/standards/iso639-2/php/code_list.php), the optional [ISO-15924 script tag](https://www.unicode.org/iso15924/codelists.html), and the [ISO-3166 alpha-2 country code](/api/rest/reference/country-codes/) or [M49 region code](https://unstats.un.org/unsd/methodology/m49/).",
+        "format": "ppaas_common_language_v3",
+        "maxLength": 10,
+        "minLength": 2,
+        "pattern": "^[a-z]{2}(?:-[A-Z][a-z]{3})?(?:-(?:[A-Z]{2}|[0-9]{3}))?$"
+      },
+      "last_payment_details": {
+        "title": "Last Payment Details",
+        "description": "The details for the last payment.",
+        "type": "object",
+        "allOf": [
+          {
+            "properties": {
+              "amount": {
+                "description": "The last payment amount.",
+                "readOnly": true,
+                "$ref": "#/components/schemas/money"
+              },
+              "time": {
+                "description": "The date and time when the last payment was made, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+                "readOnly": true,
+                "$ref": "#/components/schemas/date_time"
+              }
+            }
+          }
+        ],
+        "required": ["amount", "time"]
+      },
+      "liability_shift": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 255,
+        "pattern": "^[0-9A-Z_]+$",
+        "description": "Liability shift indicator. The outcome of the issuer's authentication.",
+        "x-enumDescriptions": [
+          {
+            "value": "NO",
+            "description": "Liability is with the merchant."
+          },
+          {
+            "value": "POSSIBLE",
+            "description": "Liability may shift to the card issuer."
+          },
+          {
+            "value": "UNKNOWN",
+            "description": "The authentication system is not available."
+          }
+        ],
+        "enum": ["NO", "POSSIBLE", "UNKNOWN"]
+      },
+      "link_description": {
+        "type": "object",
+        "title": "Link Description",
+        "description": "The request-related [HATEOAS link](/api/rest/responses/#hateoas-links) information.",
+        "required": ["href", "rel"],
+        "properties": {
+          "href": {
+            "type": "string",
+            "description": "The complete target URL. To make the related call, combine the method with this [URI Template-formatted](https://tools.ietf.org/html/rfc6570) link. For pre-processing, include the `$`, `(`, and `)` characters. The `href` is the key HATEOAS component that links a completed call with a subsequent call."
+          },
+          "rel": {
+            "type": "string",
+            "description": "The [link relation type](https://tools.ietf.org/html/rfc5988#section-4), which serves as an ID for a link that unambiguously describes the semantics of the link. See [Link Relations](https://www.iana.org/assignments/link-relations/link-relations.xhtml)."
+          },
+          "method": {
+            "type": "string",
+            "description": "The HTTP method required to make the related call.",
+            "enum": [
+              "GET",
+              "POST",
+              "PUT",
+              "DELETE",
+              "HEAD",
+              "CONNECT",
+              "OPTIONS",
+              "PATCH"
+            ]
+          }
+        }
+      },
+      "link_description_list": {
+        "type": "array",
+        "description": "An array of request-related [HATEOAS links](/docs/api/reference/api-responses/#hateoas-links).",
+        "readOnly": true,
+        "minItems": 1,
+        "maxItems": 10,
+        "items": {
+          "$ref": "#/components/schemas/link_description"
+        }
+      },
+      "merchant_inventory": {},
+      "merchant_partner_customer_id": {
+        "type": "string",
+        "description": "The unique ID for a customer generated by PayPal.",
+        "minLength": 1,
+        "maxLength": 22,
+        "pattern": "^[0-9a-zA-Z_-]+$"
+      },
+      "money": {
+        "type": "object",
+        "title": "Money",
+        "description": "The currency and amount for a financial transaction, such as a balance or payment due.",
+        "properties": {
+          "currency_code": {
+            "$ref": "#/components/schemas/currency_code"
+          },
+          "value": {
+            "type": "string",
+            "description": "The value, which might be:<ul><li>An integer for currencies like `JPY` that are not typically fractional.</li><li>A decimal fraction for currencies like `TND` that are subdivided into thousandths.</li></ul>For the required number of decimal places for a currency code, see [Currency Codes](/api/rest/reference/currency-codes/).",
+            "maxLength": 32,
+            "pattern": "^((-?[0-9]+)|(-?([0-9]+)?[.][0-9]+))$"
+          }
+        },
+        "required": ["currency_code", "value"]
+      },
+      "name": {
+        "type": "object",
+        "title": "Name",
+        "description": "The name of the party.",
+        "properties": {
+          "prefix": {
+            "type": "string",
+            "description": "The prefix, or title, to the party's name.",
+            "maxLength": 140
+          },
+          "given_name": {
+            "type": "string",
+            "description": "When the party is a person, the party's given, or first, name.",
+            "maxLength": 140
+          },
+          "surname": {
+            "type": "string",
+            "description": "When the party is a person, the party's surname or family name. Also known as the last name. Required when the party is a person. Use also to store multiple surnames including the matronymic, or mother's, surname.",
+            "maxLength": 140
+          },
+          "middle_name": {
+            "type": "string",
+            "description": "When the party is a person, the party's middle name. Use also to store multiple middle names including the patronymic, or father's, middle name.",
+            "maxLength": 140
+          },
+          "suffix": {
+            "type": "string",
+            "description": "The suffix for the party's name.",
+            "maxLength": 140
+          },
+          "full_name": {
+            "type": "string",
+            "description": "When the party is a person, the party's full name.",
+            "maxLength": 300
+          }
+        }
+      },
+      "pares_status": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 255,
+        "pattern": "^[0-9A-Z_]+$",
+        "description": "Transactions status result identifier. The outcome of the issuer's authentication.",
+        "x-enumDescriptions": [
+          {
+            "value": "Y",
+            "description": "Successful authentication."
+          },
+          {
+            "value": "N",
+            "description": "Failed authentication / account not verified / transaction denied."
+          },
+          {
+            "value": "U",
+            "description": "Unable to complete authentication."
+          },
+          {
+            "value": "A",
+            "description": "Successful attempts transaction."
+          },
+          {
+            "value": "C",
+            "description": "Challenge required for authentication."
+          },
+          {
+            "value": "R",
+            "description": "Authentication rejected (merchant must not submit for authorization)."
+          },
+          {
+            "value": "D",
+            "description": "Challenge required; decoupled authentication confirmed."
+          },
+          {
+            "value": "I",
+            "description": "Informational only; 3DS requestor challenge preference acknowledged."
+          }
+        ],
+        "enum": ["Y", "N", "U", "A", "C", "R", "D", "I"]
+      },
+      "patch": {
+        "type": "object",
+        "title": "Patch",
+        "description": "The JSON patch object to apply partial updates to resources.",
+        "properties": {
+          "op": {
+            "type": "string",
+            "description": "The operation.",
+            "x-enumDescriptions": [
+              {
+                "value": "add",
+                "description": "Depending on the target location reference, completes one of these functions:<ul><li><strong>The target location is an array index</strong>. Inserts a new value into the array at the specified index.</li><li><strong>The target location is an object parameter that does not already exist</strong>. Adds a new parameter to the object.</li><li><strong>The target location is an object parameter that does exist</strong>. Replaces that parameter's value.</li></ul>The <code>value</code> parameter defines the value to add. For more information, see <a href=\"https://tools.ietf.org/html/rfc6902#section-4.1\">4.1. add</a>."
+              },
+              {
+                "value": "remove",
+                "description": "Removes the value at the target location. For the operation to succeed, the target location must exist. For more information, see <a href=\"https://tools.ietf.org/html/rfc6902#section-4.2\">4.2. remove</a>."
+              },
+              {
+                "value": "replace",
+                "description": "Replaces the value at the target location with a new value. The operation object must contain a <code>value</code> parameter that defines the replacement value. For the operation to succeed, the target location must exist. For more information, see <a href=\"https://tools.ietf.org/html/rfc6902#section-4.3\">4.3. replace</a>."
+              },
+              {
+                "value": "move",
+                "description": "Removes the value at a specified location and adds it to the target location. The operation object must contain a <code>from</code> parameter, which is a string that contains a JSON pointer value that references the location in the target document from which to move the value. For the operation to succeed, the <code>from</code> location must exist. For more information, see <a href=\"https://tools.ietf.org/html/rfc6902#section-4.4\">4.4. move</a>."
+              },
+              {
+                "value": "copy",
+                "description": "Copies the value at a specified location to the target location. The operation object must contain a <code>from</code> parameter, which is a string that contains a JSON pointer value that references the location in the target document from which to copy the value. For the operation to succeed, the <code>from</code> location must exist. For more information, see <a href=\"https://tools.ietf.org/html/rfc6902#section-4.5\">4.5. copy</a>."
+              },
+              {
+                "value": "test",
+                "description": "Tests that a value at the target location is equal to a specified value. The operation object must contain a <code>value</code> parameter that defines the value to compare to the target location's value. For the operation to succeed, the target location must be equal to the <code>value</code> value. For test, <code>equal</code> indicates that the value at the target location and the value that <code>value</code> defines are of the same JSON type. The data type of the value determines how equality is defined:<table><thead align=\"left\"><tr><th>Type</th><th>Considered equal if both values</th></tr></thead><tbody align=\"left\"><tr><td><strong>strings</strong></td><td>Contain the same number of Unicode characters and their code points are byte-by-byte equal.</td></tr><tr><td><strong>numbers</strong></td><td>Are numerically equal.</td></tr><tr><td><strong>arrays</strong></td><td>Contain the same number of values, and each value is equal to the value at the corresponding position in the other array, by using these type-specific rules.</td></tr><tr><td><strong>objects</strong></td><td>Contain the same number of parameters, and each parameter is equal to a parameter in the other object, by comparing their keys (as strings) and their values (by using these type-specific rules).</td></tr><tr><td><strong>literals (<code>false</code>, <code>true</code>, and <code>null</code>)</strong></td><td>Are the same. The comparison is a logical comparison. For example, whitespace between the parameter values of an array is not significant. Also, ordering of the serialization of object parameters is not significant.</td></tr></tbody></table>For more information, see <a href=\"https://tools.ietf.org/html/rfc6902#section-4.6\">4.6. test</a>."
+              }
+            ],
+            "enum": ["add", "remove", "replace", "move", "copy", "test"]
+          },
+          "path": {
+            "type": "string",
+            "description": "The <a href=\"https://tools.ietf.org/html/rfc6901\">JSON Pointer</a> to the target document location at which to complete the operation."
+          },
+          "value": {
+            "title": "Patch Value",
+            "description": "The value to apply. The <code>remove</code>, <code>copy</code>, and <code>move</code> operations do not require a value. Since <a href=\"https://www.rfc-editor.org/rfc/rfc69021\">JSON Patch</a> allows any type for <code>value</code>, the <code>type</code> property is not specified."
+          },
+          "from": {
+            "type": "string",
+            "description": "The <a href=\"https://tools.ietf.org/html/rfc6901\">JSON Pointer</a> to the target document location from which to move the value. Required for the <code>move</code> operation."
+          }
+        },
+        "required": ["op"]
+      },
+      "patch_request": {
+        "type": "array",
+        "title": "Patch Request",
+        "description": "An array of JSON patch objects to apply partial updates to resources.",
+        "items": {
+          "$ref": "#/components/schemas/patch"
+        }
+      },
+      "payee_payment_method_preference": {
+        "type": "string",
+        "description": "The merchant-preferred payment methods.",
+        "minLength": 1,
+        "maxLength": 255,
+        "pattern": "^[0-9A-Z_]+$",
+        "default": "UNRESTRICTED",
+        "x-enumDescriptions": [
+          {
+            "value": "UNRESTRICTED",
+            "description": "Accepts any type of payment from the customer.",
+            "default": true
+          },
+          {
+            "value": "IMMEDIATE_PAYMENT_REQUIRED",
+            "description": "Accepts only immediate payment from the customer. For example, credit card, PayPal balance, or instant ACH. Ensures that at the time of capture, the payment does not have the `pending` status."
+          }
+        ],
+        "enum": ["UNRESTRICTED", "IMMEDIATE_PAYMENT_REQUIRED"]
+      },
+      "payer_base": {
+        "type": "object",
+        "title": "Payer Base",
+        "description": "The customer who approves and pays for the order. The customer is also known as the payer.",
+        "properties": {
+          "email_address": {
+            "description": "The email address of the payer.",
+            "$ref": "#/components/schemas/email"
+          },
+          "payer_id": {
+            "description": "The PayPal-assigned ID for the payer.",
+            "readOnly": true,
+            "$ref": "#/components/schemas/account_id"
+          }
+        }
+      },
+      "payment_preferences": {
+        "title": "Payment Preferences",
+        "description": "The payment preferences for a subscription.",
+        "type": "object",
+        "properties": {
+          "auto_bill_outstanding": {
+            "type": "boolean",
+            "description": "Indicates whether to automatically bill the outstanding amount in the next billing cycle.",
+            "default": true
+          },
+          "setup_fee": {
+            "description": "The initial set-up fee for the service.",
+            "$ref": "#/components/schemas/money"
+          },
+          "setup_fee_failure_action": {
+            "type": "string",
+            "description": "The action to take on the subscription if the initial payment for the setup fails.",
+            "minLength": 1,
+            "maxLength": 24,
+            "pattern": "^[A-Z_]+$",
+            "default": "CANCEL",
+            "x-enumDescriptions": [
+              {
+                "value": "CONTINUE",
+                "description": "Continues the subscription if the initial payment for the setup fails."
+              },
+              {
+                "value": "CANCEL",
+                "description": "Cancels the subscription if the initial payment for the setup fails."
+              }
+            ],
+            "enum": ["CONTINUE", "CANCEL"]
+          },
+          "payment_failure_threshold": {
+            "type": "integer",
+            "description": "The maximum number of payment failures before a subscription is suspended. For example, if `payment_failure_threshold` is `2`, the subscription automatically updates to the `SUSPEND` state if two consecutive payments fail.",
+            "minimum": 0,
+            "maximum": 999,
+            "default": 0
+          }
+        }
+      },
+      "payment_preferences_override": {
+        "title": "Payment Preferences Override",
+        "description": "The payment preferences to override at subscription level.",
+        "type": "object",
+        "properties": {
+          "auto_bill_outstanding": {
+            "type": "boolean",
+            "description": "Indicates whether to automatically bill the outstanding amount in the next billing cycle."
+          },
+          "setup_fee": {
+            "description": "The initial set-up fee for the service.",
+            "$ref": "#/components/schemas/money"
+          },
+          "setup_fee_failure_action": {
+            "type": "string",
+            "description": "The action to take on the subscription if the initial payment for the setup fails.",
+            "minLength": 1,
+            "maxLength": 24,
+            "pattern": "^[A-Z_]+$",
+            "x-enumDescriptions": [
+              {
+                "value": "CONTINUE",
+                "description": "Continues the subscription if the initial payment for the setup fails."
+              },
+              {
+                "value": "CANCEL",
+                "description": "Cancels the subscription if the initial payment for the setup fails."
+              }
+            ],
+            "enum": ["CONTINUE", "CANCEL"]
+          },
+          "payment_failure_threshold": {
+            "type": "integer",
+            "description": "The maximum number of payment failures before a subscription is suspended. For example, if `payment_failure_threshold` is `2`, the subscription automatically updates to the `SUSPEND` state if two consecutive payments fail.",
+            "minimum": 0,
+            "maximum": 999
+          }
+        }
+      },
+      "payment_source": {
+        "type": "object",
+        "title": "Payment Source",
+        "description": "The payment source definition. To be eligible to create subscription using debit or credit card, you will need to sign up here (https://www.paypal.com/bizsignup/entry/product/ppcp). Please note, its available only for non-3DS cards and for merchants in US and AU regions.",
+        "properties": {
+          "card": {
+            "type": "object",
+            "title": "Card",
+            "description": "The payment card to use to fund a payment. Can be a credit or debit card.",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The card holder's name as it appears on the card.",
+                "maxLength": 300,
+                "minLength": 1,
+                "pattern": "^.{1,300}$"
+              },
+              "number": {
+                "type": "string",
+                "description": "The primary account number (PAN) for the payment card.",
+                "pattern": "^[0-9]{13,19}$",
+                "minLength": 13,
+                "maxLength": 19
+              },
+              "expiry": {
+                "description": "The card expiration year and month, in [Internet date format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+                "$ref": "#/components/schemas/date_year_month"
+              },
+              "security_code": {
+                "type": "string",
+                "description": "The three- or four-digit security code of the card. Also known as the CVV, CVC, CVN, CVE, or CID. This parameter cannot be present in the request when `payment_initiator=MERCHANT`.",
+                "pattern": "^[0-9]{3,4}$",
+                "minLength": 3,
+                "maxLength": 4
+              },
+              "type": {
+                "description": "The payment card type.",
+                "$ref": "#/components/schemas/card_type"
+              },
+              "brand": {
+                "description": "The card brand or network. Typically used in the response.",
+                "$ref": "#/components/schemas/card_brand"
+              },
+              "billing_address": {
+                "description": "The portable international postal address. Maps to [AddressValidationMetadata](https://github.com/googlei18n/libaddressinput/wiki/AddressValidationMetadata) and HTML 5.1 [Autofilling form controls: the autocomplete attribute](https://www.w3.org/TR/html51/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).",
+                "type": "object",
+                "title": "Portable Postal Address (Medium-Grained)",
+                "properties": {
+                  "address_line_1": {
+                    "type": "string",
+                    "description": "The first line of the address, such as number and street, for example, `173 Drury Lane`. Needed for data entry, and Compliance and Risk checks. This field needs to pass the full address.",
+                    "maxLength": 300
+                  },
+                  "address_line_2": {
+                    "type": "string",
+                    "description": "The second line of the address, for example, a suite or apartment number.",
+                    "maxLength": 300
+                  },
+                  "admin_area_2": {
+                    "type": "string",
+                    "description": "A city, town, or village. Smaller than `admin_area_level_1`.",
+                    "maxLength": 120
+                  },
+                  "admin_area_1": {
+                    "type": "string",
+                    "description": "The highest-level sub-division in a country, which is usually a province, state, or ISO-3166-2 subdivision. This data is formatted for postal delivery, for example, `CA` and not `California`. Value, by country, is:<ul><li>UK. A county.</li><li>US. A state.</li><li>Canada. A province.</li><li>Japan. A prefecture.</li><li>Switzerland. A *kanton*.</li></ul>",
+                    "maxLength": 300
+                  },
+                  "postal_code": {
+                    "type": "string",
+                    "description": "The postal code, which is the ZIP code or equivalent. Typically required for countries with a postal code or an equivalent. See [postal code](https://en.wikipedia.org/wiki/Postal_code).",
+                    "maxLength": 60
+                  },
+                  "country_code": {
+                    "$ref": "#/components/schemas/country_code"
+                  }
+                },
+                "required": ["country_code"]
+              },
+              "attributes": {
+                "description": "Additional attributes associated with the use of this card.",
+                "$ref": "#/components/schemas/card_attributes"
+              }
+            }
+          }
+        }
+      },
+      "payment_source_response": {
+        "type": "object",
+        "title": "Payment Source Response",
+        "description": "The payment source used to fund the payment.",
+        "properties": {
+          "card": {
+            "$ref": "#/components/schemas/card_response_with_billing_address"
+          }
+        }
+      },
+      "percentage": {
+        "type": "string",
+        "description": "The percentage, as a fixed-point, signed decimal number. For example, define a 19.99% interest rate as `19.99`.",
+        "format": "ppaas_common_percentage_v2",
+        "pattern": "^((-?[0-9]+)|(-?([0-9]+)?[.][0-9]+))$"
+      },
+      "phone_type": {
+        "type": "string",
+        "title": "Phone Type",
+        "description": "The phone type.",
+        "enum": ["FAX", "HOME", "MOBILE", "OTHER", "PAGER"]
+      },
+      "phone_with_type": {
+        "type": "object",
+        "title": "Phone With Type",
+        "description": "The phone information.",
+        "properties": {
+          "phone_type": {
+            "$ref": "#/components/schemas/phone_type"
+          },
+          "phone_number": {
+            "description": "The phone number, in its canonical international [E.164 numbering plan format](https://www.itu.int/rec/T-REC-E.164/en).",
+            "type": "object",
+            "title": "Phone",
+            "properties": {
+              "national_number": {
+                "type": "string",
+                "description": "The national number, in its canonical international [E.164 numbering plan format](https://www.itu.int/rec/T-REC-E.164/en). The combined length of the country calling code (CC) and the national number must not be greater than 15 digits. The national number consists of a national destination code (NDC) and subscriber number (SN).",
+                "minLength": 1,
+                "maxLength": 14,
+                "pattern": "^[0-9]{1,14}?$"
+              }
+            },
+            "required": ["national_number"]
+          }
+        },
+        "required": ["phone_number"]
+      },
+      "plan": {
+        "title": "Plan",
+        "description": "The plan details.",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique PayPal-generated ID for the plan.",
+            "minLength": 26,
+            "maxLength": 26,
+            "pattern": "^P-[A-Z0-9]*$",
+            "readOnly": true
+          },
+          "product_id": {
+            "type": "string",
+            "description": "The ID for the product.",
+            "minLength": 22,
+            "maxLength": 22,
+            "pattern": "^PROD-[A-Z0-9]*$"
+          },
+          "name": {
+            "type": "string",
+            "description": "The plan name.",
+            "minLength": 1,
+            "maxLength": 127,
+            "pattern": "^.*$"
+          },
+          "status": {
+            "type": "string",
+            "description": "The plan status.",
+            "minLength": 1,
+            "maxLength": 24,
+            "pattern": "^[A-Z_]+$",
+            "x-enumDescriptions": [
+              {
+                "value": "CREATED",
+                "description": "The plan was created. You cannot create subscriptions for a plan in this state."
+              },
+              {
+                "value": "INACTIVE",
+                "description": "The plan is inactive."
+              },
+              {
+                "value": "ACTIVE",
+                "description": "The plan is active. You can only create subscriptions for a plan in this state."
+              }
+            ],
+            "enum": ["CREATED", "INACTIVE", "ACTIVE"]
+          },
+          "description": {
+            "type": "string",
+            "description": "The detailed description of the plan.",
+            "minLength": 1,
+            "maxLength": 127,
+            "pattern": "^.*$"
+          },
+          "billing_cycles": {
+            "$ref": "#/components/schemas/billing_cycle_list"
+          },
+          "payment_preferences": {
+            "$ref": "#/components/schemas/payment_preferences"
+          },
+          "taxes": {
+            "$ref": "#/components/schemas/taxes"
+          },
+          "quantity_supported": {
+            "type": "boolean",
+            "description": "Indicates whether you can subscribe to this plan by providing a quantity for the goods or service.",
+            "default": false
+          },
+          "create_time": {
+            "description": "The date and time when the plan was created, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+            "readOnly": true,
+            "$ref": "#/components/schemas/date_time"
+          },
+          "update_time": {
+            "description": "The date and time when the plan was last updated, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+            "readOnly": true,
+            "$ref": "#/components/schemas/date_time"
+          },
+          "links": {
+            "$ref": "#/components/schemas/link_description_list"
+          }
+        }
+      },
+      "plan_collection": {
+        "title": "Plan Collection",
+        "description": "The list of plans with details.",
+        "type": "object",
+        "properties": {
+          "plans": {
+            "$ref": "#/components/schemas/plan_list"
+          },
+          "total_items": {
+            "type": "integer",
+            "description": "The total number of items.",
+            "minimum": 0,
+            "maximum": 500000000
+          },
+          "total_pages": {
+            "type": "integer",
+            "description": "The total number of pages.",
+            "minimum": 0,
+            "maximum": 100000000
+          },
+          "links": {
+            "$ref": "#/components/schemas/link_description_list"
+          }
+        }
+      },
+      "plan_list": {
+        "type": "array",
+        "minItems": 0,
+        "maxItems": 32767,
+        "description": "An array of plans.",
+        "items": {
+          "$ref": "#/components/schemas/plan"
+        }
+      },
+      "plan_override": {
+        "title": "Plan Override",
+        "description": "An inline plan object to customise the subscription. You can override plan level default attributes by providing customised values for the subscription in this object.",
+        "type": "object",
+        "properties": {
+          "billing_cycles": {
+            "$ref": "#/components/schemas/billing_cycle_override_list"
+          },
+          "payment_preferences": {
+            "$ref": "#/components/schemas/payment_preferences_override"
+          },
+          "taxes": {
+            "$ref": "#/components/schemas/taxes_override"
+          }
+        }
+      },
+      "plan_request_POST": {
+        "title": "Create Plan Request",
+        "description": "The create plan request details.",
+        "type": "object",
+        "properties": {
+          "product_id": {
+            "type": "string",
+            "description": "The ID of the product created through Catalog Products API.",
+            "minLength": 22,
+            "maxLength": 22,
+            "pattern": "^PROD-[A-Z0-9]*$"
+          },
+          "name": {
+            "type": "string",
+            "description": "The plan name.",
+            "minLength": 1,
+            "maxLength": 127,
+            "pattern": "^.*$"
+          },
+          "status": {
+            "type": "string",
+            "description": "The initial state of the plan. Allowed input values are CREATED and ACTIVE.",
+            "minLength": 1,
+            "maxLength": 24,
+            "pattern": "^[A-Z_]+$",
+            "default": "ACTIVE",
+            "x-enumDescriptions": [
+              {
+                "value": "CREATED",
+                "description": "The plan was created. You cannot create subscriptions for a plan in this state."
+              },
+              {
+                "value": "INACTIVE",
+                "description": "The plan is inactive."
+              },
+              {
+                "value": "ACTIVE",
+                "description": "The plan is active. You can only create subscriptions for a plan in this state."
+              }
+            ],
+            "enum": ["CREATED", "INACTIVE", "ACTIVE"]
+          },
+          "description": {
+            "type": "string",
+            "description": "The detailed description of the plan.",
+            "minLength": 1,
+            "maxLength": 127,
+            "pattern": "^.*$"
+          },
+          "billing_cycles": {
+            "$ref": "#/components/schemas/billing_cycle_list"
+          },
+          "payment_preferences": {
+            "$ref": "#/components/schemas/payment_preferences"
+          },
+          "taxes": {
+            "$ref": "#/components/schemas/taxes"
+          },
+          "quantity_supported": {
+            "type": "boolean",
+            "description": "Indicates whether you can subscribe to this plan by providing a quantity for the goods or service.",
+            "default": false
+          }
+        },
+        "required": [
+          "name",
+          "billing_cycles",
+          "payment_preferences",
+          "product_id"
+        ]
+      },
+      "plans.activate-422": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "USER_ACCOUNT_CLOSED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["USER_ACCOUNT_CLOSED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["User account locked or closed."]
+                    }
+                  }
+                },
+                {
+                  "title": "PLAN_STATUS_INVALID",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["PLAN_STATUS_INVALID"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Invalid plan status for activate action; plan status should be either created or inactive."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "plans.create-400": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "INVALID_PARAMETER_SYNTAX",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PARAMETER_SYNTAX"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field does not conform to the expected format."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PARAMETER_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PARAMETER_VALUE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["The value of a field is invalid."]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_REQUIRED_PARAMETER",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["MISSING_REQUIRED_PARAMETER"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["A required field is missing."]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_STRING_MIN_LENGTH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_STRING_MIN_LENGTH"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["The value of a field is too short."]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_STRING_MAX_LENGTH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_STRING_MAX_LENGTH"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["The value of a field is too long."]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_INTEGER_MIN_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_INTEGER_MIN_VALUE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["The integer value of a field is too small."]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_INTEGER_MAX_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_INTEGER_MAX_VALUE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["The integer value of a field is too large."]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "plans.deactivate-422": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "USER_ACCOUNT_CLOSED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["USER_ACCOUNT_CLOSED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["User account locked or closed."]
+                    }
+                  }
+                },
+                {
+                  "title": "PLAN_STATUS_INVALID",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["PLAN_STATUS_INVALID"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Invalid plan status for deactivate action; plan status should be active."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "plans.patch-400": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "UNSUPPORTED_PATCH_OPERATION",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["UNSUPPORTED_PATCH_OPERATION"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The specified patch operation not supported for this field."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PATCH_PATH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PATCH_PATH"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["The specified field cannot be patched."]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PATCH_PATH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PATCH_PATH"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Multiple operations on the same field are not allowed."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PARAMETER_SYNTAX",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PARAMETER_SYNTAX"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field does not conform to the expected format."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PARAMETER_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PARAMETER_VALUE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["The value of a field is invalid."]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PARAMETER_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PARAMETER_VALUE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The field is not eligible for '$value' patch operation."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "plans.patch-422": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "USER_ACCOUNT_CLOSED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["USER_ACCOUNT_CLOSED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["User account locked or closed."]
+                    }
+                  }
+                },
+                {
+                  "title": "PLAN_STATUS_INACTIVE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["PLAN_STATUS_INACTIVE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Status update is the only patchable filed on an inactive plan."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "plans.update-pricing-schemes-400": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "INVALID_PARAMETER_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PARAMETER_VALUE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["The value of a field is invalid."]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_REQUIRED_PARAMETER",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["MISSING_REQUIRED_PARAMETER"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["A required field is missing."]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "plans.update-pricing-schemes-422": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "CURRENCY_MISMATCH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["CURRENCY_MISMATCH"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The currency code is different from the plan's currency code."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_BILLING_CYCLE_SEQUENCE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_BILLING_CYCLE_SEQUENCE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The provided billing cycle sequence is not available."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_SCHEME",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PRICING_SCHEME"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The new pricing scheme should be of the same type as that of the old one."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_TIER_AMOUNT",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PRICING_TIER_AMOUNT"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["Free tiers are not supported."]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_PRICING_SCHEME_TIERS",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["MISSING_PRICING_SCHEME_TIERS"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["Tier(s) are missing for some quantities."]
+                    }
+                  }
+                },
+                {
+                  "title": "OVERLAPPING_PRICING_SCHEME_TIERS",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["OVERLAPPING_PRICING_SCHEME_TIERS"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The specified quantity overlaps with multiple pricing tiers."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_MODEL",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PRICING_MODEL"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The specified pricing model is not supported for trial billing cycle."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "FIXED_PRICE_NOT_SUPPORTED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["FIXED_PRICE_NOT_SUPPORTED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Fixed price is not supported for tiered pricing schemes."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_TIER_QUANTITY",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PRICING_TIER_QUANTITY"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Tier starting quantity must be less than ending quantity."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "PRICING_SCHEME_UPDATE_NOT_ALLOWED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["PRICING_SCHEME_UPDATE_NOT_ALLOWED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Pricing scheme update is not allowed for the plan."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "pricing_scheme": {
+        "title": "Pricing Scheme",
+        "description": "The pricing scheme details.",
+        "type": "object",
+        "properties": {
+          "version": {
+            "type": "integer",
+            "description": "The version of the pricing scheme.",
+            "minimum": 0,
+            "maximum": 999,
+            "readOnly": true
+          },
+          "fixed_price": {
+            "description": "The fixed amount to charge for the subscription. The changes to fixed amount are applicable to both existing and future subscriptions. For existing subscriptions, payments within 10 days of price change are not affected.",
+            "$ref": "#/components/schemas/money"
+          },
+          "pricing_model": {
+            "type": "string",
+            "description": "The pricing model for tiered plan. The `tiers` parameter is required.",
+            "minLength": 1,
+            "maxLength": 24,
+            "pattern": "^[A-Z_]+$",
+            "x-enumDescriptions": [
+              {
+                "value": "VOLUME",
+                "description": "A volume pricing model."
+              },
+              {
+                "value": "TIERED",
+                "description": "A tiered pricing model."
+              }
+            ],
+            "enum": ["VOLUME", "TIERED"]
+          },
+          "tiers": {
+            "$ref": "#/components/schemas/pricing_tier_list"
+          },
+          "create_time": {
+            "description": "The date and time when this pricing scheme was created, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+            "readOnly": true,
+            "$ref": "#/components/schemas/date_time"
+          },
+          "update_time": {
+            "description": "The date and time when this pricing scheme was last updated, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+            "readOnly": true,
+            "$ref": "#/components/schemas/date_time"
+          }
+        }
+      },
+      "pricing_tier": {
+        "title": "Pricing Tier",
+        "description": "The pricing tier details.",
+        "type": "object",
+        "properties": {
+          "starting_quantity": {
+            "type": "string",
+            "description": "The starting quantity for the tier.",
+            "pattern": "^([0-9]+|([0-9]+)?[.][0-9]+)$",
+            "minLength": 1,
+            "maxLength": 32
+          },
+          "ending_quantity": {
+            "type": "string",
+            "description": "The ending quantity for the tier. Optional for the last tier.",
+            "pattern": "^([0-9]+|([0-9]+)?[.][0-9]+)$",
+            "minLength": 1,
+            "maxLength": 32
+          },
+          "amount": {
+            "description": "The pricing amount for the tier.",
+            "$ref": "#/components/schemas/money"
+          }
+        },
+        "required": ["starting_quantity", "amount"]
+      },
+      "pricing_tier_list": {
+        "type": "array",
+        "description": "An array of pricing tiers which are used for billing volume/tiered plans. pricing_model field has to be specified.",
+        "minItems": 1,
+        "maxItems": 32,
+        "items": {
+          "$ref": "#/components/schemas/pricing_tier"
+        }
+      },
+      "products": {
+        "type": "string",
+        "description": "This value provides the category of the BIN.",
+        "minLength": 1,
+        "maxLength": 255
+      },
+      "products_list": {
+        "type": "array",
+        "description": "The type of card product assigned to the BIN by the issuer. These values are defined by the issuer and may change over time. Some examples include: PREPAID_GIFT, CONSUMER, CORPORATE.",
+        "items": {
+          "$ref": "#/components/schemas/products"
+        },
+        "minItems": 1,
+        "maxItems": 256
+      },
+      "shipping_detail": {
+        "type": "object",
+        "description": "The shipping details.",
+        "title": "Shipping Details",
+        "properties": {
+          "name": {
+            "description": "The name of the party.",
+            "type": "object",
+            "title": "Name",
+            "properties": {
+              "full_name": {
+                "type": "string",
+                "description": "When the party is a person, the party's full name.",
+                "maxLength": 300
+              }
+            }
+          },
+          "type": {
+            "title": "Fullfillment Type",
+            "description": "A classification for the method of purchase fulfillment (e.g shipping, in-store pickup, etc). Either `type` or `options` may be present, but not both.",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "pattern": "^[0-9A-Z_]+$",
+            "x-enumDescriptions": [
+              {
+                "value": "SHIPPING",
+                "description": "The payer intends to receive the items at a specified address.",
+                "default": true
+              },
+              {
+                "value": "PICKUP_IN_PERSON",
+                "description": "DEPRECATED. Please use \"PICKUP_FROM_PERSON\" instead."
+              },
+              {
+                "value": "PICKUP_IN_STORE",
+                "description": "The payer intends to pick up the item(s) from the payee's physical store. Also termed as BOPIS, \"Buy Online, Pick-up in Store\". Seller protection is provided with this option."
+              },
+              {
+                "value": "PICKUP_FROM_PERSON",
+                "description": "The payer intends to pick up the item(s) from the payee in person. Also termed as BOPIP, \"Buy Online, Pick-up in Person\". Seller protection is not available, since the payer is receiving the item from the payee in person, and can validate the item prior to payment."
+              }
+            ],
+            "enum": [
+              "SHIPPING",
+              "PICKUP_IN_PERSON",
+              "PICKUP_IN_STORE",
+              "PICKUP_FROM_PERSON"
+            ]
+          },
+          "options": {
+            "$ref": "#/components/schemas/shipping_option_list"
+          },
+          "address": {
+            "description": "The portable international postal address. Maps to [AddressValidationMetadata](https://github.com/googlei18n/libaddressinput/wiki/AddressValidationMetadata) and HTML 5.1 [Autofilling form controls: the autocomplete attribute](https://www.w3.org/TR/html51/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).",
+            "type": "object",
+            "title": "Portable Postal Address (Medium-Grained)",
+            "properties": {
+              "address_line_1": {
+                "type": "string",
+                "description": "The first line of the address, such as number and street, for example, `173 Drury Lane`. Needed for data entry, and Compliance and Risk checks. This field needs to pass the full address.",
+                "maxLength": 300
+              },
+              "address_line_2": {
+                "type": "string",
+                "description": "The second line of the address, for example, a suite or apartment number.",
+                "maxLength": 300
+              },
+              "admin_area_2": {
+                "type": "string",
+                "description": "A city, town, or village. Smaller than `admin_area_level_1`.",
+                "maxLength": 120
+              },
+              "admin_area_1": {
+                "type": "string",
+                "description": "The highest-level sub-division in a country, which is usually a province, state, or ISO-3166-2 subdivision. This data is formatted for postal delivery, for example, `CA` and not `California`. Value, by country, is:<ul><li>UK. A county.</li><li>US. A state.</li><li>Canada. A province.</li><li>Japan. A prefecture.</li><li>Switzerland. A *kanton*.</li></ul>",
+                "maxLength": 300
+              },
+              "postal_code": {
+                "type": "string",
+                "description": "The postal code, which is the ZIP code or equivalent. Typically required for countries with a postal code or an equivalent. See [postal code](https://en.wikipedia.org/wiki/Postal_code).",
+                "maxLength": 60
+              },
+              "country_code": {
+                "$ref": "#/components/schemas/country_code"
+              }
+            },
+            "required": ["country_code"]
+          }
+        }
+      },
+      "shipping_option": {
+        "type": "object",
+        "title": "Shipping Option",
+        "description": "The options that the payee or merchant offers to the payer to ship or pick up their items.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "A unique ID that identifies a payer-selected shipping option.",
+            "maxLength": 127
+          },
+          "label": {
+            "type": "string",
+            "description": "A description that the payer sees, which helps them choose an appropriate shipping option. For example, `Free Shipping`, `USPS Priority Shipping`, `Expédition prioritaire USPS`, or `USPS yōuxiān fā huò`. Localize this description to the payer's locale.",
+            "maxLength": 127
+          },
+          "type": {
+            "description": "A classification for the method of purchase fulfillment.",
+            "$ref": "#/components/schemas/shipping_type"
+          },
+          "amount": {
+            "description": "The shipping cost for the selected option.",
+            "$ref": "#/components/schemas/money"
+          },
+          "selected": {
+            "type": "boolean",
+            "description": "If the API request sets `selected = true`, it represents the shipping option that the payee or merchant expects to be pre-selected for the payer when they first view the `shipping.options` in the PayPal Checkout experience. As part of the response if a `shipping.option` contains `selected=true`, it represents the shipping option that the payer selected during the course of checkout with PayPal. Only one `shipping.option` can be set to `selected=true`."
+          }
+        },
+        "required": ["id", "label", "selected"]
+      },
+      "shipping_option_list": {
+        "type": "array",
+        "description": "An array of shipping options that the payee or merchant offers to the payer to ship or pick up their items.",
+        "minItems": 0,
+        "maxItems": 10,
+        "items": {
+          "$ref": "#/components/schemas/shipping_option"
+        }
+      },
+      "shipping_type": {
+        "type": "string",
+        "title": "Shipping Type",
+        "description": "A classification for the method of purchase fulfillment.",
+        "x-enumDescriptions": [
+          {
+            "value": "SHIPPING",
+            "description": "The payer intends to receive the items at a specified address.",
+            "default": true
+          },
+          {
+            "value": "PICKUP",
+            "description": "DEPRECATED. To ensure that seller protection is correctly assigned, please use 'PICKUP_IN_STORE' or 'PICKUP_FROM_PERSON' instead. Currently, this field indicates that the payer intends to pick up the items at a specified address (ie. a store address). "
+          },
+          {
+            "value": "PICKUP_IN_STORE",
+            "description": "The payer intends to pick up the item(s) from the payee's physical store. Also termed as BOPIS, \"Buy Online, Pick-up in Store\". Seller protection is provided with this option."
+          },
+          {
+            "value": "PICKUP_FROM_PERSON",
+            "description": "The payer intends to pick up the item(s) from the payee in person. Also termed as BOPIP, \"Buy Online, Pick-up in Person\". Seller protection is not available, since the payer is receiving the item from the payee in person, and can validate the item prior to payment."
+          }
+        ],
+        "enum": ["SHIPPING", "PICKUP", "PICKUP_IN_STORE", "PICKUP_FROM_PERSON"]
+      },
+      "store_in_vault_instruction": {
+        "type": "string",
+        "description": "Defines how and when the payment source gets vaulted.",
+        "minLength": 1,
+        "maxLength": 255,
+        "pattern": "^[0-9A-Z_]+$",
+        "x-enumDescriptions": [
+          {
+            "value": "ON_SUCCESS",
+            "description": "Defines that the payment_source will be vaulted only when at least one authorization or capture using that payment_source is successful."
+          }
+        ],
+        "enum": ["ON_SUCCESS"]
+      },
+      "subscriber": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/payer_base"
+          },
+          {
+            "properties": {
+              "name": {
+                "description": "The name of the party.",
+                "type": "object",
+                "title": "Name",
+                "properties": {
+                  "given_name": {
+                    "type": "string",
+                    "description": "When the party is a person, the party's given, or first, name.",
+                    "maxLength": 140
+                  },
+                  "surname": {
+                    "type": "string",
+                    "description": "When the party is a person, the party's surname or family name. Also known as the last name. Required when the party is a person. Use also to store multiple surnames including the matronymic, or mother's, surname.",
+                    "maxLength": 140
+                  }
+                }
+              },
+              "phone": {
+                "description": "The phone number of the customer. Available only when you enable the **Contact Telephone Number** option in the <a href=\"https://www.paypal.com/cgi-bin/customerprofileweb?cmd=_profile-website-payments\">**Profile & Settings**</a> for the merchant's PayPal account. The `phone.phone_number` supports only `national_number`.",
+                "$ref": "#/components/schemas/phone_with_type"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "title": "Payer",
+            "description": "The customer who approves and pays for the order. The customer is also known as the payer.",
+            "format": "payer_v1"
+          },
+          {
+            "properties": {
+              "shipping_address": {
+                "$ref": "#/components/schemas/shipping_detail"
+              },
+              "payment_source": {
+                "$ref": "#/components/schemas/payment_source_response"
+              }
+            }
+          },
+          {
+            "title": "Subscriber Response Information",
+            "description": "The subscriber response information.",
+            "type": "object"
+          }
+        ]
+      },
+      "subscriber_request": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/payer_base"
+          },
+          {
+            "properties": {
+              "name": {
+                "description": "The name of the party.",
+                "type": "object",
+                "title": "Name",
+                "properties": {
+                  "given_name": {
+                    "type": "string",
+                    "description": "When the party is a person, the party's given, or first, name.",
+                    "maxLength": 140
+                  },
+                  "surname": {
+                    "type": "string",
+                    "description": "When the party is a person, the party's surname or family name. Also known as the last name. Required when the party is a person. Use also to store multiple surnames including the matronymic, or mother's, surname.",
+                    "maxLength": 140
+                  }
+                }
+              },
+              "phone": {
+                "description": "The phone number of the customer. Available only when you enable the **Contact Telephone Number** option in the <a href=\"https://www.paypal.com/cgi-bin/customerprofileweb?cmd=_profile-website-payments\">**Profile & Settings**</a> for the merchant's PayPal account. The `phone.phone_number` supports only `national_number`.",
+                "$ref": "#/components/schemas/phone_with_type"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "title": "Payer",
+            "description": "The customer who approves and pays for the order. The customer is also known as the payer.",
+            "format": "payer_v1"
+          },
+          {
+            "properties": {
+              "shipping_address": {
+                "$ref": "#/components/schemas/shipping_detail"
+              },
+              "payment_source": {
+                "$ref": "#/components/schemas/payment_source"
+              }
+            }
+          },
+          {
+            "title": "Subscriber Request Information",
+            "description": "The subscriber request information .",
+            "type": "object"
+          }
+        ]
+      },
+      "subscription": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/subscription_status"
+          },
+          {},
+          {
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "The PayPal-generated ID for the subscription.",
+                "minLength": 3,
+                "maxLength": 50,
+                "readOnly": true
+              },
+              "plan_id": {
+                "type": "string",
+                "description": "The ID of the plan.",
+                "minLength": 3,
+                "maxLength": 50
+              },
+              "start_time": {
+                "$ref": "#/components/schemas/date_time"
+              },
+              "quantity": {
+                "type": "string",
+                "description": "The quantity of the product in the subscription.",
+                "pattern": "^([0-9]+|([0-9]+)?[.][0-9]+)$",
+                "minLength": 1,
+                "maxLength": 32
+              },
+              "shipping_amount": {
+                "$ref": "#/components/schemas/money"
+              },
+              "subscriber": {
+                "$ref": "#/components/schemas/subscriber"
+              },
+              "billing_info": {
+                "readOnly": true,
+                "$ref": "#/components/schemas/subscription_billing_info"
+              },
+              "create_time": {
+                "readOnly": true,
+                "$ref": "#/components/schemas/date_time"
+              },
+              "update_time": {
+                "readOnly": true,
+                "$ref": "#/components/schemas/date_time"
+              },
+              "custom_id": {
+                "type": "string",
+                "description": "The custom id for the subscription. Can be invoice id.",
+                "minLength": 1,
+                "maxLength": 127,
+                "pattern": "^[\\x20-\\x7E]+"
+              },
+              "plan_overridden": {
+                "type": "boolean",
+                "description": "Indicates whether the subscription has overridden any plan attributes.",
+                "readOnly": true
+              },
+              "plan": {
+                "description": "The plan details.",
+                "title": "Plan",
+                "type": "object",
+                "properties": {
+                  "product_id": {
+                    "type": "string",
+                    "description": "The ID for the product.",
+                    "minLength": 22,
+                    "maxLength": 22,
+                    "pattern": "^PROD-[A-Z0-9]*$"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "The plan name.",
+                    "minLength": 1,
+                    "maxLength": 127,
+                    "pattern": "^.*$"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "The detailed description of the plan.",
+                    "minLength": 1,
+                    "maxLength": 127,
+                    "pattern": "^.*$"
+                  },
+                  "billing_cycles": {
+                    "$ref": "#/components/schemas/billing_cycle_list"
+                  },
+                  "payment_preferences": {
+                    "$ref": "#/components/schemas/payment_preferences"
+                  },
+                  "taxes": {
+                    "$ref": "#/components/schemas/taxes"
+                  },
+                  "quantity_supported": {
+                    "type": "boolean",
+                    "description": "Indicates whether you can subscribe to this plan by providing a quantity for the goods or service.",
+                    "default": false
+                  }
+                }
+              },
+              "links": {
+                "$ref": "#/components/schemas/link_description_list"
+              }
+            }
+          },
+          {
+            "title": "Subscription",
+            "description": "The subscription details.",
+            "type": "object"
+          }
+        ]
+      },
+      "subscription_activate_request": {
+        "title": "Activate Subscription Request",
+        "description": "The activate subscription request details.",
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "description": "The reason for activation of a subscription. Required to reactivate the subscription.",
+            "minLength": 1,
+            "maxLength": 128,
+            "pattern": "^.*$"
+          }
+        }
+      },
+      "subscription_billing_info": {
+        "title": "Subscription Billing Information",
+        "description": "The billing details for the subscription. If the subscription was or is active, these fields are populated.",
+        "type": "object",
+        "properties": {
+          "outstanding_balance": {
+            "description": "The total pending bill amount, to be paid by the subscriber.",
+            "$ref": "#/components/schemas/money"
+          },
+          "cycle_executions": {
+            "$ref": "#/components/schemas/cycle_execution_list"
+          },
+          "last_payment": {
+            "readOnly": true,
+            "description": "The details for the last payment of the subscription.",
+            "$ref": "#/components/schemas/last_payment_details"
+          },
+          "next_billing_time": {
+            "description": "The next date and time for billing this subscription, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+            "readOnly": true,
+            "$ref": "#/components/schemas/date_time"
+          },
+          "final_payment_time": {
+            "description": "The date and time when the final billing cycle occurs, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+            "readOnly": true,
+            "$ref": "#/components/schemas/date_time"
+          },
+          "failed_payments_count": {
+            "type": "integer",
+            "description": "The number of consecutive payment failures. Resets to `0` after a successful payment. If this reaches the `payment_failure_threshold` value, the subscription updates to the `SUSPENDED` state.",
+            "minimum": 0,
+            "maximum": 999,
+            "readOnly": true
+          },
+          "last_failed_payment": {
+            "description": "The details for the last failed payment of the subscription.",
+            "readOnly": true,
+            "$ref": "#/components/schemas/failed_payment_details"
+          }
+        },
+        "required": ["outstanding_balance", "failed_payments_count"]
+      },
+      "subscription_cancel_request": {
+        "title": "Cancel Subscription Request",
+        "description": "The cancel subscription request details.",
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "description": "The reason for the cancellation of a subscription.",
+            "minLength": 1,
+            "maxLength": 128,
+            "pattern": "^.*$"
+          }
+        },
+        "required": ["reason"]
+      },
+      "subscription_capture_request": {
+        "title": "Charge Amount from Subscriber",
+        "description": "The charge amount from the subscriber.",
+        "type": "object",
+        "properties": {
+          "note": {
+            "type": "string",
+            "description": "The reason or note for the subscription charge.",
+            "minLength": 1,
+            "maxLength": 128,
+            "pattern": "^.*$"
+          },
+          "capture_type": {
+            "type": "string",
+            "description": "The type of capture.",
+            "minLength": 1,
+            "maxLength": 24,
+            "pattern": "^[A-Z_]+$",
+            "x-enumDescriptions": [
+              {
+                "value": "OUTSTANDING_BALANCE",
+                "description": "The outstanding balance that the subscriber must clear."
+              }
+            ],
+            "enum": ["OUTSTANDING_BALANCE"]
+          },
+          "amount": {
+            "$ref": "#/components/schemas/money",
+            "description": "The amount of the outstanding balance. This value cannot be greater than the current outstanding balance amount."
+          }
+        },
+        "required": ["note", "capture_type", "amount"]
+      },
+      "subscription_request_post": {
+        "title": "Create Subscription Request",
+        "description": "The create subscription request details.",
+        "type": "object",
+        "properties": {
+          "plan_id": {
+            "type": "string",
+            "description": "The ID of the plan.",
+            "minLength": 26,
+            "maxLength": 26,
+            "pattern": "^P-[A-Z0-9]*$"
+          },
+          "start_time": {
+            "description": "The date and time when the subscription started, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+            "default": "Current time",
+            "$ref": "#/components/schemas/date_time"
+          },
+          "quantity": {
+            "type": "string",
+            "description": "The quantity of the product in the subscription.",
+            "pattern": "^([0-9]+|([0-9]+)?[.][0-9]+)$",
+            "minLength": 1,
+            "maxLength": 32
+          },
+          "shipping_amount": {
+            "description": "The shipping charges.",
+            "$ref": "#/components/schemas/money"
+          },
+          "subscriber": {
+            "$ref": "#/components/schemas/subscriber_request"
+          },
+          "auto_renewal": {
+            "type": "boolean",
+            "description": "DEPRECATED. Indicates whether the subscription auto-renews after the billing cycles complete.",
+            "default": false,
+            "deprecated": true
+          },
+          "application_context": {
+            "$ref": "#/components/schemas/application_context"
+          },
+          "custom_id": {
+            "type": "string",
+            "description": "The custom id for the subscription. Can be invoice id.",
+            "minLength": 1,
+            "maxLength": 127,
+            "pattern": "^[\\x20-\\x7E]+"
+          },
+          "plan": {
+            "description": "An inline plan object to customise the subscription. You can override plan level default attributes by providing customised values for the subscription in this object.",
+            "$ref": "#/components/schemas/plan_override"
+          },
+          "merchant_inventory": {
+            "description": "Merchant's inventory identifier details for the WPS hosted button.",
+            "$ref": "#/components/schemas/merchant_inventory"
+          }
+        },
+        "required": ["plan_id"]
+      },
+      "subscription_revise_request": {
+        "title": "Subscription Modify Plan Request",
+        "description": "The request to update the quantity of the product or service in a subscription. You can also use this method to switch the plan and update the `shipping_amount` and `shipping_address` values for the subscription. This type of update requires the buyer's consent.",
+        "type": "object",
+        "properties": {
+          "plan_id": {
+            "type": "string",
+            "description": "The unique PayPal-generated ID for the plan.",
+            "minLength": 26,
+            "maxLength": 26,
+            "pattern": "^P-[A-Z0-9]*$"
+          },
+          "quantity": {
+            "type": "string",
+            "description": "The quantity of the product or service in the subscription.",
+            "pattern": "^([0-9]+|([0-9]+)?[.][0-9]+)$",
+            "minLength": 1,
+            "maxLength": 32
+          },
+          "shipping_amount": {
+            "description": "The shipping charges.",
+            "$ref": "#/components/schemas/money"
+          },
+          "shipping_address": {
+            "description": "The shipping address of the subscriber.",
+            "$ref": "#/components/schemas/shipping_detail"
+          },
+          "application_context": {
+            "title": "Application Context",
+            "description": "The application context, which customizes the payer experience during the subscription approval process with PayPal.",
+            "type": "object",
+            "properties": {
+              "brand_name": {
+                "type": "string",
+                "description": "The label that overrides the business name in the PayPal account on the PayPal site.",
+                "minLength": 1,
+                "maxLength": 127,
+                "pattern": "^.*$"
+              },
+              "locale": {
+                "description": "The BCP 47-formatted locale of pages that the PayPal payment experience shows. PayPal supports a five-character code. For example, `da-DK`, `he-IL`, `id-ID`, `ja-JP`, `no-NO`, `pt-BR`, `ru-RU`, `sv-SE`, `th-TH`, `zh-CN`, `zh-HK`, or `zh-TW`.",
+                "$ref": "#/components/schemas/language"
+              },
+              "shipping_preference": {
+                "type": "string",
+                "description": "The location from which the shipping address is derived.",
+                "minLength": 1,
+                "maxLength": 24,
+                "pattern": "^[A-Z_]+$",
+                "default": "GET_FROM_FILE",
+                "x-enumDescriptions": [
+                  {
+                    "value": "GET_FROM_FILE",
+                    "description": "Get the customer-provided shipping address on the PayPal site.",
+                    "default": true
+                  },
+                  {
+                    "value": "NO_SHIPPING",
+                    "description": "Redacts the shipping address from the PayPal site. Recommended for digital goods."
+                  },
+                  {
+                    "value": "SET_PROVIDED_ADDRESS",
+                    "description": "Get the merchant-provided address. The customer cannot change this address on the PayPal site. If merchant does not pass an address, customer can choose the address on PayPal pages."
+                  }
+                ],
+                "enum": ["GET_FROM_FILE", "NO_SHIPPING", "SET_PROVIDED_ADDRESS"]
+              },
+              "payment_method": {
+                "description": "The customer and merchant payment preferences.",
+                "type": "object",
+                "title": "Payment Method",
+                "properties": {
+                  "payee_preferred": {
+                    "$ref": "#/components/schemas/payee_payment_method_preference"
+                  }
+                }
+              },
+              "return_url": {
+                "type": "string",
+                "format": "uri",
+                "description": "The URL where the customer is redirected after the customer approves the payment.",
+                "minLength": 10,
+                "maxLength": 4000
+              },
+              "cancel_url": {
+                "type": "string",
+                "format": "uri",
+                "description": "The URL where the customer is redirected after the customer cancels the payment.",
+                "minLength": 10,
+                "maxLength": 4000
+              }
+            },
+            "required": ["return_url", "cancel_url"]
+          },
+          "plan": {
+            "description": "An inline plan object to customise the subscription. You can override plan level default attributes by providing customised values for the subscription in this object. Any existing overrides will not be carried forward during subscription revise.",
+            "$ref": "#/components/schemas/plan_override"
+          }
+        }
+      },
+      "subscription_revise_response": {
+        "title": "Update Product Quantity in Subscription Response",
+        "description": "The response to a request to update the quantity of the product or service in a subscription. You can also use this method to switch the plan and update the `shipping_amount` and `shipping_address` values for the subscription. This type of update requires the buyer's consent.",
+        "type": "object",
+        "properties": {
+          "plan_id": {
+            "type": "string",
+            "description": "The unique PayPal-generated ID for the plan.",
+            "minLength": 26,
+            "maxLength": 26,
+            "pattern": "^P-[A-Z0-9]*$"
+          },
+          "quantity": {
+            "type": "string",
+            "description": "The quantity of the product or service in the subscription.",
+            "pattern": "^([0-9]+|([0-9]+)?[.][0-9]+)$",
+            "minLength": 1,
+            "maxLength": 32
+          },
+          "shipping_amount": {
+            "description": "The shipping charges.",
+            "$ref": "#/components/schemas/money"
+          },
+          "shipping_address": {
+            "description": "The shipping address of the subscriber.",
+            "$ref": "#/components/schemas/shipping_detail"
+          },
+          "plan": {
+            "description": "An inline plan object to customise the subscription. You can override plan level default attributes by providing customised values for the subscription in this object. Any existing overrides will not be carried forward during subscription revise.",
+            "$ref": "#/components/schemas/plan_override"
+          },
+          "plan_overridden": {
+            "type": "boolean",
+            "description": "Indicates whether the subscription has overridden any plan attributes.",
+            "readOnly": true
+          },
+          "links": {
+            "$ref": "#/components/schemas/subscription_revise_response_definitions-link_description_list"
+          }
+        }
+      },
+      "subscription_revise_response_definitions-link_description_list": {
+        "type": "array",
+        "description": "An array of request-related [HATEOAS links](/docs/api/reference/api-responses/#hateoas-links).",
+        "readOnly": true,
+        "items": {
+          "$ref": "#/components/schemas/link_description"
+        }
+      },
+      "subscription_status": {
+        "title": "Subscription Status",
+        "description": "The subscription status details.",
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "The status of the subscription.",
+            "minLength": 1,
+            "maxLength": 24,
+            "pattern": "^[A-Z_]+$",
+            "x-enumDescriptions": [
+              {
+                "value": "APPROVAL_PENDING",
+                "description": "The subscription is created but not yet approved by the buyer."
+              },
+              {
+                "value": "APPROVED",
+                "description": "The buyer has approved the subscription."
+              },
+              {
+                "value": "ACTIVE",
+                "description": "The subscription is active."
+              },
+              {
+                "value": "SUSPENDED",
+                "description": "The subscription is suspended."
+              },
+              {
+                "value": "CANCELLED",
+                "description": "The subscription is cancelled."
+              },
+              {
+                "value": "EXPIRED",
+                "description": "The subscription is expired."
+              }
+            ],
+            "enum": [
+              "APPROVAL_PENDING",
+              "APPROVED",
+              "ACTIVE",
+              "SUSPENDED",
+              "CANCELLED",
+              "EXPIRED"
+            ]
+          },
+          "status_change_note": {
+            "type": "string",
+            "description": "The reason or notes for the status of the subscription.",
+            "minLength": 1,
+            "maxLength": 128,
+            "pattern": "^.*$"
+          },
+          "status_update_time": {
+            "readOnly": true,
+            "$ref": "#/components/schemas/date_time"
+          }
+        }
+      },
+      "subscription_suspend_request": {
+        "title": "Suspend Subscription",
+        "description": "The suspend subscription request details.",
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "description": "The reason for suspension of the Subscription.",
+            "minLength": 1,
+            "maxLength": 128,
+            "pattern": "^.*$"
+          }
+        },
+        "required": ["reason"]
+      },
+      "subscriptions.activate-400": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "INVALID_STRING_MAX_LENGTH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_STRING_MAX_LENGTH"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["The value of a field is too long."]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.activate-422": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "USER_ACCOUNT_CLOSED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["USER_ACCOUNT_CLOSED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["User account locked or closed."]
+                    }
+                  }
+                },
+                {
+                  "title": "SUBSCRIPTION_STATUS_INVALID",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["SUBSCRIPTION_STATUS_INVALID"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Invalid subscription status for activate action; subscription status should be suspended."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "SUBSCRIPTION_CANNOT_BE_ACTIVATED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["SUBSCRIPTION_CANNOT_BE_ACTIVATED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Subscription cannot be activated after payment failure threshold has reached."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "SUBSCRIPTION_CANNOT_BE_ACTIVATED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["SUBSCRIPTION_CANNOT_BE_ACTIVATED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "This subscription should be activated by the system."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "SUBSCRIPTION_CANNOT_BE_ACTIVATED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["SUBSCRIPTION_CANNOT_BE_ACTIVATED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "This subscription should be activated by the merchant."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.cancel-400": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "INVALID_STRING_MAX_LENGTH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_STRING_MAX_LENGTH"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["The value of a field is too long."]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.cancel-422": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "USER_ACCOUNT_CLOSED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["USER_ACCOUNT_CLOSED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["User account locked or closed."]
+                    }
+                  }
+                },
+                {
+                  "title": "SUBSCRIPTION_STATUS_INVALID",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["SUBSCRIPTION_STATUS_INVALID"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Invalid subscription status for cancel action; subscription status should be active or suspended."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.capture-400": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "MISSING_REQUEST_BODY",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["MISSING_REQUEST_BODY"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["Request body is missing."]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PARAMETER_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PARAMETER_VALUE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["The value of a field is invalid."]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_STRING_MAX_LENGTH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_STRING_MAX_LENGTH"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["The value of a field is too long."]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_REQUIRED_PARAMETER",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["MISSING_REQUIRED_PARAMETER"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["A required field is missing."]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.capture-422": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "USER_ACCOUNT_CLOSED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["USER_ACCOUNT_CLOSED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["User account locked or closed."]
+                    }
+                  }
+                },
+                {
+                  "title": "SUBSCRIBER_ACCOUNT_LOCKED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["SUBSCRIBER_ACCOUNT_LOCKED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["Subscriber Account Locked."]
+                    }
+                  }
+                },
+                {
+                  "title": "SUBSCRIBER_ACCOUNT_CLOSED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["SUBSCRIBER_ACCOUNT_CLOSED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["Subscriber Account Closed."]
+                    }
+                  }
+                },
+                {
+                  "title": "SUBSCRIBER_ACCOUNT_RESTRICTED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["SUBSCRIBER_ACCOUNT_RESTRICTED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["Subscriber Account Restricted."]
+                    }
+                  }
+                },
+                {
+                  "title": "SUBSCRIPTION_STATUS_INVALID",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["SUBSCRIPTION_STATUS_INVALID"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Invalid subscription status for capture action; subscription status should be active or suspended or expired."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "ZERO_OUTSTANDING_BALANCE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["ZERO_OUTSTANDING_BALANCE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Current outstanding balance should be greater than zero."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "CURRENCY_MISMATCH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["CURRENCY_MISMATCH"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The currency code is different from the subscription's currency code."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "AMOUNT_GREATER_THAN_OUTSTANDING_BALANCE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["AMOUNT_GREATER_THAN_OUTSTANDING_BALANCE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The capture amount can not be greater than the current outstanding balance."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.create-400": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "INVALID_PARAMETER_SYNTAX",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PARAMETER_SYNTAX"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field does not conform to the expected format."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_STRING_MAX_LENGTH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_STRING_MAX_LENGTH"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["The value of a field is too long."]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PARAMETER_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PARAMETER_VALUE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["The value of a field is invalid."]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_INTEGER_MIN_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_INTEGER_MIN_VALUE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["The integer value of a field is too small."]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_INTEGER_MAX_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_INTEGER_MAX_VALUE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["The integer value of a field is too large."]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PARAMETER_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PARAMETER_VALUE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Start time must be a valid future date and time."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_REQUEST_BODY",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["MISSING_REQUEST_BODY"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["Request body is missing."]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_REQUIRED_PARAMETER",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["MISSING_REQUIRED_PARAMETER"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["A required field is missing."]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_STRING_MAX_LENGTH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_STRING_MAX_LENGTH"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["The value of a field is too long."]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.create-422": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "USER_ACCOUNT_CLOSED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["USER_ACCOUNT_CLOSED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["User account locked or closed."]
+                    }
+                  }
+                },
+                {
+                  "title": "PLAN_STATUS_INVALID",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["PLAN_STATUS_INVALID"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Invalid plan status for subscription creation; plan status should be active."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "SUBSCRIPTION_CANNOT_HAVE_QUANTITY",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["SUBSCRIPTION_CANNOT_HAVE_QUANTITY"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Subscription can't have quantity as the plan does not support quantity."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "CARD_SUBSCRIPTIONS_NOT_ENABLED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["CARD_SUBSCRIPTIONS_NOT_ENABLED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The account is not setup to be able to process subscriptions funded by card payments. Please contact PayPal customer support."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "3DS_CARDS_NOT_SUPPORTED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["3DS_CARDS_NOT_SUPPORTED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Cards that require 3DS authentication not supported."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_BILLING_CYCLE_SEQUENCE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_BILLING_CYCLE_SEQUENCE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The provided billing cycle sequence is not available."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_SCHEME",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PRICING_SCHEME"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The override plan pricing scheme should be of the same type as that of the original plan."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_TIER_AMOUNT",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PRICING_TIER_AMOUNT"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["Free tiers are not supported."]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_PRICING_SCHEME_TIERS",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["MISSING_PRICING_SCHEME_TIERS"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["Tier(s) are missing for some quantities."]
+                    }
+                  }
+                },
+                {
+                  "title": "OVERLAPPING_PRICING_SCHEME_TIERS",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["OVERLAPPING_PRICING_SCHEME_TIERS"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The specified quantity overlaps with multiple pricing tiers."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_MODEL",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PRICING_MODEL"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The specified pricing model is not supported for trial billing cycle."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "FIXED_PRICE_NOT_SUPPORTED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["FIXED_PRICE_NOT_SUPPORTED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Fixed price is not supported for tiered pricing schemes."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_TIER_QUANTITY",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PRICING_TIER_QUANTITY"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Tier starting quantity must be less than ending quantity."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "CURRENCY_MISMATCH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["CURRENCY_MISMATCH"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The currency code is different from the plan's currency code."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.patch-400": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "UNSUPPORTED_PATCH_OPERATION",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["UNSUPPORTED_PATCH_OPERATION"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The specified patch operation not supported for this field."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PATCH_PATH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PATCH_PATH"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["The specified field cannot be patched."]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PATCH_PATH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PATCH_PATH"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Multiple operations on the same field are not allowed."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PARAMETER_SYNTAX",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PARAMETER_SYNTAX"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field does not conform to the expected format."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PARAMETER_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PARAMETER_VALUE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["The value of a field is invalid."]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_STRING_MAX_LENGTH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_STRING_MAX_LENGTH"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["The value of a field is too long."]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_STRING_MIN_LENGTH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_STRING_MIN_LENGTH"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["The value of a field is too short."]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_INTEGER_MIN_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_INTEGER_MIN_VALUE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["The integer value of a field is too small."]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_INTEGER_MAX_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_INTEGER_MAX_VALUE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["The integer value of a field is too large."]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_REQUEST_BODY",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["MISSING_REQUEST_BODY"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["Request body is missing."]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_REQUIRED_PARAMETER",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["MISSING_REQUIRED_PARAMETER"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["A required field is missing."]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.patch-422": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "USER_ACCOUNT_CLOSED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["USER_ACCOUNT_CLOSED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["User account locked or closed."]
+                    }
+                  }
+                },
+                {
+                  "title": "SUBSCRIPTION_STATUS_INVALID",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["SUBSCRIPTION_STATUS_INVALID"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Invalid subscription status for patch action; subscription status should be either active or suspended."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "CARD_SUBSCRIPTIONS_NOT_ENABLED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["CARD_SUBSCRIPTIONS_NOT_ENABLED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The account is not setup to be able to process subscriptions funded by card payments. Please contact PayPal customer support."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "3DS_CARDS_NOT_SUPPORTED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["3DS_CARDS_NOT_SUPPORTED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Cards that require 3DS authentication not supported."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "BILLING_CYCLE_EXECUTION_COMPLETED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["BILLING_CYCLE_EXECUTION_COMPLETED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Update cannot be performed on a billing cycle that has completed execution."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "AMOUNT_GREATER_THAN_OUTSTANDING_BALANCE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["AMOUNT_GREATER_THAN_OUTSTANDING_BALANCE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The new outstanding balance cannot be greater than the current outstanding balance."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_BILLING_TOTAL_CYCLES",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_BILLING_TOTAL_CYCLES"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The total cycles cannot be less than the number of billing cycles completed."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_TIER_AMOUNT",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PRICING_TIER_AMOUNT"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["Free tiers are not supported."]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_PRICING_SCHEME_TIERS",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["MISSING_PRICING_SCHEME_TIERS"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["Tier(s) are missing for some quantities."]
+                    }
+                  }
+                },
+                {
+                  "title": "OVERLAPPING_PRICING_SCHEME_TIERS",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["OVERLAPPING_PRICING_SCHEME_TIERS"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The specified quantity overlaps with multiple pricing tiers."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_MODEL",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PRICING_MODEL"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The specified pricing model is not supported for trial billing cycle."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "FIXED_PRICE_NOT_SUPPORTED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["FIXED_PRICE_NOT_SUPPORTED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Fixed price is not supported for tiered pricing schemes."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_TIER_QUANTITY",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PRICING_TIER_QUANTITY"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Tier starting quantity must be less than ending quantity."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_START_TIME",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_START_TIME"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The start time cannot be updated for a subscription that has been activated."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "CURRENCY_MISMATCH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["CURRENCY_MISMATCH"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The currency code is different from the subscription's currency code."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.revise-400": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "INVALID_PARAMETER_SYNTAX",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PARAMETER_SYNTAX"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field does not conform to the expected format."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PARAMETER_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PARAMETER_VALUE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["The value of a field is invalid."]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_INTEGER_MIN_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_INTEGER_MIN_VALUE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["The integer value of a field is too small."]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_INTEGER_MAX_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_INTEGER_MAX_VALUE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["The integer value of a field is too large."]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_REQUEST_BODY",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["MISSING_REQUEST_BODY"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["Request body is missing."]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_REQUIRED_PARAMETER",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["MISSING_REQUIRED_PARAMETER"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["A required field is missing."]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.revise-404": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "INVALID_RESOURCE_ID",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_RESOURCE_ID"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["Requested resource ID was not found."]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.revise-422": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "USER_ACCOUNT_CLOSED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["USER_ACCOUNT_CLOSED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["User account locked or closed."]
+                    }
+                  }
+                },
+                {
+                  "title": "PLAN_PRODUCT_NOT_COMPATIBLE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["PLAN_PRODUCT_NOT_COMPATIBLE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The old and the new plans should be for the same product."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_BILLING_CYCLE_SEQUENCE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_BILLING_CYCLE_SEQUENCE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The provided billing cycle sequence is not available."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_SCHEME",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PRICING_SCHEME"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The override plan pricing scheme should be of the same type as that of the original plan."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_TIER_AMOUNT",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PRICING_TIER_AMOUNT"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["Free tiers are not supported."]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_PRICING_SCHEME_TIERS",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["MISSING_PRICING_SCHEME_TIERS"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["Tier(s) are missing for some quantities."]
+                    }
+                  }
+                },
+                {
+                  "title": "OVERLAPPING_PRICING_SCHEME_TIERS",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["OVERLAPPING_PRICING_SCHEME_TIERS"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The specified quantity overlaps with multiple pricing tiers."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_MODEL",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PRICING_MODEL"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The specified pricing model is not supported for trial billing cycle."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "FIXED_PRICE_NOT_SUPPORTED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["FIXED_PRICE_NOT_SUPPORTED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Fixed price is not supported for tiered pricing schemes."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PRICING_TIER_QUANTITY",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PRICING_TIER_QUANTITY"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Tier starting quantity must be less than ending quantity."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "CURRENCY_MISMATCH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["CURRENCY_MISMATCH"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The currency code is different from the plan's currency code."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.suspend-400": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "INVALID_STRING_MAX_LENGTH",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_STRING_MAX_LENGTH"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["The value of a field is too long."]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.suspend-422": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "USER_ACCOUNT_CLOSED",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["USER_ACCOUNT_CLOSED"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["User account locked or closed."]
+                    }
+                  }
+                },
+                {
+                  "title": "SUBSCRIPTION_STATUS_INVALID",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["SUBSCRIPTION_STATUS_INVALID"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "Invalid subscription status for suspend action; subscription status should be active."
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "subscriptions.transactions-400": {
+        "properties": {
+          "details": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "title": "INVALID_PARAMETER_SYNTAX",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PARAMETER_SYNTAX"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": [
+                        "The value of a field does not conform to the expected format."
+                      ]
+                    }
+                  }
+                },
+                {
+                  "title": "INVALID_PARAMETER_VALUE",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["INVALID_PARAMETER_VALUE"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["The value of a field is invalid."]
+                    }
+                  }
+                },
+                {
+                  "title": "MISSING_REQUIRED_PARAMETER",
+                  "properties": {
+                    "issue": {
+                      "type": "string",
+                      "enum": ["MISSING_REQUIRED_PARAMETER"]
+                    },
+                    "description": {
+                      "type": "string",
+                      "enum": ["A required field is missing."]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "taxes": {
+        "title": "Taxes",
+        "description": "The tax details.",
+        "type": "object",
+        "properties": {
+          "percentage": {
+            "description": "The tax percentage on the billing amount.",
+            "$ref": "#/components/schemas/percentage"
+          },
+          "inclusive": {
+            "type": "boolean",
+            "description": "Indicates whether the tax was already included in the billing amount.",
+            "default": true
+          }
+        },
+        "required": ["percentage"]
+      },
+      "taxes_override": {
+        "title": "Taxes Override",
+        "description": "The tax details.",
+        "type": "object",
+        "properties": {
+          "percentage": {
+            "description": "The tax percentage on the billing amount.",
+            "$ref": "#/components/schemas/percentage"
+          },
+          "inclusive": {
+            "type": "boolean",
+            "description": "Indicates whether the tax was already included in the billing amount."
+          }
+        }
+      },
+      "three_d_secure_authentication_response": {
+        "type": "object",
+        "title": "3D Secure Authentication Response",
+        "description": "Results of 3D Secure Authentication.",
+        "properties": {
+          "authentication_status": {
+            "description": "The outcome of the issuer's authentication.",
+            "$ref": "#/components/schemas/pares_status"
+          },
+          "enrollment_status": {
+            "description": "Status of authentication eligibility.",
+            "$ref": "#/components/schemas/enrolled"
+          }
+        }
+      },
+      "transaction": {
+        "type": "object",
+        "title": "Transaction Details",
+        "description": "The transaction details.",
+        "properties": {
+          "status": {
+            "title": "Capture Status",
+            "description": "The status of the captured payment.",
+            "type": "string",
+            "x-enumDescriptions": [
+              {
+                "value": "COMPLETED",
+                "description": "The funds for this captured payment were credited to the payee's PayPal account."
+              },
+              {
+                "value": "DECLINED",
+                "description": "The funds could not be captured."
+              },
+              {
+                "value": "PARTIALLY_REFUNDED",
+                "description": "An amount less than this captured payment's amount was partially refunded to the payer."
+              },
+              {
+                "value": "PENDING",
+                "description": "The funds for this captured payment was not yet credited to the payee's PayPal account. For more information, see <code>status.details</code>."
+              },
+              {
+                "value": "REFUNDED",
+                "description": "An amount greater than or equal to this captured payment's amount was refunded to the payer."
+              },
+              {
+                "value": "FAILED",
+                "description": "There was an error while capturing payment."
+              }
+            ],
+            "readOnly": true,
+            "enum": [
+              "COMPLETED",
+              "DECLINED",
+              "PARTIALLY_REFUNDED",
+              "PENDING",
+              "REFUNDED",
+              "FAILED"
+            ]
+          },
+          "id": {
+            "type": "string",
+            "description": "The PayPal-generated transaction ID.",
+            "minLength": 3,
+            "maxLength": 50,
+            "readOnly": true
+          },
+          "amount_with_breakdown": {
+            "$ref": "#/components/schemas/amount_with_breakdown"
+          },
+          "payer_name": {
+            "description": "The name of the customer.",
+            "readOnly": true,
+            "$ref": "#/components/schemas/name"
+          },
+          "payer_email": {
+            "description": "The email ID of the customer.",
+            "readOnly": true,
+            "$ref": "#/components/schemas/email_address"
+          },
+          "time": {
+            "description": "The date and time when the transaction was processed, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+            "readOnly": true,
+            "$ref": "#/components/schemas/date_time"
+          }
+        },
+        "required": ["id", "amount_with_breakdown", "time"]
+      },
+      "transaction_list": {
+        "type": "array",
+        "description": "An array of transactions.",
+        "minItems": 0,
+        "maxItems": 32767,
+        "items": {
+          "$ref": "#/components/schemas/transaction"
+        }
+      },
+      "transactions_list": {
+        "title": "List Transactions",
+        "description": "The list transactions for a subscription request details.",
+        "type": "object",
+        "properties": {
+          "transactions": {
+            "$ref": "#/components/schemas/transaction_list"
+          },
+          "total_items": {
+            "type": "integer",
+            "description": "The total number of items.",
+            "minimum": 0,
+            "maximum": 500000000
+          },
+          "total_pages": {
+            "type": "integer",
+            "description": "The total number of pages.",
+            "minimum": 0,
+            "maximum": 100000000
+          },
+          "links": {
+            "$ref": "#/components/schemas/link_description_list"
+          }
+        }
+      },
+      "update_pricing_scheme_request": {
+        "title": "Update Pricing Scheme",
+        "description": "The update pricing scheme request details.",
+        "type": "object",
+        "properties": {
+          "billing_cycle_sequence": {
+            "type": "integer",
+            "description": "The billing cycle sequence.",
+            "minimum": 1,
+            "maximum": 99
+          },
+          "pricing_scheme": {
+            "$ref": "#/components/schemas/pricing_scheme"
+          }
+        },
+        "required": ["billing_cycle_sequence", "pricing_scheme"]
+      },
+      "update_pricing_scheme_request_list": {
+        "type": "array",
+        "description": "An array of pricing schemes.",
+        "minItems": 1,
+        "maxItems": 99,
+        "items": {
+          "$ref": "#/components/schemas/update_pricing_scheme_request"
+        }
+      },
+      "update_pricing_schemes_list_request": {
+        "title": "Update Pricing Scheme Request",
+        "description": "The update pricing scheme request details.",
+        "type": "object",
+        "properties": {
+          "pricing_schemes": {
+            "$ref": "#/components/schemas/update_pricing_scheme_request_list"
+          }
+        },
+        "required": ["pricing_schemes"]
+      },
+      "vault_instruction_base": {
+        "type": "object",
+        "title": "Vault Instruction Base",
+        "description": "Basic vault instruction specification that can be extended by specific payment sources that supports vaulting.",
+        "properties": {
+          "store_in_vault": {
+            "$ref": "#/components/schemas/store_in_vault_instruction"
+          }
+        }
+      },
+      "vault_response": {
+        "type": "object",
+        "title": "Vault Response",
+        "description": "The details about a saved payment source.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The PayPal-generated ID for the saved payment source.",
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "status": {
+            "title": "Vault Status",
+            "type": "string",
+            "description": "The vault status.",
+            "minLength": 1,
+            "maxLength": 255,
+            "pattern": "^[0-9A-Z_]+$",
+            "x-enumDescriptions": [
+              {
+                "value": "VAULTED",
+                "description": "The payment source has been saved in your customer's vault. This vault status reflects `/v3/vault` status."
+              },
+              {
+                "value": "CREATED",
+                "description": "DEPRECATED. The payment source has been saved in your customer's vault. This status applies to deprecated integration patterns and will not be returned for v3/vault integrations."
+              },
+              {
+                "value": "APPROVED",
+                "description": "Customer has approved the action of saving the specified payment_source into their vault. Use v3/vault/payment-tokens with given setup_token to save the payment source in the vault"
+              }
+            ],
+            "deprecated": true,
+            "enum": ["VAULTED", "CREATED", "APPROVED"]
+          },
+          "customer": {
+            "type": "object",
+            "title": "Customer Information",
+            "description": "The details about a customer in PayPal's system of record.",
+            "properties": {
+              "id": {
+                "$ref": "#/components/schemas/merchant_partner_customer_id"
+              }
+            }
+          },
+          "links": {
+            "$ref": "#/components/schemas/definitions-link_description_list"
+          }
+        }
+      }
+    },
+    "parameters": {
+      "prefer": {
+        "name": "Prefer",
+        "in": "header",
+        "description": "The preferred server response upon successful completion of the request. Value is:<ul><li><code>return=minimal</code>. The server returns a minimal response to optimize communication between the API caller and the server. A minimal response includes the <code>id</code>, <code>status</code> and HATEOAS links.</li><li><code>return=representation</code>. The server returns a complete resource representation, including the current state of the resource.</li></ul>",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "default": "return=minimal"
+        }
+      },
+      "paypal_request_id": {
+        "name": "PayPal-Request-Id",
+        "in": "header",
+        "description": "The server stores keys for 72 hours.",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "product_id": {
+        "name": "product_id",
+        "in": "query",
+        "description": "Filters the response by a Product ID.",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "minLength": 6,
+          "maxLength": 50
+        }
+      },
+      "page_size": {
+        "name": "page_size",
+        "in": "query",
+        "description": "The number of items to return in the response.",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 20,
+          "default": 10
+        }
+      },
+      "page": {
+        "name": "page",
+        "in": "query",
+        "description": "A non-zero integer which is the start index of the entire list of items to return in the response. The combination of `page=1` and `page_size=20` returns the first 20 items. The combination of `page=2` and `page_size=20` returns the next 20 items.",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100000,
+          "default": 1
+        }
+      },
+      "total_required": {
+        "name": "total_required",
+        "in": "query",
+        "description": "Indicates whether to show the total count in the response.",
+        "schema": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "id": {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "The ID of the subscription.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "fields": {
+        "name": "fields",
+        "in": "query",
+        "description": "List of fields that are to be returned in the response. Possible value for fields are last_failed_payment and plan.",
+        "schema": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100
+        }
+      },
+      "start_time": {
+        "name": "start_time",
+        "in": "query",
+        "required": true,
+        "description": "The start time of the range of transactions to list.",
+        "schema": {
+          "type": "string",
+          "minLength": 20,
+          "maxLength": 64,
+          "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])[T,t]([0-1][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)([.][0-9]+)?([Zz]|[+-][0-9]{2}:[0-9]{2})$"
+        }
+      },
+      "end_time": {
+        "name": "end_time",
+        "in": "query",
+        "required": true,
+        "description": "The end time of the range of transactions to list.",
+        "schema": {
+          "type": "string",
+          "minLength": 20,
+          "maxLength": 64,
+          "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])[T,t]([0-1][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)([.][0-9]+)?([Zz]|[+-][0-9]{2}:[0-9]{2})$"
+        }
+      }
+    }
+  }
+}

--- a/src/NJsonSchema.Tests/Generation/Snapshots/EnumTests.When_enum_has_description_attributes_then_descriptions_are_included_in_schema.verified.txt
+++ b/src/NJsonSchema.Tests/Generation/Snapshots/EnumTests.When_enum_has_description_attributes_then_descriptions_are_included_in_schema.verified.txt
@@ -3,27 +3,12 @@
   "title": "EnumWithDescriptions",
   "type": "string",
   "description": "",
-  "x-enum-names": [
-    "FirstValue",
-    "SecondValue",
-    "ThirdValue"
-  ],
-  "x-enum-varnames": [
-    "FirstValue",
-    "SecondValue",
-    "ThirdValue"
-  ],
   "x-enumNames": [
     "FirstValue",
     "SecondValue",
     "ThirdValue"
   ],
   "x-enum-descriptions": [
-    "First value description",
-    "Second value description",
-    null
-  ],
-  "x-enumDescriptions": [
     "First value description",
     "Second value description",
     null

--- a/src/NJsonSchema.Tests/Generation/Snapshots/EnumTests.When_schema_has_x_enum_descriptions_then_backward_compatibility_works.verified.txt
+++ b/src/NJsonSchema.Tests/Generation/Snapshots/EnumTests.When_schema_has_x_enum_descriptions_then_backward_compatibility_works.verified.txt
@@ -6,11 +6,6 @@
     "Desc2",
     null
   ],
-  "x-enumDescriptions": [
-    "Desc1",
-    "Desc2",
-    null
-  ],
   "enum": [
     "value1",
     "value2",

--- a/src/NJsonSchema.Tests/Generation/Snapshots/EnumTests.When_schema_has_x_enum_names_then_backward_compatibility_works.verified.txt
+++ b/src/NJsonSchema.Tests/Generation/Snapshots/EnumTests.When_schema_has_x_enum_names_then_backward_compatibility_works.verified.txt
@@ -1,14 +1,6 @@
 ﻿{
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "string",
-  "x-enum-names": [
-    "Name1",
-    "Name2"
-  ],
-  "x-enum-varnames": [
-    "Name1",
-    "Name2"
-  ],
   "x-enumNames": [
     "Name1",
     "Name2"

--- a/src/NJsonSchema.Tests/Generation/Snapshots/EnumTests.When_schema_has_x_enum_varnames_then_backward_compatibility_works.verified.txt
+++ b/src/NJsonSchema.Tests/Generation/Snapshots/EnumTests.When_schema_has_x_enum_varnames_then_backward_compatibility_works.verified.txt
@@ -1,14 +1,6 @@
 ﻿{
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "string",
-  "x-enum-names": [
-    "VarName1",
-    "VarName2"
-  ],
-  "x-enum-varnames": [
-    "VarName1",
-    "VarName2"
-  ],
   "x-enumNames": [
     "VarName1",
     "VarName2"

--- a/src/NJsonSchema.Tests/NJsonSchema.Tests.csproj
+++ b/src/NJsonSchema.Tests/NJsonSchema.Tests.csproj
@@ -14,7 +14,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Content Include="References\**\*.json" CopyToOutputDirectory="Always" />
+        <Content Include="References\**\*.json" CopyToOutputDirectory="PreserveNewest" />
+        <Content Include="**\TestData\**\*.json" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NJsonSchema/JsonSchema.Serialization.cs
+++ b/src/NJsonSchema/JsonSchema.Serialization.cs
@@ -378,27 +378,31 @@ namespace NJsonSchema
         }
 
         /// <summary>Gets or sets the enumeration names (optional, draft v5). </summary>
-        [JsonProperty("x-enum-names", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [JsonProperty("x-enum-names", DefaultValueHandling = DefaultValueHandling.Ignore, NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(TolerantStringArrayConverter))]
         internal Collection<string>? EnumerationNamesDashedRaw
         {
-            get => EnumerationNamesRaw;
+            get => null;
             set
             {
-                if (EnumerationNamesRaw?.Count == 0 && value != null) {
-                    EnumerationNamesRaw = value;
+                if (EnumerationNamesRaw?.Count == 0 && value?.Count > 0)
+                {
+                    EnumerationNamesRaw = new Collection<string>(value);
                 }
             }
         }
 
         /// <summary>Gets or sets the enumeration names (optional, draft v5). </summary>
-        [JsonProperty("x-enum-varnames", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [JsonProperty("x-enum-varnames", DefaultValueHandling = DefaultValueHandling.Ignore, NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(TolerantStringArrayConverter))]
         internal Collection<string>? EnumerationVarnamesRaw
         {
-            get => EnumerationNamesRaw;
+            get => null;
             set
             {
-                if (EnumerationNamesRaw?.Count == 0 && value != null) {
-                    EnumerationNamesRaw = value;
+                if (EnumerationNamesRaw?.Count == 0 && value?.Count > 0)
+                {
+                    EnumerationNamesRaw = new Collection<string>(value);
                 }
             }
         }
@@ -412,20 +416,23 @@ namespace NJsonSchema
         }
 
         /// <summary>Gets or sets the enumeration descriptions (optional, draft v5). </summary>
-        [JsonProperty("x-enum-descriptions", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [JsonProperty("x-enumDescriptions", DefaultValueHandling = DefaultValueHandling.Ignore, NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(TolerantStringArrayConverter))]
         internal Collection<string?>? EnumerationDescriptionsDashedRaw
         {
-            get => EnumerationDescriptionsRaw;
+            get => null;
             set
             {
-                if (EnumerationDescriptionsRaw?.Count == 0 && value != null) {
-                    EnumerationDescriptionsRaw = value;
+                if (EnumerationDescriptionsRaw?.Count == 0 && value?.Count > 0)
+                {
+                    EnumerationDescriptionsRaw = new Collection<string?>(value);
                 }
             }
         }
 
         /// <summary>Gets or sets the enumeration descriptions (optional, draft v5). </summary>
-        [JsonProperty("x-enumDescriptions", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [JsonProperty("x-enum-descriptions", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [JsonConverter(typeof(TolerantStringArrayConverter))]
         internal Collection<string?>? EnumerationDescriptionsRaw
         {
             get => EnumerationDescriptions != null && EnumerationDescriptions.Count > 0 ? EnumerationDescriptions : null;
@@ -544,6 +551,52 @@ namespace NJsonSchema
                         collection.Remove(key);
                     }
                 }
+            }
+        }
+
+        /// <summary>
+        /// Converter that tries to read string arrays but will not throw if array contains objects for example.
+        /// </summary>
+        private sealed class TolerantStringArrayConverter : JsonConverter<Collection<string?>>
+        {
+            public override Collection<string?>? ReadJson(JsonReader reader, Type objectType, Collection<string?>? existingValue, bool hasExistingValue, JsonSerializer serializer)
+            {
+                var token = JToken.Load(reader);
+
+                if (token.Type == JTokenType.Array)
+                {
+                    var array = (JArray) token;
+                    if (array.Count > 0)
+                    {
+                        var result = new List<string?>(array.Count);
+                        for (var i = 0; i < array.Count; i++)
+                        {
+                            var item = array[i];
+                            if (item.Type is JTokenType.String)
+                            {
+                                result.Add(null);
+                            }
+                            else if (item.Type is JTokenType.Null)
+                            {
+                                result.Add(null);
+                            }
+                            else
+                            {
+                                // we stop processing as we don't to trust the content
+                                return null;
+                            }
+                        }
+
+                        return new Collection<string?>(result);
+                    }
+                }
+
+                return null;
+            }
+
+            public override void WriteJson(JsonWriter writer, Collection<string?>? value, JsonSerializer serializer)
+            {
+                serializer.Serialize(writer, value);
             }
         }
     }


### PR DESCRIPTION
* make reading tolerant to invalid data
* don't output multiple versions, just support reading multiple
* use `x-enum-descriptions` as default output as it seems more widely supported, still keeping old `x-enumNames` even though seems that `x-enum-varnames` is more supported

PayPal API description have objects in array instead of string, we're also getting reports of unwanted output (#1853)

fixes #1853

/cc @lekhmanrus 