### PR TITLE
Use [JsonStringEnumMemberName] instead of [EnumMember]

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NodaTime" Version="3.2.2" />
     <PackageVersion Include="NSwag.Core.Yaml" Version="14.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.9" />
     <PackageVersion Include="Verify.XunitV3" Version="30.5.0" />
     <PackageVersion Include="xunit.v3" Version="3.0.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/NJsonSchema.CodeGeneration.CSharp.Tests.csproj
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/NJsonSchema.CodeGeneration.CSharp.Tests.csproj
@@ -17,6 +17,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="System.Text.Json" />
         <PackageReference Include="Verify.XunitV3" />
         <PackageReference Include="xunit.v3" />
         <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/Snapshots/EnumTests.When_enum_is_string_then_generic_StringEnumConverter_is_used_nullable=False.verified.txt
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/Snapshots/EnumTests.When_enum_is_string_then_generic_StringEnumConverter_is_used_nullable=False.verified.txt
@@ -20,15 +20,15 @@ namespace MyNamespace
     public enum MyClassSize
     {
 
-        [System.Runtime.Serialization.EnumMember(Value = @"small")]
+        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"small")]
         Small = 0,
 
 
-        [System.Runtime.Serialization.EnumMember(Value = @"medium")]
+        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"medium")]
         Medium = 1,
 
 
-        [System.Runtime.Serialization.EnumMember(Value = @"large")]
+        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"large")]
         Large = 2,
 
 

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/Snapshots/EnumTests.When_enum_is_string_then_generic_StringEnumConverter_is_used_nullable=True.verified.txt
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/Snapshots/EnumTests.When_enum_is_string_then_generic_StringEnumConverter_is_used_nullable=True.verified.txt
@@ -20,15 +20,15 @@ namespace MyNamespace
     public enum MyClassSize
     {
 
-        [System.Runtime.Serialization.EnumMember(Value = @"small")]
+        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"small")]
         Small = 0,
 
 
-        [System.Runtime.Serialization.EnumMember(Value = @"medium")]
+        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"medium")]
         Medium = 1,
 
 
-        [System.Runtime.Serialization.EnumMember(Value = @"large")]
+        [System.Text.Json.Serialization.JsonStringEnumMemberName(@"large")]
         Large = 2,
 
 

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Enum.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Enum.liquid
@@ -12,7 +12,11 @@
 {
 {%- for enum in Enums %}
 {%-   if IsStringEnum -%}
+{%-       if UseSystemTextJson -%}
+    [System.Text.Json.Serialization.JsonStringEnumMemberName(@"{{ enum.Value | replace: '"', '""' }}")]
+{%-       else -%}
     [System.Runtime.Serialization.EnumMember(Value = @"{{ enum.Value | replace: '"', '""' }}")]
+{%-       endif -%}
 {%-   endif -%}
 {%- template Enum.Member.Annotations -%}
 {%- if IsEnumAsBitFlags -%}


### PR DESCRIPTION
System.Text.Json ignores the `System.Runtime.Serialization.EnumMember` attribute. It needs the [`System.Text.Json.Serialization.JsonStringEnumMemberName` attribute](https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/customize-properties#custom-enum-member-names) to customize the names of individual enum members.