### PR TITLE
Support C#11 required keyword in schema generation

### DIFF
--- a/src/NJsonSchema.NewtonsoftJson/Generation/NewtonsoftJsonReflectionService.cs
+++ b/src/NJsonSchema.NewtonsoftJson/Generation/NewtonsoftJsonReflectionService.cs
@@ -171,14 +171,16 @@ namespace NJsonSchema.NewtonsoftJson.Generation
                     }
                 }
 
-                var requiredAttribute = accessorInfo
-                    .GetAttributes(true)
+                var attributes = accessorInfo.GetAttributes(true);
+                var requiredAttribute = attributes
                     .FirstAssignableToTypeNameOrDefault("System.ComponentModel.DataAnnotations.RequiredAttribute");
+                var hasRequiredMemberAttribute = attributes.FirstAssignableToTypeNameOrDefault(
+                    "System.Runtime.CompilerServices.RequiredMemberAttribute") != null;
 
                 var hasJsonNetAttributeRequired = jsonProperty.Required is Required.Always or Required.AllowNull;
                 var isDataContractMemberRequired = schemaGenerator.GetDataMemberAttribute(accessorInfo, parentType)?.IsRequired == true;
 
-                var hasRequiredAttribute = requiredAttribute != null;
+                var hasRequiredAttribute = requiredAttribute != null || hasRequiredMemberAttribute;
                 if (hasRequiredAttribute || isDataContractMemberRequired || hasJsonNetAttributeRequired)
                 {
                     parentSchema.RequiredProperties.Add(propertyName);

--- a/src/NJsonSchema.Tests/Generation/AttributeGenerationTests.cs
+++ b/src/NJsonSchema.Tests/Generation/AttributeGenerationTests.cs
@@ -335,5 +335,24 @@ namespace NJsonSchema.Tests.Generation
 #endif
             Assert.Equal(1, schema.Properties["RequiredString"].MinLength);
         }
+
+#if NET7_0_OR_GREATER
+        public class ClassWithRequiredKeyword
+        {
+            public required string Name { get; set; }
+            public string Optional { get; set; }
+        }
+
+        [Fact]
+        public void When_property_has_required_keyword_then_it_is_required_in_Newtonsoft_schema()
+        {
+            // Act
+            var schema = NewtonsoftJsonSchemaGenerator.FromType<ClassWithRequiredKeyword>();
+
+            // Assert
+            Assert.Contains("Name", schema.RequiredProperties);
+            Assert.DoesNotContain("Optional", schema.RequiredProperties);
+        }
+#endif
     }
 }

--- a/src/NJsonSchema.Tests/Generation/SystemTextJson/SystemTextJsonTests.cs
+++ b/src/NJsonSchema.Tests/Generation/SystemTextJson/SystemTextJsonTests.cs
@@ -132,5 +132,42 @@ namespace NJsonSchema.Tests.Generation.SystemTextJson
             Assert.Equal("A", keys[1]); // order 1
             Assert.Equal("B", keys[2]); // order 2
         }
+
+#if NET7_0_OR_GREATER
+        public class ClassWithRequiredKeyword
+        {
+            public required string Name { get; set; }
+            public string Optional { get; set; }
+        }
+
+        [Fact]
+        public void When_property_has_required_keyword_then_it_is_required_in_schema()
+        {
+            // Act
+            var schema = JsonSchema.FromType<ClassWithRequiredKeyword>();
+
+            // Assert
+            Assert.Contains("Name", schema.RequiredProperties);
+            Assert.DoesNotContain("Optional", schema.RequiredProperties);
+        }
+
+        public class ClassWithJsonRequired
+        {
+            [System.Text.Json.Serialization.JsonRequired]
+            public string Name { get; set; }
+            public string Optional { get; set; }
+        }
+
+        [Fact]
+        public void When_property_has_JsonRequired_then_it_is_required_in_schema()
+        {
+            // Act
+            var schema = JsonSchema.FromType<ClassWithJsonRequired>();
+
+            // Assert
+            Assert.Contains("Name", schema.RequiredProperties);
+            Assert.DoesNotContain("Optional", schema.RequiredProperties);
+        }
+#endif
     }
 }

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -1205,7 +1205,7 @@ namespace NJsonSchema.Generation
                 if (hasRequiredAttribute &&
                     !propertyTypeDescription.IsEnum &&
                     propertyTypeDescription.Type == JsonObjectType.String &&
-                    !requiredAttribute.TryGetPropertyValue("AllowEmptyStrings", false) &&
+                    (requiredAttribute == null || !requiredAttribute.TryGetPropertyValue("AllowEmptyStrings", false)) &&
                     !IsDateTimeFormat(propertyTypeDescription.Format))
                 {
                     propertySchema.MinLength = 1;

--- a/src/NJsonSchema/Generation/SystemTextJsonReflectionService.cs
+++ b/src/NJsonSchema/Generation/SystemTextJsonReflectionService.cs
@@ -88,10 +88,14 @@ namespace NJsonSchema.Generation
                     }
 
                     var requiredAttribute = attributes.FirstAssignableToTypeNameOrDefault("System.ComponentModel.DataAnnotations.RequiredAttribute");
+                    var hasRequiredMemberAttribute = attributes.FirstAssignableToTypeNameOrDefault(
+                        "System.Runtime.CompilerServices.RequiredMemberAttribute") != null;
+                    var hasJsonRequiredAttribute = attributes.FirstAssignableToTypeNameOrDefault(
+                        "System.Text.Json.Serialization.JsonRequiredAttribute") != null;
 
                     var isDataContractMemberRequired = schemaGenerator.GetDataMemberAttribute(accessorInfo, contextualType.Type)?.IsRequired == true;
 
-                    var hasRequiredAttribute = requiredAttribute != null;
+                    var hasRequiredAttribute = requiredAttribute != null || hasRequiredMemberAttribute || hasJsonRequiredAttribute;
                     if (hasRequiredAttribute || isDataContractMemberRequired)
                     {
                         schema.RequiredProperties.Add(propertyName);


### PR DESCRIPTION
## Summary
- Fixes #1879, #1672
- Properties declared with C# `required` keyword were not marked as required in generated schemas
- Now recognizes `RequiredMemberAttribute` (C# `required` keyword) and `JsonRequiredAttribute` (STJ) in both `SystemTextJsonReflectionService` and `NewtonsoftJsonReflectionService`
- Added null guard for `requiredAttribute` in `MinLength` logic in `JsonSchemaGenerator.AddProperty`

## Test plan
- [x] Added STJ test: `required string Name` → property is in `RequiredProperties`
- [x] Added STJ test: `[JsonRequired] string Name` → property is in `RequiredProperties`
- [x] Added Newtonsoft test: `required string Name` → property is in `RequiredProperties`
- [x] All tests pass (459 passed + 2 Newtonsoft, 7 skipped, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)