### PR TITLE
Skip StringLength attribute for date/time properties

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/ValidationAttributesTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/ValidationAttributesTests.cs
@@ -480,5 +480,26 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             Assert.Contains("[System.ComponentModel.DataAnnotations.MinLength(10)]\n" +
                             "        public System.Collections.Generic.ICollection<string> Value { get; set; } = new System.Collections.ObjectModel.Collection<string>();\n", code);
         }
+
+        [Fact]
+        public async Task When_date_time_property_has_min_max_length_then_no_string_length_attribute_is_generated()
+        {
+            var json = @"{
+                'type': 'object',
+                'properties': {
+                    'myDateTime': {
+                        'type': 'string',
+                        'format': 'date-time',
+                        'minLength': 1,
+                        'maxLength': 50
+                    }
+                }
+            }";
+            var schema = await JsonSchema.FromJsonAsync(json);
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings { ClassStyle = CSharpClassStyle.Poco });
+            var code = generator.GenerateFile();
+
+            Assert.DoesNotContain("StringLength", code);
+        }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
@@ -224,7 +224,10 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                 }
 
                 return _property.ActualTypeSchema.Type.IsString() &&
-                       (_property.ActualSchema.MinLength.HasValue || _property.ActualSchema.MaxLength.HasValue);
+                       (_property.ActualSchema.MinLength.HasValue || _property.ActualSchema.MaxLength.HasValue) &&
+                       _property.ActualSchema.Format is not JsonFormatStrings.DateTime
+                           and not JsonFormatStrings.Date
+                           and not JsonFormatStrings.Time;
             }
         }
 


### PR DESCRIPTION
## Summary
- Do not emit `[StringLength]` on properties with `date-time`, `date`, or `time` format, as the attribute is only meaningful for string types
- Previously, a schema with `format: date-time` and `minLength`/`maxLength` would generate a `[StringLength]` attribute on a `DateTimeOffset` property, which is semantically invalid

Fixes #1373

## Test plan
- [x] New test: schema with `format: date-time` + `minLength`/`maxLength` does NOT emit `[StringLength]`
- [x] Existing `[StringLength]` tests for string properties still pass (13 tests total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)