### PR TITLE
Add validation support for JSON Schema 'const' keyword

### DIFF
--- a/src/NJsonSchema.Tests/Validation/ConstValidationTests.cs
+++ b/src/NJsonSchema.Tests/Validation/ConstValidationTests.cs
@@ -1,0 +1,165 @@
+using NJsonSchema.Validation;
+
+namespace NJsonSchema.Tests.Validation
+{
+    public class ConstValidationTests
+    {
+        [Fact]
+        public async Task When_const_is_defined_and_value_matches_then_validation_succeeds()
+        {
+            var json = @"{
+                ""type"": ""object"",
+                ""properties"": {
+                    ""type"": {
+                        ""const"": ""System.Type""
+                    }
+                },
+                ""required"": [""type""]
+            }";
+            var schema = await JsonSchema.FromJsonAsync(json);
+
+            var errors = schema.Validate(@"{ ""type"": ""System.Type"" }");
+
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public async Task When_const_is_defined_and_value_does_not_match_then_validation_fails()
+        {
+            var json = @"{
+                ""type"": ""object"",
+                ""properties"": {
+                    ""type"": {
+                        ""const"": ""System.Type""
+                    }
+                },
+                ""required"": [""type""]
+            }";
+            var schema = await JsonSchema.FromJsonAsync(json);
+
+            var errors = schema.Validate(@"{ ""type"": ""test"" }");
+
+            Assert.Single(errors);
+        }
+
+        [Fact]
+        public async Task When_const_is_integer_and_value_matches_then_validation_succeeds()
+        {
+            var json = @"{ ""const"": 42 }";
+            var schema = await JsonSchema.FromJsonAsync(json);
+
+            var errors = schema.Validate("42");
+
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public async Task When_const_is_integer_and_value_does_not_match_then_validation_fails()
+        {
+            var json = @"{ ""const"": 42 }";
+            var schema = await JsonSchema.FromJsonAsync(json);
+
+            var errors = schema.Validate("99");
+
+            Assert.Single(errors);
+            Assert.Equal(ValidationErrorKind.ConstMismatch, errors.First().Kind);
+        }
+
+        [Fact]
+        public async Task When_const_is_boolean_then_validation_works()
+        {
+            var json = @"{ ""const"": true }";
+            var schema = await JsonSchema.FromJsonAsync(json);
+
+            Assert.Empty(schema.Validate("true"));
+            Assert.Single(schema.Validate("false"));
+        }
+
+        [Fact]
+        public async Task When_const_is_null_then_validation_works()
+        {
+            var json = @"{ ""const"": null }";
+            var schema = await JsonSchema.FromJsonAsync(json);
+
+            Assert.Empty(schema.Validate("null"));
+
+            var errors = schema.Validate(@"""something""");
+            Assert.Single(errors);
+            Assert.Equal(ValidationErrorKind.ConstMismatch, errors.First().Kind);
+        }
+
+        [Fact]
+        public async Task When_const_is_object_then_validation_works()
+        {
+            var json = @"{
+                ""const"": { ""key"": ""value"" }
+            }";
+            var schema = await JsonSchema.FromJsonAsync(json);
+
+            Assert.Empty(schema.Validate(@"{ ""key"": ""value"" }"));
+            Assert.Single(schema.Validate(@"{ ""key"": ""wrong"" }"));
+        }
+
+        [Fact]
+        public async Task When_no_const_is_defined_then_validation_passes()
+        {
+            var json = @"{ ""type"": ""string"" }";
+            var schema = await JsonSchema.FromJsonAsync(json);
+
+            var errors = schema.Validate(@"""anything""");
+
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public async Task When_const_is_set_then_schema_roundtrips()
+        {
+            var json = @"{
+                ""type"": ""object"",
+                ""properties"": {
+                    ""type"": {
+                        ""const"": ""System.Type""
+                    }
+                }
+            }";
+            var schema = await JsonSchema.FromJsonAsync(json);
+
+            var output = schema.ToJson();
+            var schema2 = await JsonSchema.FromJsonAsync(output);
+
+            Assert.True(schema2.Properties["type"].HasConst);
+            Assert.Equal("System.Type", schema2.Properties["type"].Const?.ToString());
+        }
+
+        [Fact]
+        public void When_const_is_not_set_then_HasConst_is_false()
+        {
+            var schema = new JsonSchema { Type = JsonObjectType.String };
+
+            Assert.False(schema.HasConst);
+            Assert.Null(schema.Const);
+        }
+
+        [Fact]
+        public async Task When_const_with_additional_properties_false_then_wrong_value_fails()
+        {
+            var json = @"{
+                ""$schema"": ""https://json-schema.org/draft/2020-12/schema"",
+                ""type"": ""object"",
+                ""properties"": {
+                    ""type"": {
+                        ""const"": ""System.Type""
+                    }
+                },
+                ""additionalProperties"": false,
+                ""required"": [""type""]
+            }";
+            var schema = await JsonSchema.FromJsonAsync(json);
+
+            var errors = schema.Validate(@"{ ""type"": ""test"" }");
+
+            Assert.NotEmpty(errors);
+            Assert.Contains(errors, e => e.Kind == ValidationErrorKind.ConstMismatch);
+        }
+    }
+}

--- a/src/NJsonSchema/JsonSchema.Serialization.cs
+++ b/src/NJsonSchema/JsonSchema.Serialization.cs
@@ -73,6 +73,12 @@ namespace NJsonSchema
         internal void OnDeserialized(StreamingContext ctx)
         {
             Initialize();
+
+            if (ExtensionData != null && ExtensionData.TryGetValue("const", out var constValue))
+            {
+                Const = constValue;
+                HasConst = true;
+            }
         }
 
         /// <summary>Gets the discriminator property (Swagger only).</summary>

--- a/src/NJsonSchema/JsonSchema.cs
+++ b/src/NJsonSchema/JsonSchema.cs
@@ -509,6 +509,14 @@ namespace NJsonSchema
         [JsonProperty("x-enumFlags", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         public bool IsFlagEnumerable { get; set; }
 
+        /// <summary>Gets or sets the constant value of this schema (JSON Schema 'const' keyword).</summary>
+        [JsonIgnore]
+        public object? Const { get; set; }
+
+        /// <summary>Gets a value indicating whether a const value has been set.</summary>
+        [JsonIgnore]
+        public bool HasConst { get; set; }
+
         /// <summary>Gets the collection of required properties. </summary>
         [JsonIgnore]
         public ICollection<object?> Enumeration { get; internal set; }

--- a/src/NJsonSchema/Validation/JsonSchemaValidator.cs
+++ b/src/NJsonSchema/Validation/JsonSchemaValidator.cs
@@ -82,6 +82,7 @@ namespace NJsonSchema.Validation
             ValidateNot(token, schema, propertyName, propertyPath, errors);
             ValidateType(token, schema, schemaType, propertyName, propertyPath, errors);
             JsonSchemaValidator.ValidateEnum(token, schema, schemaType, propertyName, propertyPath, errors);
+            JsonSchemaValidator.ValidateConst(token, schema, propertyName, propertyPath, errors);
             ValidateProperties(token, schema, schemaType, propertyName, propertyPath, errors);
 
             return errors;
@@ -194,6 +195,18 @@ namespace NJsonSchema.Validation
             if (schema.Enumeration.Count > 0 && schema.Enumeration.All(v => v?.ToString() != token?.ToString()))
             {
                 errors.Add(new ValidationError(ValidationErrorKind.NotInEnumeration, propertyName, propertyPath, token, schema));
+            }
+        }
+
+        private static void ValidateConst(JToken token, JsonSchema schema, string? propertyName, string propertyPath, List<ValidationError> errors)
+        {
+            if (schema.HasConst)
+            {
+                var constToken = schema.Const is JToken jt ? jt : new JValue(schema.Const);
+                if (!JToken.DeepEquals(token, constToken))
+                {
+                    errors.Add(new ValidationError(ValidationErrorKind.ConstMismatch, propertyName, propertyPath, token, schema));
+                }
             }
         }
 

--- a/src/NJsonSchema/Validation/ValidationErrorKind.cs
+++ b/src/NJsonSchema/Validation/ValidationErrorKind.cs
@@ -145,5 +145,8 @@ namespace NJsonSchema.Validation
 
         /// <summary>A valid UUID is expected. </summary>
         UuidExpected,
+
+        /// <summary>The value does not match the const value. </summary>
+        ConstMismatch,
     }
 }


### PR DESCRIPTION
## Summary

- Adds support for the JSON Schema `const` keyword validation, which was previously completely ignored by `Validate()`
- When a schema defines `"const": "someValue"`, validation now correctly fails if the input value doesn't match
- Adds `Const` and `HasConst` properties to `JsonSchema` for programmatic access
- Adds `ConstMismatch` to `ValidationErrorKind` enum
- The `const` value is extracted from `ExtensionData` during deserialization, preserving full serialization roundtrip

## Test plan

- [x] 11 new tests in `ConstValidationTests.cs` covering:
  - String const matching and mismatching
  - Integer const matching and mismatching
  - Boolean const validation
  - Null const validation
  - Object const validation (deep equality)
  - Schema without const (no false positives)
  - Schema roundtrip (serialize/deserialize preserves const)
  - HasConst flag behavior
  - Integration with additionalProperties: false
- [x] All 459 existing + new tests pass with no regressions

Fixes #1857

🤖 Generated with [Claude Code](https://claude.com/claude-code)