### PR TITLE
Add support for `JsonStringEnumConverter<T>` detection and test it

### DIFF
--- a/src/NJsonSchema.Tests/Generation/SystemTextJson/SystemTextJsonOptionsConverterTests.cs
+++ b/src/NJsonSchema.Tests/Generation/SystemTextJson/SystemTextJsonOptionsConverterTests.cs
@@ -72,6 +72,9 @@ namespace NJsonSchema.Tests.Generation.SystemTextJson
 
             [JsonConverter(typeof(JsonStringEnumConverter))]
             public MyEnum StringEnum { get; set; }
+           
+            [JsonConverter(typeof(JsonStringEnumConverter<MyEnum>))]
+            public MyEnum StringEnum2 { get; set; }
 
             public MyEnum IntEnum { get; set; }
         }
@@ -103,6 +106,7 @@ namespace NJsonSchema.Tests.Generation.SystemTextJson
             Assert.True(schema.Properties.ContainsKey("NameLast"));
 
             Assert.True(schema.Properties["stringEnum"].ActualSchema.Type.HasFlag(JsonObjectType.String));
+            Assert.True(schema.Properties["stringEnum2"].ActualSchema.Type.HasFlag(JsonObjectType.String));
             Assert.True(schema.Properties["intEnum"].ActualSchema.Type.HasFlag(JsonObjectType.Integer));
         }
     }

--- a/src/NJsonSchema/Generation/ReflectionServiceBase.cs
+++ b/src/NJsonSchema/Generation/ReflectionServiceBase.cs
@@ -379,7 +379,8 @@ namespace NJsonSchema.Generation
                 if (jsonConverterAttribute?.ConverterType is Type converterType)
                 {
                     return converterType.IsAssignableToTypeName("StringEnumConverter", TypeNameStyle.Name) ||
-                           converterType.IsAssignableToTypeName("System.Text.Json.Serialization.JsonStringEnumConverter", TypeNameStyle.FullName);
+                           converterType.IsAssignableToTypeName("System.Text.Json.Serialization.JsonStringEnumConverter", TypeNameStyle.FullName) ||
+                           converterType.IsAssignableToTypeName($"System.Text.Json.Serialization.JsonStringEnumConverter`1[[{contextualType.OriginalType.AssemblyQualifiedName}]]", TypeNameStyle.FullName);
                 }
             }
 


### PR DESCRIPTION
Add test case to ensure proper handling of `JsonStringEnumConverter<T>` and fix condition to find converter attribute in `HasStringEnumConverter`.

Closes:
- https://github.com/RicoSuter/NJsonSchema/issues/1867
- https://github.com/RicoSuter/NJsonSchema/issues/1741