### PR TITLE
Removed logic that removes newlines after annotation templates are used

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
@@ -34,7 +34,7 @@
 {%- if IsDeprecated -%}
 [System.Obsolete{% if HasDeprecatedMessage %}({{ DeprecatedMessage | literal }}){% endif %}]
 {% endif -%}
-{%- template Class.Annotations -%}
+{%- template Class.Annotations %}
 {{ TypeAccessModifier }} {% if IsAbstract %}abstract {% endif %}partial {{ ClassType }} {{ClassName}} {%- template Class.Inheritance %}
 {
 {%- if IsTuple -%}
@@ -106,7 +106,7 @@
 {%-   if property.IsDeprecated -%}
     [System.Obsolete{% if property.HasDeprecatedMessage %}({{ property.DeprecatedMessage | literal }}){% endif %}]
 {%-   endif -%}
-    {%- template Class.Property.Annotations -%}
+    {%- template Class.Property.Annotations %}
     public {% if UseRequiredKeyword and property.IsRequired %}required {% endif %}{{ property.Type }} {{ property.PropertyName }}{% if RenderInpc == false and RenderPrism == false %} { get; {% if property.HasSetter and RenderRecord == false %}set; {% elsif RenderRecord and GenerateNativeRecords %}init; {% endif %}}{% if property.HasDefaultValue and RenderRecord == false %} = {{ property.DefaultValue }};{% elsif GenerateNullableReferenceTypes and RenderRecord == false %} = default!;{% endif %}
 {%- else -%}
     {


### PR DESCRIPTION
When using the CSharp annotation templates, the newlines after the annotations are removed. See https://github.com/RicoSuter/NJsonSchema/issues/1592 for more details.