### PR TITLE
Fix IPv4 format validator regex false positives

### DIFF
--- a/src/NJsonSchema.Tests/Validation/FormatIpV4Tests.cs
+++ b/src/NJsonSchema.Tests/Validation/FormatIpV4Tests.cs
@@ -38,5 +38,56 @@ namespace NJsonSchema.Tests.Validation
             // Assert
             Assert.Empty(errors);
         }
+
+        [Fact]
+        public void When_format_ipv4_has_colons_instead_of_dots_then_validation_fails()
+        {
+            // Arrange
+            var schema = new JsonSchema();
+            schema.Type = JsonObjectType.String;
+            schema.Format = JsonFormatStrings.IpV4;
+
+            var token = new JValue("00:45:00.0");
+
+            // Act
+            var errors = schema.Validate(token);
+
+            // Assert
+            Assert.Equal(ValidationErrorKind.IpV4Expected, errors.First().Kind);
+        }
+
+        [Fact]
+        public void When_format_ipv4_has_colons_as_separators_then_validation_fails()
+        {
+            // Arrange
+            var schema = new JsonSchema();
+            schema.Type = JsonObjectType.String;
+            schema.Format = JsonFormatStrings.IpV4;
+
+            var token = new JValue("1:2:3:4");
+
+            // Act
+            var errors = schema.Validate(token);
+
+            // Assert
+            Assert.Equal(ValidationErrorKind.IpV4Expected, errors.First().Kind);
+        }
+
+        [Fact]
+        public void When_format_ipv4_octet_exceeds_255_then_validation_fails()
+        {
+            // Arrange
+            var schema = new JsonSchema();
+            schema.Type = JsonObjectType.String;
+            schema.Format = JsonFormatStrings.IpV4;
+
+            var token = new JValue("256.1.1.1");
+
+            // Act
+            var errors = schema.Validate(token);
+
+            // Assert
+            Assert.Equal(ValidationErrorKind.IpV4Expected, errors.First().Kind);
+        }
     }
 }

--- a/src/NJsonSchema/Validation/FormatValidators/IpV4FormatValidator.cs
+++ b/src/NJsonSchema/Validation/FormatValidators/IpV4FormatValidator.cs
@@ -14,7 +14,7 @@ namespace NJsonSchema.Validation.FormatValidators
     /// <summary>Validator for "IpV4" format.</summary>
     public class IpV4FormatValidator : IFormatValidator
     {
-        private const string IpV4RegexExpression = @"^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?).){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$";
+        private const string IpV4RegexExpression = @"^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$";
 
         /// <summary>Gets the format attribute's value.</summary>
         public string Format { get; } = JsonFormatStrings.IpV4;


### PR DESCRIPTION
## Summary
- Escape the dot character (`.` → `\.`) in the IPv4 validation regex to match only literal dots
- Previously, strings like `"00:45:00.0"` or `"1:2:3:4"` incorrectly passed IPv4 validation because the unescaped `.` matches any character
- Added test cases for invalid inputs that were previously accepted

Fixes #1409

## Test plan
- [x] Existing IPv4 tests continue to pass (`"192.168.0.1"` valid, `"test"` invalid)
- [x] New test: `"00:45:00.0"` correctly rejected
- [x] New test: `"1:2:3:4"` correctly rejected
- [x] New test: `"256.1.1.1"` correctly rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)