### PR TITLE
Fix public fields excluded with STJ IncludeFields=true

### DIFF
--- a/src/NJsonSchema.Tests/Generation/SystemTextJson/SystemTextJsonTests.cs
+++ b/src/NJsonSchema.Tests/Generation/SystemTextJson/SystemTextJsonTests.cs
@@ -169,5 +169,56 @@ namespace NJsonSchema.Tests.Generation.SystemTextJson
             Assert.DoesNotContain("Optional", schema.RequiredProperties);
         }
 #endif
+
+        public class ClassWithPublicField
+        {
+            public string MyField;
+            public string MyProperty { get; set; }
+        }
+
+        [Fact]
+        public void When_IncludeFields_is_true_then_public_fields_are_in_schema()
+        {
+            // Act
+            var settings = new SystemTextJsonSchemaGeneratorSettings
+            {
+                SerializerOptions = new System.Text.Json.JsonSerializerOptions { IncludeFields = true }
+            };
+            var schema = JsonSchema.FromType<ClassWithPublicField>(settings);
+
+            // Assert
+            Assert.True(schema.Properties.ContainsKey("MyField"));
+            Assert.True(schema.Properties.ContainsKey("MyProperty"));
+        }
+
+        [Fact]
+        public void When_IncludeFields_is_false_then_public_fields_are_not_in_schema()
+        {
+            // Act
+            var schema = JsonSchema.FromType<ClassWithPublicField>();
+
+            // Assert
+            Assert.False(schema.Properties.ContainsKey("MyField"));
+            Assert.True(schema.Properties.ContainsKey("MyProperty"));
+        }
+
+        public class ClassWithJsonIncludeField
+        {
+            [System.Text.Json.Serialization.JsonInclude]
+            public string IncludedField;
+
+            public string ExcludedField;
+        }
+
+        [Fact]
+        public void When_field_has_JsonInclude_then_it_is_in_schema()
+        {
+            // Act
+            var schema = JsonSchema.FromType<ClassWithJsonIncludeField>();
+
+            // Assert
+            Assert.True(schema.Properties.ContainsKey("IncludedField"));
+            Assert.False(schema.Properties.ContainsKey("ExcludedField"));
+        }
     }
 }

--- a/src/NJsonSchema/Generation/SystemTextJsonReflectionService.cs
+++ b/src/NJsonSchema/Generation/SystemTextJsonReflectionService.cs
@@ -26,7 +26,10 @@ namespace NJsonSchema.Generation
                 .OrderBy(a => GetPropertyOrder(a)))
             {
                 if (accessorInfo.MemberInfo.DeclaringType != contextualType.Type ||
-                    (accessorInfo.MemberInfo is FieldInfo fieldInfo && (fieldInfo.IsPrivate || fieldInfo.IsStatic || !fieldInfo.IsDefined(typeof(DataMemberAttribute)))))
+                    (accessorInfo.MemberInfo is FieldInfo fieldInfo && (fieldInfo.IsPrivate || fieldInfo.IsStatic ||
+                        (!fieldInfo.IsDefined(typeof(DataMemberAttribute)) &&
+                         !settings.SerializerOptions.IncludeFields &&
+                         !fieldInfo.IsDefined(typeof(JsonIncludeAttribute))))))
                 {
                     continue;
                 }


### PR DESCRIPTION
## Summary
- Fixes #1680
- `SystemTextJsonReflectionService` required `[DataMember]` on fields, ignoring `SerializerOptions.IncludeFields` and `[JsonInclude]`
- Now respects both `IncludeFields = true` and `[JsonInclude]` attribute on fields

## Test plan
- [x] Added test: class with public field + `IncludeFields = true` → field is in schema
- [x] Added test: class with public field without `IncludeFields` → field is NOT in schema
- [x] Added test: field with `[JsonInclude]` → field is in schema regardless of `IncludeFields`
- [x] All tests pass (459 passed, 7 skipped, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)