### PR TITLE
chore: Clarify required-marker logic and strengthen MinLength assertions

### DIFF
--- a/src/NJsonSchema.NewtonsoftJson/Generation/NewtonsoftJsonReflectionService.cs
+++ b/src/NJsonSchema.NewtonsoftJson/Generation/NewtonsoftJsonReflectionService.cs
@@ -180,16 +180,18 @@ namespace NJsonSchema.NewtonsoftJson.Generation
                 var hasJsonNetAttributeRequired = jsonProperty.Required is Required.Always or Required.AllowNull;
                 var isDataContractMemberRequired = schemaGenerator.GetDataMemberAttribute(accessorInfo, parentType)?.IsRequired == true;
 
-                var hasRequiredAttribute = requiredAttribute != null || hasRequiredMemberAttribute;
-                if (hasRequiredAttribute || isDataContractMemberRequired || hasJsonNetAttributeRequired)
+                // Any of these markers places the property in the schema's required array.
+                var hasAnyRequiredMarker = requiredAttribute != null || hasRequiredMemberAttribute || isDataContractMemberRequired || hasJsonNetAttributeRequired;
+                if (hasAnyRequiredMarker)
                 {
                     parentSchema.RequiredProperties.Add(propertyName);
                 }
 
-                // The C# required keyword marks a property as required in the schema's required array
-                // but does not imply a non-nullable value. Only [Required] carries the semantic meaning
-                // of "non-null value required" and should suppress nullability and trigger MinLength = 1
-                // on strings.
+                // Only [Required] from DataAnnotations carries the "non-null value required" semantic
+                // that suppresses nullability and triggers MinLength = 1 on strings. The C# required
+                // keyword and DataMember.IsRequired are presence-only markers. Newtonsoft's
+                // Required.Always / Required.DisallowNull also suppress nullability because the
+                // Newtonsoft runtime rejects null in those modes.
                 var isNullable = propertyTypeDescription.IsNullable && requiredAttribute == null && jsonProperty.Required is Required.Default or Required.AllowNull;
 
                 var defaultValue = jsonProperty.DefaultValue;

--- a/src/NJsonSchema.Tests/Generation/AttributeGenerationTests.cs
+++ b/src/NJsonSchema.Tests/Generation/AttributeGenerationTests.cs
@@ -352,6 +352,9 @@ namespace NJsonSchema.Tests.Generation
             // Assert
             Assert.Contains("Name", schema.RequiredProperties);
             Assert.DoesNotContain("Optional", schema.RequiredProperties);
+            // Assert: required keyword is a presence marker only — it must not trigger MinLength = 1
+            // on the string type. That is reserved for [Required] from DataAnnotations.
+            Assert.Null(schema.Properties["Name"].MinLength);
         }
 
 #nullable enable

--- a/src/NJsonSchema.Tests/Generation/SystemTextJson/SystemTextJsonTests.cs
+++ b/src/NJsonSchema.Tests/Generation/SystemTextJson/SystemTextJsonTests.cs
@@ -149,6 +149,9 @@ namespace NJsonSchema.Tests.Generation.SystemTextJson
             // Assert
             Assert.Contains("Name", schema.RequiredProperties);
             Assert.DoesNotContain("Optional", schema.RequiredProperties);
+            // Assert: required keyword is a presence marker only — it must not trigger MinLength = 1
+            // on the string type. That is reserved for [Required] from DataAnnotations.
+            Assert.Null(schema.Properties["Name"].MinLength);
         }
 
 #nullable enable
@@ -189,6 +192,8 @@ namespace NJsonSchema.Tests.Generation.SystemTextJson
             // Assert
             Assert.Contains("Name", schema.RequiredProperties);
             Assert.DoesNotContain("Optional", schema.RequiredProperties);
+            // Assert: [JsonRequired] is a presence marker only — it must not trigger MinLength = 1.
+            Assert.Null(schema.Properties["Name"].MinLength);
         }
 
 #nullable enable

--- a/src/NJsonSchema/Generation/SystemTextJsonReflectionService.cs
+++ b/src/NJsonSchema/Generation/SystemTextJsonReflectionService.cs
@@ -98,16 +98,16 @@ namespace NJsonSchema.Generation
 
                     var isDataContractMemberRequired = schemaGenerator.GetDataMemberAttribute(accessorInfo, contextualType.Type)?.IsRequired == true;
 
-                    var hasRequiredAttribute = requiredAttribute != null || hasRequiredMemberAttribute || hasJsonRequiredAttribute;
-                    if (hasRequiredAttribute || isDataContractMemberRequired)
+                    // Any of these markers places the property in the schema's required array.
+                    var hasAnyRequiredMarker = requiredAttribute != null || hasRequiredMemberAttribute || hasJsonRequiredAttribute || isDataContractMemberRequired;
+                    if (hasAnyRequiredMarker)
                     {
                         schema.RequiredProperties.Add(propertyName);
                     }
 
-                    // Presence markers (C# required keyword, [JsonRequired], DataMember.IsRequired) only
-                    // mark a property as required in the schema's required array. Only [Required] carries
-                    // the semantic meaning of "non-null value required" and should suppress nullability
-                    // and trigger MinLength = 1 on strings.
+                    // Only [Required] from DataAnnotations carries the "non-null value required" semantic
+                    // that suppresses nullability and triggers MinLength = 1 on strings. The C# required
+                    // keyword, [JsonRequired], and DataMember.IsRequired are presence-only markers.
                     var isNullable = propertyTypeDescription.IsNullable && requiredAttribute == null;
 
                     // TODO: Add default value


### PR DESCRIPTION
## Summary

Non-behavioral cleanup around how "required" markers are handled in the Newtonsoft and System.Text.Json reflection services, plus a few tests tightened to lock the current semantics.

## Changes

- **Refactor boolean logic** in `NewtonsoftJsonReflectionService` and `SystemTextJsonReflectionService`: flatten `(A || B) || C || D` into a single expression and rename the misleading local `hasRequiredAttribute` to `hasAnyRequiredMarker`. Logically identical, just clearer.
- **Clarify comments** to explicitly enumerate which markers are presence-only (C# `required` keyword, `[JsonRequired]`, `DataMember.IsRequired`) vs. which carry "non-null value required" semantics (`[Required]` from DataAnnotations, and for Newtonsoft also `Required.Always` / `Required.DisallowNull`).
- **Strengthen tests** by adding `Assert.Null(schema.Properties["Name"].MinLength)` to the existing `required`-keyword and `[JsonRequired]` tests, so regressions that accidentally apply `MinLength = 1` to presence-only markers are caught.

No runtime behavior changes — the `isNullable` computation and the set of markers feeding `RequiredProperties` are unchanged.

## Test plan

- [x] `AttributeGenerationTests.When_property_has_required_keyword_then_it_is_required_in_Newtonsoft_schema` passes with new `MinLength` assertion
- [x] `SystemTextJsonTests.When_property_has_required_keyword_then_it_is_required_in_schema` passes with new `MinLength` assertion
- [x] `SystemTextJsonTests.When_property_has_JsonRequired_then_it_is_required_in_schema` passes with new `MinLength` assertion
- [x] Full test suite green