### PR TITLE
required string? incorrectly loses nullable and gains MinLength=1

### DIFF
--- a/src/NJsonSchema.NewtonsoftJson/Generation/NewtonsoftJsonReflectionService.cs
+++ b/src/NJsonSchema.NewtonsoftJson/Generation/NewtonsoftJsonReflectionService.cs
@@ -186,11 +186,15 @@ namespace NJsonSchema.NewtonsoftJson.Generation
                     parentSchema.RequiredProperties.Add(propertyName);
                 }
 
-                var isNullable = propertyTypeDescription.IsNullable && !hasRequiredAttribute && jsonProperty.Required is Required.Default or Required.AllowNull;
+                // The C# required keyword marks a property as required in the schema's required array
+                // but does not imply a non-nullable value. Only [Required] carries the semantic meaning
+                // of "non-null value required" and should suppress nullability and trigger MinLength = 1
+                // on strings.
+                var isNullable = propertyTypeDescription.IsNullable && requiredAttribute == null && jsonProperty.Required is Required.Default or Required.AllowNull;
 
                 var defaultValue = jsonProperty.DefaultValue;
 
-                schemaGenerator.AddProperty(parentSchema, accessorInfo, propertyTypeDescription, propertyName, requiredAttribute, hasRequiredAttribute, isNullable, defaultValue, schemaResolver);
+                schemaGenerator.AddProperty(parentSchema, accessorInfo, propertyTypeDescription, propertyName, requiredAttribute, requiredAttribute != null, isNullable, defaultValue, schemaResolver);
             }
         }
 

--- a/src/NJsonSchema.Tests/Generation/AttributeGenerationTests.cs
+++ b/src/NJsonSchema.Tests/Generation/AttributeGenerationTests.cs
@@ -353,6 +353,28 @@ namespace NJsonSchema.Tests.Generation
             Assert.Contains("Name", schema.RequiredProperties);
             Assert.DoesNotContain("Optional", schema.RequiredProperties);
         }
+
+#nullable enable
+        public class ClassWithRequiredNullableKeyword
+        {
+            public required string? Name { get; set; }
+            public string? Optional { get; set; }
+        }
+#nullable restore
+
+        [Fact]
+        public void When_property_has_required_keyword_and_nullable_type_then_it_is_required_and_nullable_in_Newtonsoft_schema()
+        {
+            // Act
+            var schema = NewtonsoftJsonSchemaGenerator.FromType<ClassWithRequiredNullableKeyword>();
+
+            // Assert: required keyword adds to required array
+            Assert.Contains("Name", schema.RequiredProperties);
+            Assert.DoesNotContain("Optional", schema.RequiredProperties);
+            // Assert: nullable type is preserved — required keyword alone must not suppress nullability
+            Assert.True(schema.Properties["Name"].IsNullable(SchemaType.JsonSchema));
+            Assert.Null(schema.Properties["Name"].MinLength);
+        }
 #endif
 
 #if NET6_0_OR_GREATER

--- a/src/NJsonSchema.Tests/Generation/SystemTextJson/SystemTextJsonTests.cs
+++ b/src/NJsonSchema.Tests/Generation/SystemTextJson/SystemTextJsonTests.cs
@@ -190,6 +190,30 @@ namespace NJsonSchema.Tests.Generation.SystemTextJson
             Assert.Contains("Name", schema.RequiredProperties);
             Assert.DoesNotContain("Optional", schema.RequiredProperties);
         }
+
+#nullable enable
+        public class ClassWithJsonRequiredNullable
+        {
+            [System.Text.Json.Serialization.JsonRequired]
+            public string? Name { get; set; }
+            public string? Optional { get; set; }
+        }
+#nullable restore
+
+        [Fact]
+        public void When_property_has_JsonRequired_and_nullable_type_then_it_is_required_and_nullable_in_schema()
+        {
+            // Act
+            var schema = JsonSchema.FromType<ClassWithJsonRequiredNullable>();
+
+            // Assert: [JsonRequired] is a presence marker (like the C# required keyword) and matches
+            // System.Text.Json runtime semantics — the property must be present in the JSON, but the
+            // value may be null. Only [Required] (DataAnnotations) implies a non-null value.
+            Assert.Contains("Name", schema.RequiredProperties);
+            Assert.DoesNotContain("Optional", schema.RequiredProperties);
+            Assert.True(schema.Properties["Name"].IsNullable(SchemaType.JsonSchema));
+            Assert.Null(schema.Properties["Name"].MinLength);
+        }
 #endif
 
         public class ClassWithPublicField

--- a/src/NJsonSchema.Tests/Generation/SystemTextJson/SystemTextJsonTests.cs
+++ b/src/NJsonSchema.Tests/Generation/SystemTextJson/SystemTextJsonTests.cs
@@ -151,6 +151,28 @@ namespace NJsonSchema.Tests.Generation.SystemTextJson
             Assert.DoesNotContain("Optional", schema.RequiredProperties);
         }
 
+#nullable enable
+        public class ClassWithRequiredNullableKeyword
+        {
+            public required string? Name { get; set; }
+            public string? Optional { get; set; }
+        }
+#nullable restore
+
+        [Fact]
+        public void When_property_has_required_keyword_and_nullable_type_then_it_is_required_and_nullable_in_schema()
+        {
+            // Act
+            var schema = JsonSchema.FromType<ClassWithRequiredNullableKeyword>();
+
+            // Assert: required keyword adds to required array
+            Assert.Contains("Name", schema.RequiredProperties);
+            Assert.DoesNotContain("Optional", schema.RequiredProperties);
+            // Assert: nullable type is preserved — required keyword alone must not suppress nullability
+            Assert.True(schema.Properties["Name"].IsNullable(SchemaType.JsonSchema));
+            Assert.Null(schema.Properties["Name"].MinLength);
+        }
+
         public class ClassWithJsonRequired
         {
             [System.Text.Json.Serialization.JsonRequired]

--- a/src/NJsonSchema/Generation/SystemTextJsonReflectionService.cs
+++ b/src/NJsonSchema/Generation/SystemTextJsonReflectionService.cs
@@ -104,15 +104,14 @@ namespace NJsonSchema.Generation
                         schema.RequiredProperties.Add(propertyName);
                     }
 
-                    // The C# required keyword marks a property as required in the schema's required array
-                    // but does not imply a non-nullable value. Only [Required] and [JsonRequired] carry
+                    // Presence markers (C# required keyword, [JsonRequired], DataMember.IsRequired) only
+                    // mark a property as required in the schema's required array. Only [Required] carries
                     // the semantic meaning of "non-null value required" and should suppress nullability
                     // and trigger MinLength = 1 on strings.
-                    var hasSemanticRequiredAttribute = requiredAttribute != null || hasJsonRequiredAttribute;
-                    var isNullable = propertyTypeDescription.IsNullable && !hasSemanticRequiredAttribute;
+                    var isNullable = propertyTypeDescription.IsNullable && requiredAttribute == null;
 
                     // TODO: Add default value
-                    schemaGenerator.AddProperty(schema, accessorInfo, propertyTypeDescription, propertyName, requiredAttribute, hasSemanticRequiredAttribute, isNullable, null, schemaResolver);
+                    schemaGenerator.AddProperty(schema, accessorInfo, propertyTypeDescription, propertyName, requiredAttribute, requiredAttribute != null, isNullable, null, schemaResolver);
                 }
             }
         }

--- a/src/NJsonSchema/Generation/SystemTextJsonReflectionService.cs
+++ b/src/NJsonSchema/Generation/SystemTextJsonReflectionService.cs
@@ -104,10 +104,15 @@ namespace NJsonSchema.Generation
                         schema.RequiredProperties.Add(propertyName);
                     }
 
-                    var isNullable = propertyTypeDescription.IsNullable && !hasRequiredAttribute;
+                    // The C# required keyword marks a property as required in the schema's required array
+                    // but does not imply a non-nullable value. Only [Required] and [JsonRequired] carry
+                    // the semantic meaning of "non-null value required" and should suppress nullability
+                    // and trigger MinLength = 1 on strings.
+                    var hasSemanticRequiredAttribute = requiredAttribute != null || hasJsonRequiredAttribute;
+                    var isNullable = propertyTypeDescription.IsNullable && !hasSemanticRequiredAttribute;
 
                     // TODO: Add default value
-                    schemaGenerator.AddProperty(schema, accessorInfo, propertyTypeDescription, propertyName, requiredAttribute, hasRequiredAttribute, isNullable, null, schemaResolver);
+                    schemaGenerator.AddProperty(schema, accessorInfo, propertyTypeDescription, propertyName, requiredAttribute, hasSemanticRequiredAttribute, isNullable, null, schemaResolver);
                 }
             }
         }


### PR DESCRIPTION
Fixes #1918.

## Root cause

Commit ec1f9c3d correctly wired up `RequiredMemberAttribute` (C# 11 `required`) to add properties to the `required` array in the schema. The mistake was folding it into the existing `hasRequiredAttribute` boolean, which is also used in both reflection services to suppress nullability and in `JsonSchemaGenerator.cs:1216` to add `MinLength=1` to strings.

For `required string?`, `propertyTypeDescription.IsNullable` is `true` but `hasRequiredAttribute` is now also `true` (due to `RequiredMemberAttribute`), so `isNullable` becomes `false`. `nullable:true` is dropped and `MinLength=1` is added. Both are wrong.

The semantic distinction is:

- `[Required]` / `[JsonRequired]`: "this value must be non-null and non-empty" -- suppressing nullability and adding `MinLength=1` are correct
- C# 11 `required` keyword: "this property must be present in object initializers / JSON deserialization, but the value can still be null" -- should only add to the `required` array; nullability and `MinLength` come from the type alone

## Fix

Introduce `hasSemanticRequiredAttribute` (excludes `RequiredMemberAttribute`) for the `isNullable` and `MinLength` decisions in both reflection services.

| C# property | required array | nullable | minLength |
|---|---|---|---|
| `string name` | no | no | - |
| `string? name` | no | yes | - |
| `[Required] string name` | yes | no | 1 |
| `[Required] string? name` | yes | no | 1 |
| `required string name` | yes | no | - |
| `required string? name` | yes | yes | - |
| `[JsonRequired] string? name` | yes | no | - |

The Newtonsoft path has no `hasJsonRequiredAttribute` concept, so it only needs the `requiredAttribute == null` guard. The System.Text.Json path keeps `[JsonRequired]` in the semantic bucket since `[JsonRequired]` explicitly states the JSON value must not be null, unlike the language-level `required` keyword.

## Tests

Regression tests added to `AttributeGenerationTests` (Newtonsoft) and `SystemTextJsonTests` (System.Text.Json) asserting that `required string?` lands in `RequiredProperties`, has `IsNullable = true`, and has `MinLength = null`.

---

## Follow-up (added by @RicoSuter)

Extended the fix to also treat `[JsonRequired]` as a presence-only marker on the System.Text.Json path, for symmetry with the C# `required` keyword and to match STJ's actual runtime semantics (`[JsonRequired]` enforces presence during deserialization, not value non-nullness).

This means the `hasSemanticRequiredAttribute` concept collapses — `[Required]` (DataAnnotations) is now the single signal that suppresses nullability and triggers `MinLength = 1` on strings, across both STJ and Newtonsoft paths.

Updated truth table:

| C# property | required array | nullable | minLength |
|---|---|---|---|
| `string name` | no | no | — |
| `string? name` | no | yes | — |
| `[Required] string name` | yes | no | 1 |
| `[Required] string? name` | yes | no | 1 |
| `required string name` | yes | no | — |
| `required string? name` | yes | yes | — |
| `[JsonRequired] string name` | yes | no | — |
| `[JsonRequired] string? name` | yes | yes | — |

### Behavior changes vs v11.6.0

1. `required string?` and `[JsonRequired] string?` are now correctly `nullable: true` with no `MinLength`. Also fixes the regression reported in [NSwag#5359](https://github.com/RicoSuter/NSwag/issues/5359).
2. `required string` and `[JsonRequired] string` (non-nullable types) no longer get `MinLength = 1`. Neither attribute says anything about string emptiness; users who want that should use `[Required]` or `[MinLength(1)]` explicitly.

Pre-v11.6.0 nullability semantics are restored, and the `required` keyword / `[JsonRequired]` → required-array feature added in #1908 is preserved.

Added one regression test for `[JsonRequired] string?` in `SystemTextJsonTests`.
