### PR TITLE
Support $defs keyword for JSON Schema draft 2019-09+

### DIFF
--- a/src/NJsonSchema.Tests/References/LocalReferencesTests.cs
+++ b/src/NJsonSchema.Tests/References/LocalReferencesTests.cs
@@ -184,6 +184,83 @@ namespace NJsonSchema.Tests.References
             Assert.Equal(JsonObjectType.Integer, schema.ActualTypeSchema.Type);
         }
 
+        [Fact]
+        public async Task When_schema_uses_defs_keyword_then_references_are_resolved()
+        {
+            //// Arrange
+            var json = @"{
+    ""type"": ""object"",
+    ""$defs"": {
+        ""address"": {
+            ""type"": ""object"",
+            ""properties"": {
+                ""street"": { ""type"": ""string"" },
+                ""city"": { ""type"": ""string"" }
+            }
+        }
+    },
+    ""properties"": {
+        ""home"": { ""$ref"": ""#/$defs/address"" },
+        ""work"": { ""$ref"": ""#/$defs/address"" }
+    }
+}";
+
+            //// Act
+            var schema = await JsonSchema.FromJsonAsync(json);
+
+            //// Assert
+            Assert.NotNull(schema.Properties["home"].ActualTypeSchema);
+            Assert.True(schema.Properties["home"].ActualTypeSchema.Properties.ContainsKey("street"));
+            Assert.True(schema.Properties["home"].ActualTypeSchema.Properties.ContainsKey("city"));
+            Assert.Equal(schema.Properties["home"].ActualTypeSchema, schema.Properties["work"].ActualTypeSchema);
+        }
+
+        [Fact]
+        public async Task When_schema_uses_defs_keyword_then_definitions_are_populated()
+        {
+            //// Arrange
+            var json = @"{
+    ""type"": ""object"",
+    ""$defs"": {
+        ""myType"": {
+            ""type"": ""string""
+        }
+    }
+}";
+
+            //// Act
+            var schema = await JsonSchema.FromJsonAsync(json);
+
+            //// Assert
+            Assert.True(schema.Definitions.ContainsKey("myType"));
+            Assert.Equal(JsonObjectType.String, schema.Definitions["myType"].Type);
+        }
+
+        [Fact]
+        public async Task When_schema_uses_defs_keyword_then_serialized_as_definitions()
+        {
+            //// Arrange
+            var json = @"{
+    ""type"": ""object"",
+    ""$defs"": {
+        ""myType"": {
+            ""type"": ""string""
+        }
+    },
+    ""properties"": {
+        ""foo"": { ""$ref"": ""#/$defs/myType"" }
+    }
+}";
+
+            //// Act
+            var schema = await JsonSchema.FromJsonAsync(json);
+            var outputJson = schema.ToJson();
+
+            //// Assert
+            Assert.Contains("\"definitions\"", outputJson);
+            Assert.DoesNotContain("\"$defs\"", outputJson);
+        }
+
         private string GetTestDirectory()
         {
             var codeBase = Assembly.GetExecutingAssembly().CodeBase.Replace("#", "%23");

--- a/src/NJsonSchema/JsonExtensionObject.cs
+++ b/src/NJsonSchema/JsonExtensionObject.cs
@@ -37,6 +37,7 @@ namespace NJsonSchema
                 var obj = (IJsonExtensionObject)Activator.CreateInstance(objectType)!;
                 serializer.Populate(reader, obj);
                 DeserializeExtensionDataSchemas(obj, serializer);
+                MergeDefsIntoDefinitions(obj);
                 return obj;
             }
             else
@@ -54,6 +55,29 @@ namespace NJsonSchema
         public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
             throw new NotImplementedException();
+        }
+
+        /// <summary>Merges $defs entries from extension data into the Definitions dictionary
+        /// to support JSON Schema draft 2019-09+ $defs keyword.</summary>
+        private static void MergeDefsIntoDefinitions(IJsonExtensionObject extensionObject)
+        {
+            if (extensionObject is JsonSchema schema &&
+                extensionObject.ExtensionData != null &&
+                extensionObject.ExtensionData.TryGetValue("$defs", out var defsValue))
+            {
+                extensionObject.ExtensionData.Remove("$defs");
+
+                if (defsValue is IDictionary<string, object?> defsDict)
+                {
+                    foreach (var pair in defsDict)
+                    {
+                        if (pair.Value is JsonSchema defSchema)
+                        {
+                            schema.Definitions[pair.Key] = defSchema;
+                        }
+                    }
+                }
+            }
         }
 
         /// <summary>Transforms the extension data so that contained schemas are correctly deserialized.</summary>

--- a/src/NJsonSchema/JsonReferenceResolver.cs
+++ b/src/NJsonSchema/JsonReferenceResolver.cs
@@ -279,6 +279,13 @@ namespace NJsonSchema
             checkedObjects.Add(obj);
             var firstSegment = segments[0];
 
+            // Map "$defs" (draft 2019-09+) to "definitions" since $defs content
+            // is merged into the Definitions dictionary during deserialization
+            if (firstSegment == "$defs")
+            {
+                firstSegment = "definitions";
+            }
+
             if (obj is IDictionary dictionary)
             {
                 if (dictionary.Contains(firstSegment))

--- a/src/NJsonSchema/JsonSchemaReferenceUtilities.cs
+++ b/src/NJsonSchema/JsonSchemaReferenceUtilities.cs
@@ -100,7 +100,7 @@ namespace NJsonSchema
                 {
                     if (_replaceRefsRound)
                     {
-                        if (path.EndsWith("/definitions/" + typeNameHint) || path.EndsWith("/schemas/" + typeNameHint))
+                        if (path.EndsWith("/definitions/" + typeNameHint) || path.EndsWith("/$defs/" + typeNameHint) || path.EndsWith("/schemas/" + typeNameHint))
                         {
                             // inline $refs in "definitions"
                             return await _referenceResolver


### PR DESCRIPTION
## Summary
- Support the `$defs` keyword (JSON Schema draft 2019-09+) in addition to the existing `definitions` keyword (draft-04/06/07)
- `$defs` entries are extracted from `ExtensionData` after deserialization and merged into the `Definitions` dictionary
- References like `#/$defs/Foo` are resolved by mapping `$defs` path segments to the `Definitions` dictionary in the reference resolver
- When re-serialized, schemas use `definitions` (normalized to draft-04 format)

Fixes #1536

## Changes
- `JsonExtensionObject.cs`: Added `MergeDefsIntoDefinitions` method called during deserialization
- `JsonReferenceResolver.cs`: Map `$defs` path segment to `definitions` during reference resolution
- `JsonSchemaReferenceUtilities.cs`: Added `/$defs/` path detection for inline reference replacement

## Test plan
- [x] Schema with `$defs` and `$ref: "#/$defs/..."` references resolves correctly
- [x] `$defs` entries appear in `Definitions` dictionary after deserialization
- [x] Re-serialization uses `definitions` (not `$defs`)
- [x] All 413 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)